### PR TITLE
Add interactive flowsheet visualization module

### DIFF
--- a/examples/09_visualization.ipynb
+++ b/examples/09_visualization.ipynb
@@ -1,0 +1,528 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "cell-0",
+   "metadata": {},
+   "source": [
+    "# Interactive Flowsheet Visualization\n",
+    "\n",
+    "This notebook demonstrates the visualization capabilities of difflow for creating interactive\n",
+    "process flow diagrams (PFDs) that look like chemical engineering flowsheets.\n",
+    "\n",
+    "## Features\n",
+    "\n",
+    "- **Custom P&ID-style icons** for each unit operation type\n",
+    "- **Left-to-right hierarchical layout** (typical for process flowsheets)\n",
+    "- **Interactive drag-and-drop** to rearrange nodes\n",
+    "- **Tooltips** showing stream data (composition, T, P) and unit parameters\n",
+    "- **Export to HTML** for publications and sharing\n",
+    "\n",
+    "## Requirements\n",
+    "\n",
+    "```bash\n",
+    "pip install difflow[visualization]\n",
+    "# or\n",
+    "pip install ipycytoscape networkx\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-1",
+   "metadata": {},
+   "source": [
+    "## Setup and Imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "os.environ['JAX_PLATFORM_NAME'] = 'cpu'\n",
+    "\n",
+    "import jax\n",
+    "import jax.numpy as jnp\n",
+    "jax.config.update(\"jax_enable_x64\", True)\n",
+    "\n",
+    "from difflow import (\n",
+    "    Flowsheet, Unit, make_stream,\n",
+    "    CSTR, Flash, Mixer, Heater, Cooler,\n",
+    "    IdealThermo, SpeciesData,\n",
+    ")\n",
+    "from difflow.visualization import (\n",
+    "    FlowsheetVisualizer,\n",
+    "    visualize_flowsheet,\n",
+    "    get_icon_svg,\n",
+    "    list_available_icons,\n",
+    ")\n",
+    "\n",
+    "print(\"Imports successful!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-3",
+   "metadata": {},
+   "source": [
+    "## Preview Available Icons\n",
+    "\n",
+    "The visualization module includes P&ID-style icons for all common unit operations.\n",
+    "Let's see what icons are available:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# List all available icon types\n",
+    "icons = list_available_icons()\n",
+    "print(\"Available icon types:\")\n",
+    "for i, icon in enumerate(icons):\n",
+    "    print(f\"  {icon}\", end=\"\\n\" if (i+1) % 5 == 0 else \", \")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Display some icons (as HTML in Jupyter)\n",
+    "from IPython.display import HTML, display\n",
+    "\n",
+    "icon_types = [\"CSTR\", \"PFR\", \"Flash\", \"Mixer\", \"Splitter\", \"Heater\", \"Cooler\", \n",
+    "              \"distillation\", \"heat_exchanger\", \"bioreactor\", \"feed\", \"product\"]\n",
+    "\n",
+    "html = '<div style=\"display: flex; flex-wrap: wrap; gap: 20px;\">'\n",
+    "for icon_type in icon_types:\n",
+    "    svg = get_icon_svg(icon_type)\n",
+    "    html += f'<div style=\"text-align: center;\"><div style=\"width: 60px; height: 60px;\">{svg}</div><small>{icon_type}</small></div>'\n",
+    "html += '</div>'\n",
+    "\n",
+    "display(HTML(html))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-6",
+   "metadata": {},
+   "source": [
+    "## Example 1: Simple CSTR + Flash Flowsheet\n",
+    "\n",
+    "Let's visualize the classic reaction-separation flowsheet:\n",
+    "\n",
+    "```\n",
+    "Feed → CSTR → Flash → Product\n",
+    "         ↑      ↓\n",
+    "         └──────┘ (recycle)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define thermodynamic properties\n",
+    "species_data = {\n",
+    "    \"A\": SpeciesData(\n",
+    "        name=\"A\", MW=92.0,\n",
+    "        Cp_coeffs=(75.0, 0.0, 0.0, 0.0),\n",
+    "        Hvap_coeffs=(35000.0, 0.38, 590.0),\n",
+    "        antoine_coeffs=(10.0, 2000.0, -40.0),\n",
+    "        Hf=0.0,\n",
+    "    ),\n",
+    "    \"B\": SpeciesData(\n",
+    "        name=\"B\", MW=78.0,\n",
+    "        Cp_coeffs=(50.0, 0.0, 0.0, 0.0),\n",
+    "        Hvap_coeffs=(30000.0, 0.38, 560.0),\n",
+    "        antoine_coeffs=(10.0, 1500.0, -40.0),\n",
+    "        Hf=-50000.0,\n",
+    "    ),\n",
+    "}\n",
+    "thermo = IdealThermo(species_data)\n",
+    "species_order = [\"A\", \"B\"]\n",
+    "\n",
+    "# Create reaction kinetics\n",
+    "def rate_fn(C, T, params):\n",
+    "    k = params[\"A\"] * jnp.exp(-params[\"Ea\"] / (8.314 * T))\n",
+    "    return jnp.array([k * C[\"A\"]])\n",
+    "\n",
+    "stoich = jnp.array([[-1.0], [1.0]])\n",
+    "\n",
+    "print(\"Thermodynamics and kinetics defined.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from difflow.units.cstr import CSTRParams\n",
+    "from difflow.units.flash import FlashParams\n",
+    "\n",
+    "# Create the flowsheet\n",
+    "fs = Flowsheet(species_order)\n",
+    "\n",
+    "# Add feed\n",
+    "feed = make_stream({\"A\": 10.0, \"B\": 0.0}, T=300.0, P=101325.0)\n",
+    "fs.add_feed(\"feed\", feed)\n",
+    "\n",
+    "# Create unit operations\n",
+    "cstr_params = CSTRParams(\n",
+    "    V=1.0,\n",
+    "    rate_fn=rate_fn,\n",
+    "    stoich=stoich,\n",
+    "    rate_params={\"A\": 1e8, \"Ea\": 50000.0},\n",
+    "    species_order=species_order,\n",
+    ")\n",
+    "cstr = CSTR(cstr_params, thermo=thermo, mode=\"isothermal\")\n",
+    "\n",
+    "flash_params = FlashParams(species_order=species_order)\n",
+    "flash = Flash(flash_params, thermo=thermo)\n",
+    "\n",
+    "mixer = Mixer(species_order, thermo=thermo)\n",
+    "\n",
+    "# Add units to flowsheet\n",
+    "fs.add_unit(Unit(\n",
+    "    name=\"Mixer\",\n",
+    "    operation=mixer,\n",
+    "    inlet_names=[\"feed\", \"recycle\"],\n",
+    "    outlet_names=[\"mixer_out\"],\n",
+    "))\n",
+    "\n",
+    "fs.add_unit(Unit(\n",
+    "    name=\"Reactor\",\n",
+    "    operation=lambda s, **kw: cstr(s, T_spec=400.0),\n",
+    "    inlet_names=[\"mixer_out\"],\n",
+    "    outlet_names=[\"reactor_out\"],\n",
+    "    params={\"V\": 1.0, \"T\": 400.0},\n",
+    "))\n",
+    "\n",
+    "fs.add_unit(Unit(\n",
+    "    name=\"Flash\",\n",
+    "    operation=lambda s, **kw: flash(s, T=350.0, P=101325.0),\n",
+    "    inlet_names=[\"reactor_out\"],\n",
+    "    outlet_names=[\"liquid\", \"vapor\"],\n",
+    "    params={\"T\": 350.0, \"P\": 101325.0},\n",
+    "))\n",
+    "\n",
+    "# Add recycle\n",
+    "fs.add_recycle(\"liquid\", \"recycle\")\n",
+    "\n",
+    "print(f\"Flowsheet created with {len(fs.units)} units\")\n",
+    "print(f\"Feeds: {list(fs.feeds.keys())}\")\n",
+    "print(f\"Recycles: {fs.recycles}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Solve the flowsheet\n",
+    "recycle_init = {\n",
+    "    \"recycle\": make_stream({\"A\": 1.0, \"B\": 0.1}, T=350.0, P=101325.0)\n",
+    "}\n",
+    "\n",
+    "print(\"Solving flowsheet...\")\n",
+    "streams = fs.solve(tear_initial=recycle_init)\n",
+    "print(\"Solved!\")\n",
+    "\n",
+    "# Show stream summary\n",
+    "for name, stream in streams.items():\n",
+    "    total = float(stream[\"F_A\"]) + float(stream[\"F_B\"])\n",
+    "    print(f\"  {name}: F={total:.2f} mol/s, T={float(stream['T']):.0f} K\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-10",
+   "metadata": {},
+   "source": [
+    "## Visualize the Flowsheet\n",
+    "\n",
+    "Now let's create an interactive visualization. You can:\n",
+    "- **Drag nodes** to rearrange the layout\n",
+    "- **Hover over nodes** to see unit parameters\n",
+    "- **Hover over edges** to see stream compositions\n",
+    "- **Zoom and pan** using mouse scroll and drag"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-11",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Quick visualization with one line\n",
+    "visualize_flowsheet(fs, streams=streams)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-12",
+   "metadata": {},
+   "source": [
+    "## Advanced Visualization Options\n",
+    "\n",
+    "For more control, use the `FlowsheetVisualizer` class directly:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-13",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create visualizer with custom options\n",
+    "viz = FlowsheetVisualizer(\n",
+    "    fs,\n",
+    "    show_feeds=True,\n",
+    "    show_products=True,\n",
+    "    layout=\"dagre\",  # Left-to-right hierarchical layout\n",
+    "    layout_options={\n",
+    "        \"rankDir\": \"LR\",  # Left to right\n",
+    "        \"nodeSep\": 100,   # Vertical spacing\n",
+    "        \"rankSep\": 150,   # Horizontal spacing\n",
+    "    },\n",
+    ")\n",
+    "\n",
+    "# Show with custom size\n",
+    "widget = viz.show(streams=streams, height=\"400px\")\n",
+    "widget"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-14",
+   "metadata": {},
+   "source": [
+    "## Export to HTML\n",
+    "\n",
+    "Export the visualization as a standalone HTML file for publications, reports, or sharing:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-15",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Export to HTML\n",
+    "viz.export_html(\n",
+    "    \"cstr_flash_flowsheet.html\",\n",
+    "    title=\"CSTR + Flash Recycle Process\",\n",
+    ")\n",
+    "print(\"Exported to: cstr_flash_flowsheet.html\")\n",
+    "print(\"Open this file in a browser for full interactivity!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-16",
+   "metadata": {},
+   "source": [
+    "## Example 2: More Complex Flowsheet\n",
+    "\n",
+    "Let's create a more complex flowsheet with multiple unit operations:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-17",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from difflow.units.heat_exchanger import Heater, HeaterParams, Cooler, CoolerParams\n",
+    "\n",
+    "# Create a more complex flowsheet\n",
+    "fs2 = Flowsheet(species_order)\n",
+    "\n",
+    "# Add feed\n",
+    "fs2.add_feed(\"raw_feed\", make_stream({\"A\": 10.0, \"B\": 0.5}, T=298.0, P=101325.0))\n",
+    "\n",
+    "# Heater to preheat feed\n",
+    "heater_params = HeaterParams(species_order=species_order)\n",
+    "heater = Heater(heater_params, thermo=thermo)\n",
+    "\n",
+    "fs2.add_unit(Unit(\n",
+    "    name=\"Feed_Heater\",\n",
+    "    operation=lambda s, **kw: heater(s, T_out=350.0),\n",
+    "    inlet_names=[\"raw_feed\"],\n",
+    "    outlet_names=[\"heated_feed\"],\n",
+    "    params={\"T_out\": 350.0},\n",
+    "))\n",
+    "\n",
+    "# Mixer\n",
+    "fs2.add_unit(Unit(\n",
+    "    name=\"Feed_Mixer\",\n",
+    "    operation=mixer,\n",
+    "    inlet_names=[\"heated_feed\", \"recycle\"],\n",
+    "    outlet_names=[\"mixed_feed\"],\n",
+    "))\n",
+    "\n",
+    "# CSTR\n",
+    "fs2.add_unit(Unit(\n",
+    "    name=\"CSTR_1\",\n",
+    "    operation=lambda s, **kw: cstr(s, T_spec=400.0),\n",
+    "    inlet_names=[\"mixed_feed\"],\n",
+    "    outlet_names=[\"cstr_out\"],\n",
+    "    params={\"V\": 1.0, \"T\": 400.0},\n",
+    "))\n",
+    "\n",
+    "# Cooler before flash\n",
+    "cooler_params = CoolerParams(species_order=species_order)\n",
+    "cooler = Cooler(cooler_params, thermo=thermo)\n",
+    "\n",
+    "fs2.add_unit(Unit(\n",
+    "    name=\"Pre_Flash_Cooler\",\n",
+    "    operation=lambda s, **kw: cooler(s, T_out=350.0),\n",
+    "    inlet_names=[\"cstr_out\"],\n",
+    "    outlet_names=[\"cooled_stream\"],\n",
+    "    params={\"T_out\": 350.0},\n",
+    "))\n",
+    "\n",
+    "# Flash separator\n",
+    "fs2.add_unit(Unit(\n",
+    "    name=\"Flash_Drum\",\n",
+    "    operation=lambda s, **kw: flash(s, T=350.0, P=101325.0),\n",
+    "    inlet_names=[\"cooled_stream\"],\n",
+    "    outlet_names=[\"bottoms\", \"overhead\"],\n",
+    "    params={\"T\": 350.0, \"P\": 101325.0},\n",
+    "))\n",
+    "\n",
+    "# Add recycle\n",
+    "fs2.add_recycle(\"bottoms\", \"recycle\")\n",
+    "\n",
+    "print(f\"Complex flowsheet with {len(fs2.units)} units\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-18",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Solve\n",
+    "recycle_init2 = {\n",
+    "    \"recycle\": make_stream({\"A\": 1.0, \"B\": 0.1}, T=350.0, P=101325.0)\n",
+    "}\n",
+    "streams2 = fs2.solve(tear_initial=recycle_init2)\n",
+    "print(\"Solved!\")\n",
+    "\n",
+    "# Visualize\n",
+    "visualize_flowsheet(fs2, streams=streams2, height=\"450px\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-19",
+   "metadata": {},
+   "source": [
+    "## Export Graph Data\n",
+    "\n",
+    "You can also export the graph data for use with other visualization tools:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-20",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "viz2 = FlowsheetVisualizer(fs2)\n",
+    "\n",
+    "# Get raw graph data\n",
+    "graph_data = viz2.get_graph_data()\n",
+    "print(f\"Nodes: {len(graph_data['nodes'])}\")\n",
+    "print(f\"Edges: {len(graph_data['edges'])}\")\n",
+    "\n",
+    "print(\"\\nNode IDs:\")\n",
+    "for node in graph_data['nodes']:\n",
+    "    print(f\"  - {node['data']['id']} ({node['data']['type']})\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-21",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Convert to NetworkX for further analysis\n",
+    "try:\n",
+    "    G = viz2.to_networkx()\n",
+    "    print(f\"NetworkX DiGraph: {G.number_of_nodes()} nodes, {G.number_of_edges()} edges\")\n",
+    "    print(f\"\\nTopological order: {list(nx.topological_sort(G))}\")\n",
+    "except ImportError:\n",
+    "    print(\"NetworkX not installed. Run: pip install networkx\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-22",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "The visualization module provides:\n",
+    "\n",
+    "1. **P&ID-style icons** for all common unit operations\n",
+    "2. **Interactive drag-and-drop** layout adjustment\n",
+    "3. **Rich tooltips** with stream compositions and unit parameters\n",
+    "4. **HTML export** for publications and sharing\n",
+    "5. **NetworkX integration** for graph analysis\n",
+    "\n",
+    "### Tips for Best Results\n",
+    "\n",
+    "- Use the `dagre` layout with `rankDir: \"LR\"` for left-to-right flow\n",
+    "- Adjust `nodeSep` and `rankSep` to control spacing\n",
+    "- Export to HTML for full interactivity in publications\n",
+    "- Pass solved streams to `show()` for detailed tooltips"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,11 +22,15 @@ examples = [
     "matplotlib>=3.5.0",
     "jupyter>=1.0.0",
 ]
+visualization = [
+    "ipycytoscape>=1.3.0",
+    "networkx>=2.6.0",
+]
 bio = [
     # Bio manufacturing operations are included in the main package
 ]
 all = [
-    "difflow[dev,examples,bio]",
+    "difflow[dev,examples,visualization,bio]",
 ]
 
 [project.entry-points."difflow.plugins"]

--- a/src/difflow/__init__.py
+++ b/src/difflow/__init__.py
@@ -122,6 +122,17 @@ from difflow.plugins import (
 # Economics submodule
 from difflow import economics
 
+# Visualization submodule (optional - requires ipycytoscape)
+try:
+    from difflow import visualization
+    from difflow.visualization import visualize_flowsheet, FlowsheetVisualizer
+    _HAS_VISUALIZATION = True
+except ImportError:
+    _HAS_VISUALIZATION = False
+    visualization = None
+    visualize_flowsheet = None
+    FlowsheetVisualizer = None
+
 __all__ = [
     # Streams
     "Stream",
@@ -232,4 +243,8 @@ __all__ = [
     "OperationRegistry",
     # Economics
     "economics",
+    # Visualization (optional)
+    "visualization",
+    "visualize_flowsheet",
+    "FlowsheetVisualizer",
 ]

--- a/src/difflow/visualization/__init__.py
+++ b/src/difflow/visualization/__init__.py
@@ -1,0 +1,55 @@
+"""Visualization module for difflow.
+
+This module provides interactive visualization of process flowsheets
+using ipycytoscape with:
+- Custom P&ID-style icons for unit operations
+- Left-to-right hierarchical layout
+- Tooltips showing stream compositions and unit parameters
+- Drag-and-drop node positioning
+- Export to HTML and PNG for publications
+
+Requirements:
+    pip install ipycytoscape
+
+Example usage:
+    >>> from difflow import Flowsheet, Unit, CSTR, Flash
+    >>> from difflow.visualization import visualize_flowsheet, FlowsheetVisualizer
+    >>>
+    >>> # Create and solve flowsheet
+    >>> fs = Flowsheet(["A", "B", "C"])
+    >>> # ... add feeds, units, etc.
+    >>> results = fs.solve()
+    >>>
+    >>> # Quick visualization
+    >>> visualize_flowsheet(fs, streams=results)
+    >>>
+    >>> # Or with more control
+    >>> viz = FlowsheetVisualizer(fs)
+    >>> widget = viz.show(streams=results)
+    >>> viz.export_html("flowsheet.html")
+"""
+
+from difflow.visualization.icons import (
+    get_icon_svg,
+    get_icon_data_uri,
+    list_available_icons,
+    register_icon,
+    ICON_REGISTRY,
+)
+
+from difflow.visualization.flowsheet_viz import (
+    FlowsheetVisualizer,
+    visualize_flowsheet,
+)
+
+__all__ = [
+    # Main visualizer
+    "FlowsheetVisualizer",
+    "visualize_flowsheet",
+    # Icon utilities
+    "get_icon_svg",
+    "get_icon_data_uri",
+    "list_available_icons",
+    "register_icon",
+    "ICON_REGISTRY",
+]

--- a/src/difflow/visualization/flowsheet_viz.py
+++ b/src/difflow/visualization/flowsheet_viz.py
@@ -1,0 +1,734 @@
+"""Interactive flowsheet visualization using ipycytoscape.
+
+This module provides visualization of process flowsheets as interactive
+graphs with:
+- Custom icons for each unit operation type
+- Drag-and-drop node positioning
+- Tooltips showing stream data and unit parameters
+- Export to HTML and PNG for publications
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+import json
+import warnings
+
+from difflow.visualization.icons import get_icon_data_uri, get_icon_svg
+
+if TYPE_CHECKING:
+    from difflow.flowsheet import Flowsheet, Unit
+    from difflow.streams import Stream
+
+# Try to import ipycytoscape, but provide helpful error if not available
+try:
+    import ipycytoscape
+    HAS_IPYCYTOSCAPE = True
+except ImportError:
+    HAS_IPYCYTOSCAPE = False
+    ipycytoscape = None
+
+
+def _get_operation_type(unit: "Unit") -> str:
+    """Extract operation type name from a Unit."""
+    op = unit.operation
+    # Try to get the class/function name
+    if hasattr(op, "__name__"):
+        return op.__name__
+    if hasattr(op, "__class__"):
+        return op.__class__.__name__
+    return "generic"
+
+
+def _format_stream_tooltip(stream: "Stream", name: str) -> str:
+    """Format stream data for tooltip display."""
+    import jax.numpy as jnp
+
+    lines = [f"<b>Stream: {name}</b>"]
+
+    # Temperature and pressure
+    T = float(stream.get("T", 0))
+    P = float(stream.get("P", 0))
+    lines.append(f"T = {T:.1f} K ({T - 273.15:.1f} °C)")
+    lines.append(f"P = {P:.0f} Pa ({P / 1e5:.2f} bar)")
+
+    # Flow rates
+    lines.append("<br><b>Flows (mol/s):</b>")
+    total_flow = 0.0
+    for key, value in sorted(stream.items()):
+        if key.startswith("F_"):
+            species = key[2:]  # Remove "F_" prefix
+            flow = float(value)
+            total_flow += flow
+            if flow > 1e-10:
+                lines.append(f"  {species}: {flow:.4g}")
+
+    lines.append(f"<br><b>Total: {total_flow:.4g} mol/s</b>")
+
+    return "<br>".join(lines)
+
+
+def _format_unit_tooltip(unit: "Unit", streams: dict[str, "Stream"] | None = None) -> str:
+    """Format unit operation data for tooltip display."""
+    lines = [f"<b>{unit.name}</b>"]
+    lines.append(f"Type: {_get_operation_type(unit)}")
+
+    # Inlets and outlets
+    lines.append(f"<br>Inlets: {', '.join(unit.inlet_names)}")
+    lines.append(f"Outlets: {', '.join(unit.outlet_names)}")
+
+    # Parameters
+    if unit.params:
+        lines.append("<br><b>Parameters:</b>")
+        for key, value in unit.params.items():
+            if callable(value):
+                lines.append(f"  {key}: <function>")
+            else:
+                try:
+                    lines.append(f"  {key}: {value:.4g}" if isinstance(value, float) else f"  {key}: {value}")
+                except (TypeError, ValueError):
+                    lines.append(f"  {key}: {value}")
+
+    return "<br>".join(lines)
+
+
+class FlowsheetVisualizer:
+    """Interactive visualization of process flowsheets.
+
+    Creates an interactive graph visualization using ipycytoscape with:
+    - Custom P&ID-style icons for unit operations
+    - Left-to-right hierarchical layout (configurable)
+    - Tooltips showing stream compositions and unit parameters
+    - Drag-and-drop node positioning
+    - Export to HTML/PNG for publications
+
+    Example:
+        >>> fs = Flowsheet(["A", "B", "C"])
+        >>> fs.add_feed("feed", feed_stream)
+        >>> fs.add_unit(Unit("reactor", CSTR, ["feed"], ["product"]))
+        >>> results = fs.solve()
+        >>>
+        >>> viz = FlowsheetVisualizer(fs)
+        >>> viz.show(streams=results)  # Returns interactive widget
+        >>> viz.export_html("flowsheet.html")
+    """
+
+    def __init__(
+        self,
+        flowsheet: "Flowsheet",
+        *,
+        show_feeds: bool = True,
+        show_products: bool = True,
+        layout: str = "dagre",
+        layout_options: dict[str, Any] | None = None,
+    ):
+        """Initialize the visualizer.
+
+        Args:
+            flowsheet: The Flowsheet object to visualize
+            show_feeds: Whether to show feed stream nodes
+            show_products: Whether to show product stream nodes
+            layout: Layout algorithm ('dagre', 'breadthfirst', 'grid', 'circle', 'cose')
+            layout_options: Additional options for the layout algorithm
+        """
+        if not HAS_IPYCYTOSCAPE:
+            raise ImportError(
+                "ipycytoscape is required for visualization. "
+                "Install it with: pip install ipycytoscape"
+            )
+
+        self.flowsheet = flowsheet
+        self.show_feeds = show_feeds
+        self.show_products = show_products
+        self.layout = layout
+        self.layout_options = layout_options or {}
+
+        # Build graph data
+        self._nodes: list[dict] = []
+        self._edges: list[dict] = []
+        self._build_graph()
+
+        # Widget reference (created on show())
+        self._widget: ipycytoscape.CytoscapeWidget | None = None
+
+    def _build_graph(self) -> None:
+        """Build graph nodes and edges from flowsheet."""
+        # Track which streams are unit outputs
+        stream_sources: dict[str, str] = {}  # stream_name -> unit_name
+        stream_targets: dict[str, list[str]] = {}  # stream_name -> [unit_names]
+
+        # First pass: identify all streams and their sources
+        for unit in self.flowsheet.units:
+            for outlet in unit.outlet_names:
+                stream_sources[outlet] = unit.name
+            for inlet in unit.inlet_names:
+                if inlet not in stream_targets:
+                    stream_targets[inlet] = []
+                stream_targets[inlet].append(unit.name)
+
+        # Add feed nodes
+        if self.show_feeds:
+            for feed_name in self.flowsheet.feeds:
+                self._nodes.append({
+                    "data": {
+                        "id": f"feed_{feed_name}",
+                        "label": feed_name,
+                        "type": "feed",
+                        "node_type": "feed",
+                    }
+                })
+
+        # Add unit nodes
+        for unit in self.flowsheet.units:
+            op_type = _get_operation_type(unit)
+            self._nodes.append({
+                "data": {
+                    "id": unit.name,
+                    "label": unit.name,
+                    "type": op_type,
+                    "node_type": "unit",
+                    "tooltip": _format_unit_tooltip(unit),
+                }
+            })
+
+        # Identify product streams (outputs not connected to any unit input)
+        product_streams = set()
+        for unit in self.flowsheet.units:
+            for outlet in unit.outlet_names:
+                # Check if this stream is used as input anywhere
+                is_input = any(
+                    outlet in u.inlet_names for u in self.flowsheet.units
+                )
+                # Check if it's a recycle source
+                is_recycle = outlet in self.flowsheet.recycles
+                if not is_input and not is_recycle:
+                    product_streams.add(outlet)
+
+        # Add product nodes
+        if self.show_products:
+            for product_name in product_streams:
+                self._nodes.append({
+                    "data": {
+                        "id": f"product_{product_name}",
+                        "label": product_name,
+                        "type": "product",
+                        "node_type": "product",
+                    }
+                })
+
+        # Add edges
+        edge_id = 0
+
+        # Feed -> Unit edges
+        for feed_name in self.flowsheet.feeds:
+            for unit in self.flowsheet.units:
+                if feed_name in unit.inlet_names:
+                    self._edges.append({
+                        "data": {
+                            "id": f"edge_{edge_id}",
+                            "source": f"feed_{feed_name}",
+                            "target": unit.name,
+                            "label": feed_name,
+                            "stream_name": feed_name,
+                        }
+                    })
+                    edge_id += 1
+
+        # Unit -> Unit edges
+        for source_unit in self.flowsheet.units:
+            for outlet in source_unit.outlet_names:
+                for target_unit in self.flowsheet.units:
+                    if outlet in target_unit.inlet_names:
+                        self._edges.append({
+                            "data": {
+                                "id": f"edge_{edge_id}",
+                                "source": source_unit.name,
+                                "target": target_unit.name,
+                                "label": outlet,
+                                "stream_name": outlet,
+                            }
+                        })
+                        edge_id += 1
+
+        # Unit -> Product edges
+        if self.show_products:
+            for unit in self.flowsheet.units:
+                for outlet in unit.outlet_names:
+                    if outlet in product_streams:
+                        self._edges.append({
+                            "data": {
+                                "id": f"edge_{edge_id}",
+                                "source": unit.name,
+                                "target": f"product_{outlet}",
+                                "label": outlet,
+                                "stream_name": outlet,
+                            }
+                        })
+                        edge_id += 1
+
+        # Recycle edges (with special styling)
+        for source, dest in self.flowsheet.recycles.items():
+            # Find the source unit
+            source_unit = None
+            for unit in self.flowsheet.units:
+                if source in unit.outlet_names:
+                    source_unit = unit.name
+                    break
+
+            # Find the target unit
+            target_unit = None
+            for unit in self.flowsheet.units:
+                if dest in unit.inlet_names:
+                    target_unit = unit.name
+                    break
+
+            if source_unit and target_unit:
+                self._edges.append({
+                    "data": {
+                        "id": f"edge_{edge_id}",
+                        "source": source_unit,
+                        "target": target_unit,
+                        "label": f"{source}→{dest}",
+                        "stream_name": source,
+                        "is_recycle": True,
+                    }
+                })
+                edge_id += 1
+
+    def _get_stylesheet(self) -> list[dict]:
+        """Generate Cytoscape stylesheet with custom icons."""
+        styles = [
+            # Base node style
+            {
+                "selector": "node",
+                "style": {
+                    "label": "data(label)",
+                    "text-valign": "bottom",
+                    "text-halign": "center",
+                    "text-margin-y": "5px",
+                    "font-size": "12px",
+                    "font-weight": "bold",
+                    "width": "60px",
+                    "height": "60px",
+                    "background-color": "#ffffff",
+                    "border-width": "0px",
+                }
+            },
+            # Base edge style
+            {
+                "selector": "edge",
+                "style": {
+                    "width": 2,
+                    "line-color": "#666666",
+                    "target-arrow-color": "#666666",
+                    "target-arrow-shape": "triangle",
+                    "curve-style": "bezier",
+                    "label": "data(label)",
+                    "font-size": "10px",
+                    "text-rotation": "autorotate",
+                    "text-margin-y": "-10px",
+                }
+            },
+            # Recycle edge style
+            {
+                "selector": "edge[is_recycle]",
+                "style": {
+                    "line-style": "dashed",
+                    "line-color": "#e74c3c",
+                    "target-arrow-color": "#e74c3c",
+                }
+            },
+            # Feed node style
+            {
+                "selector": "node[node_type='feed']",
+                "style": {
+                    "background-image": get_icon_data_uri("feed"),
+                    "background-fit": "contain",
+                    "background-clip": "none",
+                }
+            },
+            # Product node style
+            {
+                "selector": "node[node_type='product']",
+                "style": {
+                    "background-image": get_icon_data_uri("product"),
+                    "background-fit": "contain",
+                    "background-clip": "none",
+                }
+            },
+        ]
+
+        # Add styles for each unit type
+        unit_types_seen = set()
+        for unit in self.flowsheet.units:
+            op_type = _get_operation_type(unit)
+            if op_type not in unit_types_seen:
+                unit_types_seen.add(op_type)
+                styles.append({
+                    "selector": f"node[type='{op_type}']",
+                    "style": {
+                        "background-image": get_icon_data_uri(op_type),
+                        "background-fit": "contain",
+                        "background-clip": "none",
+                    }
+                })
+
+        return styles
+
+    def _get_layout_config(self) -> dict:
+        """Get layout configuration."""
+        base_config = {
+            "name": self.layout,
+        }
+
+        if self.layout == "dagre":
+            base_config.update({
+                "rankDir": "LR",  # Left to right
+                "nodeSep": 80,
+                "rankSep": 100,
+                "edgeSep": 20,
+            })
+        elif self.layout == "breadthfirst":
+            base_config.update({
+                "directed": True,
+                "spacingFactor": 1.5,
+            })
+        elif self.layout == "cose":
+            base_config.update({
+                "nodeRepulsion": 8000,
+                "idealEdgeLength": 100,
+            })
+
+        base_config.update(self.layout_options)
+        return base_config
+
+    def show(
+        self,
+        streams: dict[str, "Stream"] | None = None,
+        width: str = "100%",
+        height: str = "500px",
+    ) -> "ipycytoscape.CytoscapeWidget":
+        """Display the interactive flowsheet visualization.
+
+        Args:
+            streams: Solved stream data to include in tooltips (from flowsheet.solve())
+            width: Widget width (CSS value)
+            height: Widget height (CSS value)
+
+        Returns:
+            ipycytoscape CytoscapeWidget for display in Jupyter
+        """
+        # Update tooltips with stream data if provided
+        if streams:
+            self._update_stream_tooltips(streams)
+
+        # Create widget
+        self._widget = ipycytoscape.CytoscapeWidget()
+        self._widget.graph.add_graph_from_json({
+            "nodes": self._nodes,
+            "edges": self._edges,
+        })
+
+        # Apply stylesheet
+        self._widget.set_style(self._get_stylesheet())
+
+        # Apply layout
+        self._widget.set_layout(**self._get_layout_config())
+
+        # Configure interaction
+        self._widget.min_zoom = 0.3
+        self._widget.max_zoom = 3.0
+
+        # Set size
+        self._widget.layout.width = width
+        self._widget.layout.height = height
+
+        # Enable tooltips via node data (using popper extension)
+        self._setup_tooltips()
+
+        return self._widget
+
+    def _update_stream_tooltips(self, streams: dict[str, "Stream"]) -> None:
+        """Update edge tooltips with stream data."""
+        for edge in self._edges:
+            stream_name = edge["data"].get("stream_name")
+            if stream_name and stream_name in streams:
+                edge["data"]["tooltip"] = _format_stream_tooltip(
+                    streams[stream_name], stream_name
+                )
+
+        # Also update feed tooltips
+        for node in self._nodes:
+            if node["data"].get("node_type") == "feed":
+                feed_name = node["data"]["label"]
+                if feed_name in streams:
+                    node["data"]["tooltip"] = _format_stream_tooltip(
+                        streams[feed_name], feed_name
+                    )
+                elif feed_name in self.flowsheet.feeds:
+                    node["data"]["tooltip"] = _format_stream_tooltip(
+                        self.flowsheet.feeds[feed_name], feed_name
+                    )
+
+    def _setup_tooltips(self) -> None:
+        """Configure tooltip display on hover."""
+        if self._widget is None:
+            return
+
+        # ipycytoscape supports tooltips via the 'tooltip_source' attribute
+        # which uses the node/edge data for tooltip content
+        self._widget.tooltip_source = "tooltip"
+
+    def export_html(
+        self,
+        filename: str,
+        include_cytoscape_js: bool = True,
+        title: str = "Process Flowsheet",
+    ) -> None:
+        """Export the flowsheet to a standalone HTML file.
+
+        Args:
+            filename: Output filename (should end with .html)
+            include_cytoscape_js: Whether to include Cytoscape.js library inline
+            title: HTML page title
+        """
+        # Generate HTML with embedded Cytoscape.js
+        html_content = self._generate_html(title, include_cytoscape_js)
+
+        with open(filename, "w") as f:
+            f.write(html_content)
+
+    def _generate_html(self, title: str, include_js: bool) -> str:
+        """Generate standalone HTML content."""
+        graph_data = json.dumps({
+            "nodes": self._nodes,
+            "edges": self._edges,
+        }, indent=2)
+
+        stylesheet = json.dumps(self._get_stylesheet(), indent=2)
+        layout_config = json.dumps(self._get_layout_config(), indent=2)
+
+        if include_js:
+            cytoscape_src = "https://cdnjs.cloudflare.com/ajax/libs/cytoscape/3.28.1/cytoscape.min.js"
+            dagre_src = "https://cdnjs.cloudflare.com/ajax/libs/dagre/0.8.5/dagre.min.js"
+            cytoscape_dagre_src = "https://cdn.jsdelivr.net/npm/cytoscape-dagre@2.5.0/cytoscape-dagre.min.js"
+            popper_src = "https://unpkg.com/@popperjs/core@2"
+            cytoscape_popper_src = "https://cdn.jsdelivr.net/npm/cytoscape-popper@2.0.0/cytoscape-popper.min.js"
+            tippy_src = "https://unpkg.com/tippy.js@6"
+        else:
+            cytoscape_src = ""
+            dagre_src = ""
+            cytoscape_dagre_src = ""
+            popper_src = ""
+            cytoscape_popper_src = ""
+            tippy_src = ""
+
+        return f'''<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{title}</title>
+    <script src="{cytoscape_src}"></script>
+    <script src="{dagre_src}"></script>
+    <script src="{cytoscape_dagre_src}"></script>
+    <script src="{popper_src}"></script>
+    <script src="{cytoscape_popper_src}"></script>
+    <script src="{tippy_src}"></script>
+    <link rel="stylesheet" href="https://unpkg.com/tippy.js@6/dist/tippy.css">
+    <style>
+        body {{
+            margin: 0;
+            padding: 20px;
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+            background: #f5f5f5;
+        }}
+        h1 {{
+            margin: 0 0 20px 0;
+            color: #333;
+        }}
+        #cy {{
+            width: 100%;
+            height: calc(100vh - 100px);
+            background: white;
+            border: 1px solid #ddd;
+            border-radius: 8px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }}
+        .tippy-box {{
+            background: rgba(0, 0, 0, 0.9);
+            color: white;
+            border-radius: 4px;
+            padding: 8px 12px;
+            font-size: 12px;
+            max-width: 300px;
+        }}
+        .tippy-box b {{
+            color: #3498db;
+        }}
+    </style>
+</head>
+<body>
+    <h1>{title}</h1>
+    <div id="cy"></div>
+    <script>
+        // Register dagre layout
+        if (typeof cytoscape !== 'undefined' && typeof cytoscape.use !== 'undefined' && typeof cytoscapeDagre !== 'undefined') {{
+            cytoscape.use(cytoscapeDagre);
+        }}
+
+        // Graph data
+        var graphData = {graph_data};
+
+        // Stylesheet
+        var stylesheet = {stylesheet};
+
+        // Layout configuration
+        var layoutConfig = {layout_config};
+
+        // Initialize Cytoscape
+        var cy = cytoscape({{
+            container: document.getElementById('cy'),
+            elements: graphData,
+            style: stylesheet,
+            layout: layoutConfig,
+            minZoom: 0.3,
+            maxZoom: 3,
+            wheelSensitivity: 0.3,
+        }});
+
+        // Setup tooltips with Tippy.js
+        if (typeof tippy !== 'undefined') {{
+            cy.nodes().forEach(function(node) {{
+                var tooltip = node.data('tooltip');
+                if (tooltip) {{
+                    var ref = node.popperRef();
+                    var dummyDomEle = document.createElement('div');
+                    tippy(dummyDomEle, {{
+                        getReferenceClientRect: ref.getBoundingClientRect,
+                        content: tooltip,
+                        trigger: 'manual',
+                        placement: 'bottom',
+                        arrow: true,
+                        allowHTML: true,
+                    }});
+                    var tippyInstance = dummyDomEle._tippy;
+                    node.on('mouseover', function() {{ tippyInstance.show(); }});
+                    node.on('mouseout', function() {{ tippyInstance.hide(); }});
+                }}
+            }});
+
+            cy.edges().forEach(function(edge) {{
+                var tooltip = edge.data('tooltip');
+                if (tooltip) {{
+                    var ref = edge.popperRef();
+                    var dummyDomEle = document.createElement('div');
+                    tippy(dummyDomEle, {{
+                        getReferenceClientRect: ref.getBoundingClientRect,
+                        content: tooltip,
+                        trigger: 'manual',
+                        placement: 'top',
+                        arrow: true,
+                        allowHTML: true,
+                    }});
+                    var tippyInstance = dummyDomEle._tippy;
+                    edge.on('mouseover', function() {{ tippyInstance.show(); }});
+                    edge.on('mouseout', function() {{ tippyInstance.hide(); }});
+                }}
+            }});
+        }}
+
+        // Fit to viewport on load
+        cy.fit(50);
+    </script>
+</body>
+</html>'''
+
+    def export_png(self, filename: str, scale: float = 2.0) -> None:
+        """Export the flowsheet to a PNG image.
+
+        Note: This requires the widget to be displayed first.
+
+        Args:
+            filename: Output filename (should end with .png)
+            scale: Scale factor for resolution (2.0 = 2x resolution)
+        """
+        if self._widget is None:
+            raise RuntimeError(
+                "Widget must be displayed first. Call show() before export_png()."
+            )
+
+        # ipycytoscape doesn't have direct PNG export,
+        # so we'll save a message about using browser export
+        warnings.warn(
+            "PNG export requires manual screenshot or browser export. "
+            "In the HTML export, you can use browser developer tools to "
+            "capture the canvas, or use a screenshot tool. "
+            f"For automated PNG export, consider using the HTML export: {filename.replace('.png', '.html')}"
+        )
+
+    def get_graph_data(self) -> dict:
+        """Get the raw graph data as a dictionary.
+
+        Returns:
+            Dictionary with 'nodes' and 'edges' lists
+        """
+        return {
+            "nodes": self._nodes,
+            "edges": self._edges,
+        }
+
+    def to_networkx(self) -> "Any":
+        """Convert the flowsheet graph to a NetworkX DiGraph.
+
+        Returns:
+            networkx.DiGraph representation of the flowsheet
+
+        Raises:
+            ImportError: If networkx is not installed
+        """
+        try:
+            import networkx as nx
+        except ImportError:
+            raise ImportError(
+                "networkx is required for this method. "
+                "Install it with: pip install networkx"
+            )
+
+        G = nx.DiGraph()
+
+        # Add nodes
+        for node in self._nodes:
+            node_id = node["data"]["id"]
+            G.add_node(node_id, **node["data"])
+
+        # Add edges
+        for edge in self._edges:
+            source = edge["data"]["source"]
+            target = edge["data"]["target"]
+            G.add_edge(source, target, **edge["data"])
+
+        return G
+
+
+def visualize_flowsheet(
+    flowsheet: "Flowsheet",
+    streams: dict[str, "Stream"] | None = None,
+    **kwargs,
+) -> "ipycytoscape.CytoscapeWidget":
+    """Convenience function to visualize a flowsheet.
+
+    Args:
+        flowsheet: The Flowsheet object to visualize
+        streams: Solved stream data (from flowsheet.solve())
+        **kwargs: Additional arguments passed to FlowsheetVisualizer
+
+    Returns:
+        ipycytoscape CytoscapeWidget for display in Jupyter
+
+    Example:
+        >>> results = flowsheet.solve()
+        >>> visualize_flowsheet(flowsheet, streams=results)
+    """
+    viz = FlowsheetVisualizer(flowsheet, **kwargs)
+    return viz.show(streams=streams)

--- a/src/difflow/visualization/icons.py
+++ b/src/difflow/visualization/icons.py
@@ -1,0 +1,324 @@
+"""SVG icons for chemical engineering unit operations.
+
+Icons are based on ISO 10628 P&ID symbols, simplified for clarity.
+Each icon is provided as an SVG string and as a data URI for use in
+visualization libraries.
+"""
+
+import base64
+from typing import Callable
+
+# Icon dimensions (viewBox)
+ICON_SIZE = 60
+
+
+def _svg_to_data_uri(svg: str) -> str:
+    """Convert SVG string to data URI for embedding in HTML/CSS."""
+    encoded = base64.b64encode(svg.encode('utf-8')).decode('utf-8')
+    return f"data:image/svg+xml;base64,{encoded}"
+
+
+# =============================================================================
+# Core Unit Operation Icons
+# =============================================================================
+
+def _cstr_svg(fill: str = "#4a90d9", stroke: str = "#2c5aa0") -> str:
+    """CSTR - Continuous Stirred Tank Reactor (tank with agitator)."""
+    return f'''<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {ICON_SIZE} {ICON_SIZE}">
+  <rect x="10" y="15" width="40" height="35" rx="3" fill="{fill}" stroke="{stroke}" stroke-width="2"/>
+  <line x1="30" y1="5" x2="30" y2="20" stroke="{stroke}" stroke-width="2"/>
+  <line x1="22" y1="30" x2="38" y2="30" stroke="{stroke}" stroke-width="2"/>
+  <line x1="25" y1="36" x2="35" y2="36" stroke="{stroke}" stroke-width="2"/>
+  <ellipse cx="30" cy="50" rx="12" ry="3" fill="{fill}" stroke="{stroke}" stroke-width="1"/>
+</svg>'''
+
+
+def _pfr_svg(fill: str = "#5ba55b", stroke: str = "#3d7a3d") -> str:
+    """PFR - Plug Flow Reactor (horizontal tube)."""
+    return f'''<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {ICON_SIZE} {ICON_SIZE}">
+  <rect x="5" y="20" width="50" height="20" rx="10" fill="{fill}" stroke="{stroke}" stroke-width="2"/>
+  <line x1="15" y1="25" x2="15" y2="35" stroke="{stroke}" stroke-width="1.5"/>
+  <line x1="25" y1="25" x2="25" y2="35" stroke="{stroke}" stroke-width="1.5"/>
+  <line x1="35" y1="25" x2="35" y2="35" stroke="{stroke}" stroke-width="1.5"/>
+  <line x1="45" y1="25" x2="45" y2="35" stroke="{stroke}" stroke-width="1.5"/>
+</svg>'''
+
+
+def _flash_svg(fill: str = "#9b59b6", stroke: str = "#7d3c98") -> str:
+    """Flash drum - Vapor-liquid separator (vertical vessel with V/L)."""
+    return f'''<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {ICON_SIZE} {ICON_SIZE}">
+  <ellipse cx="30" cy="12" rx="15" ry="6" fill="{fill}" stroke="{stroke}" stroke-width="2"/>
+  <rect x="15" y="12" width="30" height="36" fill="{fill}" stroke="{stroke}" stroke-width="2"/>
+  <ellipse cx="30" cy="48" rx="15" ry="6" fill="{fill}" stroke="{stroke}" stroke-width="2"/>
+  <line x1="15" y1="30" x2="45" y2="30" stroke="{stroke}" stroke-width="1" stroke-dasharray="3,2"/>
+  <text x="30" y="22" text-anchor="middle" font-size="8" fill="{stroke}">V</text>
+  <text x="30" y="42" text-anchor="middle" font-size="8" fill="{stroke}">L</text>
+</svg>'''
+
+
+def _mixer_svg(fill: str = "#3498db", stroke: str = "#2471a3") -> str:
+    """Mixer - Stream combining (converging triangle)."""
+    return f'''<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {ICON_SIZE} {ICON_SIZE}">
+  <polygon points="10,15 10,45 50,30" fill="{fill}" stroke="{stroke}" stroke-width="2"/>
+</svg>'''
+
+
+def _splitter_svg(fill: str = "#e67e22", stroke: str = "#ba6318") -> str:
+    """Splitter - Stream dividing (diverging triangle)."""
+    return f'''<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {ICON_SIZE} {ICON_SIZE}">
+  <polygon points="10,30 50,15 50,45" fill="{fill}" stroke="{stroke}" stroke-width="2"/>
+</svg>'''
+
+
+def _distillation_svg(fill: str = "#1abc9c", stroke: str = "#16a085") -> str:
+    """Distillation column (tall column with trays)."""
+    return f'''<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {ICON_SIZE} {ICON_SIZE}">
+  <ellipse cx="30" cy="8" rx="12" ry="4" fill="{fill}" stroke="{stroke}" stroke-width="2"/>
+  <rect x="18" y="8" width="24" height="44" fill="{fill}" stroke="{stroke}" stroke-width="2"/>
+  <ellipse cx="30" cy="52" rx="12" ry="4" fill="{fill}" stroke="{stroke}" stroke-width="2"/>
+  <line x1="20" y1="18" x2="40" y2="18" stroke="{stroke}" stroke-width="1"/>
+  <line x1="20" y1="26" x2="40" y2="26" stroke="{stroke}" stroke-width="1"/>
+  <line x1="20" y1="34" x2="40" y2="34" stroke="{stroke}" stroke-width="1"/>
+  <line x1="20" y1="42" x2="40" y2="42" stroke="{stroke}" stroke-width="1"/>
+</svg>'''
+
+
+def _heater_svg(fill: str = "#e74c3c", stroke: str = "#c0392b") -> str:
+    """Heater (box with flame symbol)."""
+    return f'''<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {ICON_SIZE} {ICON_SIZE}">
+  <rect x="10" y="15" width="40" height="30" rx="3" fill="{fill}" stroke="{stroke}" stroke-width="2"/>
+  <path d="M30 22 Q25 28 30 34 Q35 28 30 22" fill="#f39c12" stroke="#d68910" stroke-width="1"/>
+  <path d="M24 26 Q21 30 24 34 Q27 30 24 26" fill="#f39c12" stroke="#d68910" stroke-width="1"/>
+  <path d="M36 26 Q33 30 36 34 Q39 30 36 26" fill="#f39c12" stroke="#d68910" stroke-width="1"/>
+</svg>'''
+
+
+def _cooler_svg(fill: str = "#3498db", stroke: str = "#2980b9") -> str:
+    """Cooler (box with snowflake/wave symbol)."""
+    return f'''<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {ICON_SIZE} {ICON_SIZE}">
+  <rect x="10" y="15" width="40" height="30" rx="3" fill="{fill}" stroke="{stroke}" stroke-width="2"/>
+  <path d="M20 25 Q25 22 30 25 Q35 28 40 25" fill="none" stroke="white" stroke-width="2"/>
+  <path d="M20 30 Q25 27 30 30 Q35 33 40 30" fill="none" stroke="white" stroke-width="2"/>
+  <path d="M20 35 Q25 32 30 35 Q35 38 40 35" fill="none" stroke="white" stroke-width="2"/>
+</svg>'''
+
+
+def _heat_exchanger_svg(fill: str = "#9b59b6", stroke: str = "#7d3c98") -> str:
+    """Shell-and-tube heat exchanger."""
+    return f'''<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {ICON_SIZE} {ICON_SIZE}">
+  <ellipse cx="10" cy="30" rx="6" ry="15" fill="{fill}" stroke="{stroke}" stroke-width="2"/>
+  <ellipse cx="50" cy="30" rx="6" ry="15" fill="{fill}" stroke="{stroke}" stroke-width="2"/>
+  <rect x="10" y="15" width="40" height="30" fill="{fill}" stroke="{stroke}" stroke-width="2"/>
+  <line x1="15" y1="22" x2="45" y2="22" stroke="{stroke}" stroke-width="1"/>
+  <line x1="15" y1="30" x2="45" y2="30" stroke="{stroke}" stroke-width="1"/>
+  <line x1="15" y1="38" x2="45" y2="38" stroke="{stroke}" stroke-width="1"/>
+</svg>'''
+
+
+def _fed_batch_svg(fill: str = "#4a90d9", stroke: str = "#2c5aa0") -> str:
+    """Fed-batch reactor (tank with feed arrow)."""
+    return f'''<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {ICON_SIZE} {ICON_SIZE}">
+  <rect x="10" y="18" width="40" height="32" rx="3" fill="{fill}" stroke="{stroke}" stroke-width="2"/>
+  <line x1="30" y1="8" x2="30" y2="18" stroke="{stroke}" stroke-width="2"/>
+  <polygon points="26,12 30,18 34,12" fill="{stroke}"/>
+  <line x1="22" y1="32" x2="38" y2="32" stroke="{stroke}" stroke-width="2"/>
+  <line x1="25" y1="38" x2="35" y2="38" stroke="{stroke}" stroke-width="2"/>
+</svg>'''
+
+
+def _cascade_svg(fill: str = "#16a085", stroke: str = "#0e6655") -> str:
+    """Multistage cascade (LLE or extraction)."""
+    return f'''<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {ICON_SIZE} {ICON_SIZE}">
+  <rect x="5" y="20" width="14" height="20" rx="2" fill="{fill}" stroke="{stroke}" stroke-width="1.5"/>
+  <rect x="23" y="20" width="14" height="20" rx="2" fill="{fill}" stroke="{stroke}" stroke-width="1.5"/>
+  <rect x="41" y="20" width="14" height="20" rx="2" fill="{fill}" stroke="{stroke}" stroke-width="1.5"/>
+  <line x1="19" y1="30" x2="23" y2="30" stroke="{stroke}" stroke-width="1.5"/>
+  <line x1="37" y1="30" x2="41" y2="30" stroke="{stroke}" stroke-width="1.5"/>
+</svg>'''
+
+
+def _bioreactor_svg(fill: str = "#27ae60", stroke: str = "#1e8449") -> str:
+    """Bioreactor (vessel with bubbles)."""
+    return f'''<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {ICON_SIZE} {ICON_SIZE}">
+  <ellipse cx="30" cy="12" rx="15" ry="6" fill="{fill}" stroke="{stroke}" stroke-width="2"/>
+  <rect x="15" y="12" width="30" height="36" fill="{fill}" stroke="{stroke}" stroke-width="2"/>
+  <ellipse cx="30" cy="48" rx="15" ry="6" fill="{fill}" stroke="{stroke}" stroke-width="2"/>
+  <circle cx="24" cy="35" r="3" fill="white" opacity="0.6"/>
+  <circle cx="32" cy="28" r="2" fill="white" opacity="0.6"/>
+  <circle cx="36" cy="38" r="2.5" fill="white" opacity="0.6"/>
+  <circle cx="26" cy="42" r="2" fill="white" opacity="0.6"/>
+</svg>'''
+
+
+def _centrifuge_svg(fill: str = "#8e44ad", stroke: str = "#6c3483") -> str:
+    """Centrifuge (disk with rotation arrows)."""
+    return f'''<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {ICON_SIZE} {ICON_SIZE}">
+  <circle cx="30" cy="30" r="20" fill="{fill}" stroke="{stroke}" stroke-width="2"/>
+  <circle cx="30" cy="30" r="8" fill="white" stroke="{stroke}" stroke-width="1"/>
+  <path d="M30 8 A22 22 0 0 1 52 30" fill="none" stroke="{stroke}" stroke-width="2" marker-end="url(#arrow)"/>
+  <defs>
+    <marker id="arrow" markerWidth="6" markerHeight="6" refX="3" refY="3" orient="auto">
+      <path d="M0,0 L6,3 L0,6 Z" fill="{stroke}"/>
+    </marker>
+  </defs>
+</svg>'''
+
+
+def _filtration_svg(fill: str = "#2980b9", stroke: str = "#1a5276") -> str:
+    """Filtration unit (funnel shape with filter)."""
+    return f'''<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {ICON_SIZE} {ICON_SIZE}">
+  <polygon points="10,15 50,15 40,35 20,35" fill="{fill}" stroke="{stroke}" stroke-width="2"/>
+  <rect x="20" y="35" width="20" height="15" fill="{fill}" stroke="{stroke}" stroke-width="2"/>
+  <line x1="15" y1="25" x2="45" y2="25" stroke="white" stroke-width="2" stroke-dasharray="2,2"/>
+</svg>'''
+
+
+def _chromatography_svg(fill: str = "#d35400", stroke: str = "#a04000") -> str:
+    """Chromatography column (column with gradient)."""
+    return f'''<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {ICON_SIZE} {ICON_SIZE}">
+  <defs>
+    <linearGradient id="chromGrad" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#f39c12"/>
+      <stop offset="50%" style="stop-color:#e74c3c"/>
+      <stop offset="100%" style="stop-color:#9b59b6"/>
+    </linearGradient>
+  </defs>
+  <rect x="20" y="8" width="20" height="44" rx="3" fill="url(#chromGrad)" stroke="{stroke}" stroke-width="2"/>
+  <ellipse cx="30" cy="8" rx="10" ry="3" fill="{fill}" stroke="{stroke}" stroke-width="2"/>
+  <ellipse cx="30" cy="52" rx="10" ry="3" fill="{fill}" stroke="{stroke}" stroke-width="2"/>
+</svg>'''
+
+
+def _feed_svg(fill: str = "#2ecc71", stroke: str = "#229954") -> str:
+    """Feed stream source (circle with arrow out)."""
+    return f'''<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {ICON_SIZE} {ICON_SIZE}">
+  <circle cx="25" cy="30" r="15" fill="{fill}" stroke="{stroke}" stroke-width="2"/>
+  <line x1="40" y1="30" x2="55" y2="30" stroke="{stroke}" stroke-width="3"/>
+  <polygon points="50,25 55,30 50,35" fill="{stroke}"/>
+</svg>'''
+
+
+def _product_svg(fill: str = "#e74c3c", stroke: str = "#c0392b") -> str:
+    """Product stream sink (circle with arrow in)."""
+    return f'''<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {ICON_SIZE} {ICON_SIZE}">
+  <circle cx="35" cy="30" r="15" fill="{fill}" stroke="{stroke}" stroke-width="2"/>
+  <line x1="5" y1="30" x2="20" y2="30" stroke="{stroke}" stroke-width="3"/>
+  <polygon points="15,25 20,30 15,35" fill="{stroke}"/>
+</svg>'''
+
+
+def _generic_svg(fill: str = "#95a5a6", stroke: str = "#7f8c8d") -> str:
+    """Generic unit operation (simple box)."""
+    return f'''<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {ICON_SIZE} {ICON_SIZE}">
+  <rect x="10" y="15" width="40" height="30" rx="5" fill="{fill}" stroke="{stroke}" stroke-width="2"/>
+</svg>'''
+
+
+# =============================================================================
+# Icon Registry
+# =============================================================================
+
+# Map operation functions/names to their icon generators
+ICON_REGISTRY: dict[str, Callable[[], str]] = {
+    # Core reactors
+    "CSTR": _cstr_svg,
+    "cstr": _cstr_svg,
+    "PFR": _pfr_svg,
+    "pfr": _pfr_svg,
+    "GasPFR": _pfr_svg,
+    "FedBatchReactor": _fed_batch_svg,
+    "fed_batch": _fed_batch_svg,
+    "SemiBatchReactor": _fed_batch_svg,
+
+    # Separations
+    "Flash": _flash_svg,
+    "flash": _flash_svg,
+    "Mixer": _mixer_svg,
+    "mixer": _mixer_svg,
+    "Splitter": _splitter_svg,
+    "splitter": _splitter_svg,
+
+    # Distillation
+    "ShortcutColumn": _distillation_svg,
+    "DistillationColumn": _distillation_svg,
+    "distillation": _distillation_svg,
+
+    # Heat exchange
+    "Heater": _heater_svg,
+    "heater": _heater_svg,
+    "Cooler": _cooler_svg,
+    "cooler": _cooler_svg,
+    "CounterCurrentHX": _heat_exchanger_svg,
+    "CoCurrentHX": _heat_exchanger_svg,
+    "heat_exchanger": _heat_exchanger_svg,
+
+    # LLE
+    "MultistageCascade": _cascade_svg,
+    "cascade": _cascade_svg,
+    "DifferentialContactor": _cascade_svg,
+    "LLEEquilibrium": _cascade_svg,
+
+    # Bio units
+    "ContinuousBioreactor": _bioreactor_svg,
+    "FedBatchBioreactor": _bioreactor_svg,
+    "bioreactor": _bioreactor_svg,
+    "Centrifuge": _centrifuge_svg,
+    "DiscStackCentrifuge": _centrifuge_svg,
+    "centrifuge": _centrifuge_svg,
+    "Ultrafiltration": _filtration_svg,
+    "Diafiltration": _filtration_svg,
+    "TFF": _filtration_svg,
+    "filtration": _filtration_svg,
+    "ProteinAChromatography": _chromatography_svg,
+    "IonExchangeChromatography": _chromatography_svg,
+    "SizeExclusionChromatography": _chromatography_svg,
+    "chromatography": _chromatography_svg,
+
+    # Special nodes
+    "feed": _feed_svg,
+    "Feed": _feed_svg,
+    "product": _product_svg,
+    "Product": _product_svg,
+    "generic": _generic_svg,
+}
+
+
+def get_icon_svg(operation_type: str) -> str:
+    """Get SVG string for a given operation type.
+
+    Args:
+        operation_type: Name of the operation (e.g., 'CSTR', 'Flash', 'Mixer')
+
+    Returns:
+        SVG string for the icon
+    """
+    icon_fn = ICON_REGISTRY.get(operation_type, _generic_svg)
+    return icon_fn()
+
+
+def get_icon_data_uri(operation_type: str) -> str:
+    """Get data URI for a given operation type.
+
+    Args:
+        operation_type: Name of the operation (e.g., 'CSTR', 'Flash', 'Mixer')
+
+    Returns:
+        Data URI string (data:image/svg+xml;base64,...)
+    """
+    svg = get_icon_svg(operation_type)
+    return _svg_to_data_uri(svg)
+
+
+def list_available_icons() -> list[str]:
+    """List all available icon types."""
+    return sorted(set(ICON_REGISTRY.keys()))
+
+
+def register_icon(name: str, icon_fn: Callable[[], str]) -> None:
+    """Register a custom icon.
+
+    Args:
+        name: Name for the icon (will be matched against operation names)
+        icon_fn: Function that returns an SVG string
+    """
+    ICON_REGISTRY[name] = icon_fn


### PR DESCRIPTION
- Add visualization module with ipycytoscape-based interactive graphs
- Create P&ID-style SVG icons for all unit operations (CSTR, PFR, Flash, Mixer, Splitter, Heater, Cooler, distillation, heat exchangers, etc.)
- Implement FlowsheetVisualizer class with:
  - Left-to-right dagre layout for process flowsheets
  - Drag-and-drop node positioning
  - Rich tooltips showing stream data (T, P, compositions)
  - HTML export for publications
  - NetworkX integration for graph analysis
- Add visualization optional dependency group in pyproject.toml
- Add example notebook (09_visualization.ipynb) demonstrating features