### PR TITLE
Add update method to all *Params dataclasses for JAX-compatible differentiation

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -333,19 +333,22 @@ import jax
 import jax.numpy as jnp
 from jax import grad
 
-# Objective: Maximize conversion while minimizing heat duty
-def objective(params):
-    T_reactor, volume = params
+# Define base parameters once
+base_params = CSTRParams(
+    volume=1.0,  # Will be optimized
+    stoichiometry=jnp.array([[-1.0], [1.0]]),
+    k_ref=0.1,
+    E_a=50000.0,
+    T_ref=350.0,
+    dH_rxn=jnp.array([-50000.0])
+)
 
-    # Update reactor with new volume
-    reactor_params = CSTRParams(
-        volume=volume,
-        stoichiometry=jnp.array([[-1.0], [1.0]]),
-        k_ref=0.1,
-        E_a=50000.0,
-        T_ref=350.0,
-        dH_rxn=jnp.array([-50000.0])
-    )
+# Objective: Maximize conversion while minimizing heat duty
+def objective(opt_params):
+    T_reactor, volume = opt_params
+
+    # Use update() to create new params - JAX compatible!
+    reactor_params = base_params.update(volume=volume)
     reactor = CSTR(reactor_params, thermo, ['A', 'B'])
 
     inlet = make_stream({'A': 1.0, 'B': 0.0}, T=350.0, P=101325.0)
@@ -360,15 +363,18 @@ def objective(params):
 # Gradient-based optimization
 grad_obj = grad(objective)
 
-params = jnp.array([350.0, 1.0])  # Initial: T=350K, V=1m³
+opt_params = jnp.array([350.0, 1.0])  # Initial: T=350K, V=1m³
 learning_rate = 0.1
 
 for i in range(50):
-    gradient = grad_obj(params)
-    params = params + learning_rate * gradient
+    gradient = grad_obj(opt_params)
+    opt_params = opt_params + learning_rate * gradient
 
     if i % 10 == 0:
-        print(f"Iter {i}: T={params[0]:.1f}K, V={params[1]:.2f}m³, obj={objective(params):.4f}")
+        print(f"Iter {i}: T={opt_params[0]:.1f}K, V={opt_params[1]:.2f}m³, obj={objective(opt_params):.4f}")
+
+# Access parameters with dict-like syntax
+print(f"Base volume: {base_params['volume']}")  # Read access
 ```
 
 ---

--- a/src/difflow/economics/capital.py
+++ b/src/difflow/economics/capital.py
@@ -449,6 +449,26 @@ class InstallationFactors:
         """Convert params to a dictionary."""
         return dc_asdict(self)
 
+    def __repr__(self) -> str:
+        """Concise string representation."""
+        def fmt(v):
+            if v is None:
+                return "None"
+            if callable(v) and hasattr(v, '__name__'):
+                return v.__name__
+            if hasattr(v, 'shape'):
+                if v.ndim == 0:
+                    return f"{float(v):.4g}"
+                return f"Array{list(v.shape)}"
+            if isinstance(v, dict):
+                items = ", ".join(f"{k}: {fmt(val)}" for k, val in v.items())
+                return "{" + items + "}"
+            if isinstance(v, (list, tuple)) and len(v) > 5:
+                return f"{type(v).__name__}[{len(v)}]"
+            return repr(v)
+        items = ", ".join(f"{f.name}={fmt(getattr(self, f.name))}" for f in fields(self))
+        return f"{self.__class__.__name__}({items})"
+
 
 # Pre-defined installation factors by plant type
 INSTALLATION_FACTORS = {

--- a/src/difflow/economics/capital.py
+++ b/src/difflow/economics/capital.py
@@ -19,7 +19,7 @@ Reference: Turton et al., "Analysis, Synthesis, and Design of Chemical Processes
 import jax.numpy as jnp
 from jax import Array
 from typing import NamedTuple, Optional
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, replace, fields, asdict as dc_asdict
 
 from .indices import escalate_cost, DEFAULT_BASE_YEAR, DEFAULT_CURRENT_YEAR
 
@@ -436,6 +436,18 @@ class InstallationFactors:
             return getattr(self, key)
         except AttributeError:
             raise KeyError(key)
+
+    def __contains__(self, key: str) -> bool:
+        """Check if a field exists in the params."""
+        return key in {f.name for f in fields(self)}
+
+    def keys(self):
+        """Return field names for dict-like iteration."""
+        return (f.name for f in fields(self))
+
+    def asdict(self) -> dict:
+        """Convert params to a dictionary."""
+        return dc_asdict(self)
 
 
 # Pre-defined installation factors by plant type

--- a/src/difflow/economics/capital.py
+++ b/src/difflow/economics/capital.py
@@ -19,7 +19,7 @@ Reference: Turton et al., "Analysis, Synthesis, and Design of Chemical Processes
 import jax.numpy as jnp
 from jax import Array
 from typing import NamedTuple, Optional
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 
 from .indices import escalate_cost, DEFAULT_BASE_YEAR, DEFAULT_CURRENT_YEAR
 
@@ -416,6 +416,19 @@ class InstallationFactors:
             self.buildings + self.yard_improvements + self.service_facilities +
             self.engineering + self.construction + self.contingency
         )
+
+    def update(self, **kwargs) -> "InstallationFactors":
+        """Return a new InstallationFactors with specified fields replaced.
+
+        This enables JAX-compatible parameter updates for differentiation.
+
+        Args:
+            **kwargs: Fields to update (e.g., piping=0.40, contingency=0.20)
+
+        Returns:
+            New InstallationFactors with updated fields
+        """
+        return replace(self, **kwargs)
 
 
 # Pre-defined installation factors by plant type

--- a/src/difflow/economics/capital.py
+++ b/src/difflow/economics/capital.py
@@ -430,6 +430,13 @@ class InstallationFactors:
         """
         return replace(self, **kwargs)
 
+    def __getitem__(self, key: str):
+        """Get parameter value by name for dict-like access."""
+        try:
+            return getattr(self, key)
+        except AttributeError:
+            raise KeyError(key)
+
 
 # Pre-defined installation factors by plant type
 INSTALLATION_FACTORS = {

--- a/src/difflow/economics/capital.py
+++ b/src/difflow/economics/capital.py
@@ -445,6 +445,30 @@ class InstallationFactors:
         """Return field names for dict-like iteration."""
         return (f.name for f in fields(self))
 
+    def values(self):
+        """Return field values for dict-like iteration.
+
+        Returns:
+            Iterator over field values
+        """
+        return (getattr(self, f.name) for f in fields(self))
+
+    def items(self):
+        """Return (name, value) pairs for dict-like iteration.
+
+        Returns:
+            Iterator over (field_name, value) tuples
+        """
+        return ((f.name, getattr(self, f.name)) for f in fields(self))
+
+    def __iter__(self):
+        """Iterate over field names (like dict)."""
+        return (f.name for f in fields(self))
+
+    def __len__(self) -> int:
+        """Return number of fields."""
+        return len(fields(self))
+
     def asdict(self) -> dict:
         """Convert params to a dictionary."""
         return dc_asdict(self)

--- a/src/difflow/economics/profitability.py
+++ b/src/difflow/economics/profitability.py
@@ -16,7 +16,7 @@ import jax
 import jax.numpy as jnp
 from jax import Array
 from jax import lax
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Callable, NamedTuple
 import optimistix as optx
 
@@ -36,6 +36,19 @@ class FinancialParams:
     salvage_fraction: float = 0.05  # Salvage value as fraction of FCI
     working_capital_fraction: float = 0.15  # Working capital as fraction of FCI
     inflation_rate: float = 0.02  # Annual inflation for revenues/costs
+
+    def update(self, **kwargs) -> "FinancialParams":
+        """Return a new FinancialParams with specified fields replaced.
+
+        This enables JAX-compatible parameter updates for differentiation.
+
+        Args:
+            **kwargs: Fields to update (e.g., discount_rate=0.12, tax_rate=0.25)
+
+        Returns:
+            New FinancialParams with updated fields
+        """
+        return replace(self, **kwargs)
 
 
 DEFAULT_FINANCIAL = FinancialParams()

--- a/src/difflow/economics/profitability.py
+++ b/src/difflow/economics/profitability.py
@@ -65,6 +65,30 @@ class FinancialParams:
         """Return field names for dict-like iteration."""
         return (f.name for f in fields(self))
 
+    def values(self):
+        """Return field values for dict-like iteration.
+
+        Returns:
+            Iterator over field values
+        """
+        return (getattr(self, f.name) for f in fields(self))
+
+    def items(self):
+        """Return (name, value) pairs for dict-like iteration.
+
+        Returns:
+            Iterator over (field_name, value) tuples
+        """
+        return ((f.name, getattr(self, f.name)) for f in fields(self))
+
+    def __iter__(self):
+        """Iterate over field names (like dict)."""
+        return (f.name for f in fields(self))
+
+    def __len__(self) -> int:
+        """Return number of fields."""
+        return len(fields(self))
+
     def asdict(self) -> dict:
         """Convert params to a dictionary."""
         return dc_asdict(self)

--- a/src/difflow/economics/profitability.py
+++ b/src/difflow/economics/profitability.py
@@ -16,7 +16,7 @@ import jax
 import jax.numpy as jnp
 from jax import Array
 from jax import lax
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, replace, fields, asdict as dc_asdict
 from typing import Callable, NamedTuple
 import optimistix as optx
 
@@ -56,6 +56,18 @@ class FinancialParams:
             return getattr(self, key)
         except AttributeError:
             raise KeyError(key)
+
+    def __contains__(self, key: str) -> bool:
+        """Check if a field exists in the params."""
+        return key in {f.name for f in fields(self)}
+
+    def keys(self):
+        """Return field names for dict-like iteration."""
+        return (f.name for f in fields(self))
+
+    def asdict(self) -> dict:
+        """Convert params to a dictionary."""
+        return dc_asdict(self)
 
 
 DEFAULT_FINANCIAL = FinancialParams()

--- a/src/difflow/economics/profitability.py
+++ b/src/difflow/economics/profitability.py
@@ -50,6 +50,13 @@ class FinancialParams:
         """
         return replace(self, **kwargs)
 
+    def __getitem__(self, key: str):
+        """Get parameter value by name for dict-like access."""
+        try:
+            return getattr(self, key)
+        except AttributeError:
+            raise KeyError(key)
+
 
 DEFAULT_FINANCIAL = FinancialParams()
 

--- a/src/difflow/economics/profitability.py
+++ b/src/difflow/economics/profitability.py
@@ -69,6 +69,26 @@ class FinancialParams:
         """Convert params to a dictionary."""
         return dc_asdict(self)
 
+    def __repr__(self) -> str:
+        """Concise string representation."""
+        def fmt(v):
+            if v is None:
+                return "None"
+            if callable(v) and hasattr(v, '__name__'):
+                return v.__name__
+            if hasattr(v, 'shape'):
+                if v.ndim == 0:
+                    return f"{float(v):.4g}"
+                return f"Array{list(v.shape)}"
+            if isinstance(v, dict):
+                items = ", ".join(f"{k}: {fmt(val)}" for k, val in v.items())
+                return "{" + items + "}"
+            if isinstance(v, (list, tuple)) and len(v) > 5:
+                return f"{type(v).__name__}[{len(v)}]"
+            return repr(v)
+        items = ", ".join(f"{f.name}={fmt(getattr(self, f.name))}" for f in fields(self))
+        return f"{self.__class__.__name__}({items})"
+
 
 DEFAULT_FINANCIAL = FinancialParams()
 

--- a/src/difflow/eos.py
+++ b/src/difflow/eos.py
@@ -91,6 +91,26 @@ class EOSParams:
         """Convert params to a dictionary."""
         return dc_asdict(self)
 
+    def __repr__(self) -> str:
+        """Concise string representation."""
+        def fmt(v):
+            if v is None:
+                return "None"
+            if callable(v) and hasattr(v, '__name__'):
+                return v.__name__
+            if hasattr(v, 'shape'):
+                if v.ndim == 0:
+                    return f"{float(v):.4g}"
+                return f"Array{list(v.shape)}"
+            if isinstance(v, dict):
+                items = ", ".join(f"{k}: {fmt(val)}" for k, val in v.items())
+                return "{" + items + "}"
+            if isinstance(v, (list, tuple)) and len(v) > 5:
+                return f"{type(v).__name__}[{len(v)}]"
+            return repr(v)
+        items = ", ".join(f"{f.name}={fmt(getattr(self, f.name))}" for f in fields(self))
+        return f"{self.__class__.__name__}({items})"
+
 
 class PengRobinson:
     """Peng-Robinson equation of state.

--- a/src/difflow/eos.py
+++ b/src/difflow/eos.py
@@ -17,7 +17,7 @@ All calculations are JAX-compatible for automatic differentiation.
 """
 
 from typing import NamedTuple, Literal
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 import jax.numpy as jnp
 from jax import Array, lax
 
@@ -58,6 +58,19 @@ class EOSParams:
     Pc: Array   # Critical pressures
     omega: Array  # Acentric factors
     species_order: list[str]
+
+    def update(self, **kwargs) -> "EOSParams":
+        """Return a new EOSParams with specified fields replaced.
+
+        This enables JAX-compatible parameter updates for differentiation.
+
+        Args:
+            **kwargs: Fields to update
+
+        Returns:
+            New EOSParams with updated fields
+        """
+        return replace(self, **kwargs)
 
 
 class PengRobinson:

--- a/src/difflow/eos.py
+++ b/src/difflow/eos.py
@@ -17,7 +17,7 @@ All calculations are JAX-compatible for automatic differentiation.
 """
 
 from typing import NamedTuple, Literal
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, replace, fields, asdict as dc_asdict
 import jax.numpy as jnp
 from jax import Array, lax
 
@@ -78,6 +78,18 @@ class EOSParams:
             return getattr(self, key)
         except AttributeError:
             raise KeyError(key)
+
+    def __contains__(self, key: str) -> bool:
+        """Check if a field exists in the params."""
+        return key in {f.name for f in fields(self)}
+
+    def keys(self):
+        """Return field names for dict-like iteration."""
+        return (f.name for f in fields(self))
+
+    def asdict(self) -> dict:
+        """Convert params to a dictionary."""
+        return dc_asdict(self)
 
 
 class PengRobinson:

--- a/src/difflow/eos.py
+++ b/src/difflow/eos.py
@@ -72,6 +72,13 @@ class EOSParams:
         """
         return replace(self, **kwargs)
 
+    def __getitem__(self, key: str):
+        """Get parameter value by name for dict-like access."""
+        try:
+            return getattr(self, key)
+        except AttributeError:
+            raise KeyError(key)
+
 
 class PengRobinson:
     """Peng-Robinson equation of state.

--- a/src/difflow/eos.py
+++ b/src/difflow/eos.py
@@ -87,6 +87,30 @@ class EOSParams:
         """Return field names for dict-like iteration."""
         return (f.name for f in fields(self))
 
+    def values(self):
+        """Return field values for dict-like iteration.
+
+        Returns:
+            Iterator over field values
+        """
+        return (getattr(self, f.name) for f in fields(self))
+
+    def items(self):
+        """Return (name, value) pairs for dict-like iteration.
+
+        Returns:
+            Iterator over (field_name, value) tuples
+        """
+        return ((f.name, getattr(self, f.name)) for f in fields(self))
+
+    def __iter__(self):
+        """Iterate over field names (like dict)."""
+        return (f.name for f in fields(self))
+
+    def __len__(self) -> int:
+        """Return number of fields."""
+        return len(fields(self))
+
     def asdict(self) -> dict:
         """Convert params to a dictionary."""
         return dc_asdict(self)

--- a/src/difflow/units/cstr.py
+++ b/src/difflow/units/cstr.py
@@ -118,6 +118,30 @@ class CSTRParams:
         """
         return (f.name for f in fields(self))
 
+    def values(self):
+        """Return field values for dict-like iteration.
+
+        Returns:
+            Iterator over field values
+        """
+        return (getattr(self, f.name) for f in fields(self))
+
+    def items(self):
+        """Return (name, value) pairs for dict-like iteration.
+
+        Returns:
+            Iterator over (field_name, value) tuples
+        """
+        return ((f.name, getattr(self, f.name)) for f in fields(self))
+
+    def __iter__(self):
+        """Iterate over field names (like dict)."""
+        return (f.name for f in fields(self))
+
+    def __len__(self) -> int:
+        """Return number of fields."""
+        return len(fields(self))
+
     def asdict(self) -> dict:
         """Convert params to a dictionary.
 

--- a/src/difflow/units/cstr.py
+++ b/src/difflow/units/cstr.py
@@ -126,6 +126,26 @@ class CSTRParams:
         """
         return dc_asdict(self)
 
+    def __repr__(self) -> str:
+        """Concise string representation."""
+        def fmt(v):
+            if v is None:
+                return "None"
+            if callable(v) and hasattr(v, '__name__'):
+                return v.__name__
+            if hasattr(v, 'shape'):  # JAX/numpy array
+                if v.ndim == 0:
+                    return f"{float(v):.4g}"
+                return f"Array{list(v.shape)}"
+            if isinstance(v, dict):
+                items = ", ".join(f"{k}: {fmt(val)}" for k, val in v.items())
+                return "{" + items + "}"
+            if isinstance(v, (list, tuple)) and len(v) > 5:
+                return f"{type(v).__name__}[{len(v)}]"
+            return repr(v)
+        items = ", ".join(f"{f.name}={fmt(getattr(self, f.name))}" for f in fields(self))
+        return f"{self.__class__.__name__}({items})"
+
 
 class CSTR:
     """Continuous Stirred Tank Reactor with multiple reactions.

--- a/src/difflow/units/cstr.py
+++ b/src/difflow/units/cstr.py
@@ -82,6 +82,23 @@ class CSTRParams:
         """
         return replace(self, **kwargs)
 
+    def __getitem__(self, key: str):
+        """Get parameter value by name for dict-like access.
+
+        Args:
+            key: Field name to access
+
+        Returns:
+            Value of the field
+
+        Raises:
+            KeyError: If field doesn't exist
+        """
+        try:
+            return getattr(self, key)
+        except AttributeError:
+            raise KeyError(key)
+
 
 class CSTR:
     """Continuous Stirred Tank Reactor with multiple reactions.

--- a/src/difflow/units/cstr.py
+++ b/src/difflow/units/cstr.py
@@ -21,7 +21,7 @@ and the new DynamicUnit protocol for unified dynamic modeling.
 """
 
 from typing import Callable, Literal, Any
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, replace, fields, asdict as dc_asdict
 import jax.numpy as jnp
 from jax import Array
 
@@ -98,6 +98,33 @@ class CSTRParams:
             return getattr(self, key)
         except AttributeError:
             raise KeyError(key)
+
+    def __contains__(self, key: str) -> bool:
+        """Check if a field exists in the params.
+
+        Args:
+            key: Field name to check
+
+        Returns:
+            True if field exists, False otherwise
+        """
+        return key in {f.name for f in fields(self)}
+
+    def keys(self):
+        """Return field names for dict-like iteration.
+
+        Returns:
+            Iterator over field names
+        """
+        return (f.name for f in fields(self))
+
+    def asdict(self) -> dict:
+        """Convert params to a dictionary.
+
+        Returns:
+            Dictionary with field names as keys and values
+        """
+        return dc_asdict(self)
 
 
 class CSTR:

--- a/src/difflow/units/distillation.py
+++ b/src/difflow/units/distillation.py
@@ -82,6 +82,13 @@ class ShortcutColumnParams:
         """
         return replace(self, **kwargs)
 
+    def __getitem__(self, key: str):
+        """Get parameter value by name for dict-like access."""
+        try:
+            return getattr(self, key)
+        except AttributeError:
+            raise KeyError(key)
+
 
 class ShortcutColumn:
     """Shortcut distillation column using Fenske-Underwood-Gilliland.
@@ -568,6 +575,13 @@ class DistillationColumnParams:
             New DistillationColumnParams with updated fields
         """
         return replace(self, **kwargs)
+
+    def __getitem__(self, key: str):
+        """Get parameter value by name for dict-like access."""
+        try:
+            return getattr(self, key)
+        except AttributeError:
+            raise KeyError(key)
 
 
 class DistillationColumn:

--- a/src/difflow/units/distillation.py
+++ b/src/difflow/units/distillation.py
@@ -19,7 +19,7 @@ Numerical Considerations:
 """
 
 from typing import Callable, Literal
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 import jax
 import jax.numpy as jnp
 from jax import Array, lax
@@ -68,6 +68,19 @@ class ShortcutColumnParams:
     heavy_key: str
     x_D_LK: float = 0.99  # LK recovery in distillate
     x_B_HK: float = 0.99  # HK recovery in bottoms
+
+    def update(self, **kwargs) -> "ShortcutColumnParams":
+        """Return a new ShortcutColumnParams with specified fields replaced.
+
+        This enables JAX-compatible parameter updates for differentiation.
+
+        Args:
+            **kwargs: Fields to update (e.g., x_D_LK=0.995)
+
+        Returns:
+            New ShortcutColumnParams with updated fields
+        """
+        return replace(self, **kwargs)
 
 
 class ShortcutColumn:
@@ -542,6 +555,19 @@ class DistillationColumnParams:
     feed_stage: int
     condenser_type: Literal["total", "partial"] = "total"
     P: float = 101325.0
+
+    def update(self, **kwargs) -> "DistillationColumnParams":
+        """Return a new DistillationColumnParams with specified fields replaced.
+
+        This enables JAX-compatible parameter updates for differentiation.
+
+        Args:
+            **kwargs: Fields to update (e.g., n_stages=20, P=50000.0)
+
+        Returns:
+            New DistillationColumnParams with updated fields
+        """
+        return replace(self, **kwargs)
 
 
 class DistillationColumn:

--- a/src/difflow/units/distillation.py
+++ b/src/difflow/units/distillation.py
@@ -97,6 +97,30 @@ class ShortcutColumnParams:
         """Return field names for dict-like iteration."""
         return (f.name for f in fields(self))
 
+    def values(self):
+        """Return field values for dict-like iteration.
+
+        Returns:
+            Iterator over field values
+        """
+        return (getattr(self, f.name) for f in fields(self))
+
+    def items(self):
+        """Return (name, value) pairs for dict-like iteration.
+
+        Returns:
+            Iterator over (field_name, value) tuples
+        """
+        return ((f.name, getattr(self, f.name)) for f in fields(self))
+
+    def __iter__(self):
+        """Iterate over field names (like dict)."""
+        return (f.name for f in fields(self))
+
+    def __len__(self) -> int:
+        """Return number of fields."""
+        return len(fields(self))
+
     def asdict(self) -> dict:
         """Convert params to a dictionary."""
         return dc_asdict(self)
@@ -622,6 +646,30 @@ class DistillationColumnParams:
     def keys(self):
         """Return field names for dict-like iteration."""
         return (f.name for f in fields(self))
+
+    def values(self):
+        """Return field values for dict-like iteration.
+
+        Returns:
+            Iterator over field values
+        """
+        return (getattr(self, f.name) for f in fields(self))
+
+    def items(self):
+        """Return (name, value) pairs for dict-like iteration.
+
+        Returns:
+            Iterator over (field_name, value) tuples
+        """
+        return ((f.name, getattr(self, f.name)) for f in fields(self))
+
+    def __iter__(self):
+        """Iterate over field names (like dict)."""
+        return (f.name for f in fields(self))
+
+    def __len__(self) -> int:
+        """Return number of fields."""
+        return len(fields(self))
 
     def asdict(self) -> dict:
         """Convert params to a dictionary."""

--- a/src/difflow/units/distillation.py
+++ b/src/difflow/units/distillation.py
@@ -101,6 +101,26 @@ class ShortcutColumnParams:
         """Convert params to a dictionary."""
         return dc_asdict(self)
 
+    def __repr__(self) -> str:
+        """Concise string representation."""
+        def fmt(v):
+            if v is None:
+                return "None"
+            if callable(v) and hasattr(v, '__name__'):
+                return v.__name__
+            if hasattr(v, 'shape'):
+                if v.ndim == 0:
+                    return f"{float(v):.4g}"
+                return f"Array{list(v.shape)}"
+            if isinstance(v, dict):
+                items = ", ".join(f"{k}: {fmt(val)}" for k, val in v.items())
+                return "{" + items + "}"
+            if isinstance(v, (list, tuple)) and len(v) > 5:
+                return f"{type(v).__name__}[{len(v)}]"
+            return repr(v)
+        items = ", ".join(f"{f.name}={fmt(getattr(self, f.name))}" for f in fields(self))
+        return f"{self.__class__.__name__}({items})"
+
 
 class ShortcutColumn:
     """Shortcut distillation column using Fenske-Underwood-Gilliland.
@@ -606,6 +626,26 @@ class DistillationColumnParams:
     def asdict(self) -> dict:
         """Convert params to a dictionary."""
         return dc_asdict(self)
+
+    def __repr__(self) -> str:
+        """Concise string representation."""
+        def fmt(v):
+            if v is None:
+                return "None"
+            if callable(v) and hasattr(v, '__name__'):
+                return v.__name__
+            if hasattr(v, 'shape'):
+                if v.ndim == 0:
+                    return f"{float(v):.4g}"
+                return f"Array{list(v.shape)}"
+            if isinstance(v, dict):
+                items = ", ".join(f"{k}: {fmt(val)}" for k, val in v.items())
+                return "{" + items + "}"
+            if isinstance(v, (list, tuple)) and len(v) > 5:
+                return f"{type(v).__name__}[{len(v)}]"
+            return repr(v)
+        items = ", ".join(f"{f.name}={fmt(getattr(self, f.name))}" for f in fields(self))
+        return f"{self.__class__.__name__}({items})"
 
 
 class DistillationColumn:

--- a/src/difflow/units/distillation.py
+++ b/src/difflow/units/distillation.py
@@ -19,7 +19,7 @@ Numerical Considerations:
 """
 
 from typing import Callable, Literal
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, replace, fields, asdict as dc_asdict
 import jax
 import jax.numpy as jnp
 from jax import Array, lax
@@ -88,6 +88,18 @@ class ShortcutColumnParams:
             return getattr(self, key)
         except AttributeError:
             raise KeyError(key)
+
+    def __contains__(self, key: str) -> bool:
+        """Check if a field exists in the params."""
+        return key in {f.name for f in fields(self)}
+
+    def keys(self):
+        """Return field names for dict-like iteration."""
+        return (f.name for f in fields(self))
+
+    def asdict(self) -> dict:
+        """Convert params to a dictionary."""
+        return dc_asdict(self)
 
 
 class ShortcutColumn:
@@ -582,6 +594,18 @@ class DistillationColumnParams:
             return getattr(self, key)
         except AttributeError:
             raise KeyError(key)
+
+    def __contains__(self, key: str) -> bool:
+        """Check if a field exists in the params."""
+        return key in {f.name for f in fields(self)}
+
+    def keys(self):
+        """Return field names for dict-like iteration."""
+        return (f.name for f in fields(self))
+
+    def asdict(self) -> dict:
+        """Convert params to a dictionary."""
+        return dc_asdict(self)
 
 
 class DistillationColumn:

--- a/src/difflow/units/flash.py
+++ b/src/difflow/units/flash.py
@@ -80,6 +80,26 @@ class FlashParams:
         """Convert params to a dictionary."""
         return dc_asdict(self)
 
+    def __repr__(self) -> str:
+        """Concise string representation."""
+        def fmt(v):
+            if v is None:
+                return "None"
+            if callable(v) and hasattr(v, '__name__'):
+                return v.__name__
+            if hasattr(v, 'shape'):
+                if v.ndim == 0:
+                    return f"{float(v):.4g}"
+                return f"Array{list(v.shape)}"
+            if isinstance(v, dict):
+                items = ", ".join(f"{k}: {fmt(val)}" for k, val in v.items())
+                return "{" + items + "}"
+            if isinstance(v, (list, tuple)) and len(v) > 5:
+                return f"{type(v).__name__}[{len(v)}]"
+            return repr(v)
+        items = ", ".join(f"{f.name}={fmt(getattr(self, f.name))}" for f in fields(self))
+        return f"{self.__class__.__name__}({items})"
+
 
 class Flash:
     """Flash separator with TP specification.

--- a/src/difflow/units/flash.py
+++ b/src/difflow/units/flash.py
@@ -11,7 +11,7 @@ differentiation through the converged solution.
 """
 
 from typing import Any
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 import jax
 import jax.numpy as jnp
 from jax import Array
@@ -47,6 +47,19 @@ class FlashParams:
         species_order: List of species names for array ordering
     """
     species_order: list[str]
+
+    def update(self, **kwargs) -> "FlashParams":
+        """Return a new FlashParams with specified fields replaced.
+
+        This enables JAX-compatible parameter updates for differentiation.
+
+        Args:
+            **kwargs: Fields to update
+
+        Returns:
+            New FlashParams with updated fields
+        """
+        return replace(self, **kwargs)
 
 
 class Flash:

--- a/src/difflow/units/flash.py
+++ b/src/difflow/units/flash.py
@@ -76,6 +76,30 @@ class FlashParams:
         """Return field names for dict-like iteration."""
         return (f.name for f in fields(self))
 
+    def values(self):
+        """Return field values for dict-like iteration.
+
+        Returns:
+            Iterator over field values
+        """
+        return (getattr(self, f.name) for f in fields(self))
+
+    def items(self):
+        """Return (name, value) pairs for dict-like iteration.
+
+        Returns:
+            Iterator over (field_name, value) tuples
+        """
+        return ((f.name, getattr(self, f.name)) for f in fields(self))
+
+    def __iter__(self):
+        """Iterate over field names (like dict)."""
+        return (f.name for f in fields(self))
+
+    def __len__(self) -> int:
+        """Return number of fields."""
+        return len(fields(self))
+
     def asdict(self) -> dict:
         """Convert params to a dictionary."""
         return dc_asdict(self)

--- a/src/difflow/units/flash.py
+++ b/src/difflow/units/flash.py
@@ -11,7 +11,7 @@ differentiation through the converged solution.
 """
 
 from typing import Any
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, replace, fields, asdict as dc_asdict
 import jax
 import jax.numpy as jnp
 from jax import Array
@@ -67,6 +67,18 @@ class FlashParams:
             return getattr(self, key)
         except AttributeError:
             raise KeyError(key)
+
+    def __contains__(self, key: str) -> bool:
+        """Check if a field exists in the params."""
+        return key in {f.name for f in fields(self)}
+
+    def keys(self):
+        """Return field names for dict-like iteration."""
+        return (f.name for f in fields(self))
+
+    def asdict(self) -> dict:
+        """Convert params to a dictionary."""
+        return dc_asdict(self)
 
 
 class Flash:

--- a/src/difflow/units/flash.py
+++ b/src/difflow/units/flash.py
@@ -61,6 +61,13 @@ class FlashParams:
         """
         return replace(self, **kwargs)
 
+    def __getitem__(self, key: str):
+        """Get parameter value by name for dict-like access."""
+        try:
+            return getattr(self, key)
+        except AttributeError:
+            raise KeyError(key)
+
 
 class Flash:
     """Flash separator with TP specification.

--- a/src/difflow/units/heat_exchanger.py
+++ b/src/difflow/units/heat_exchanger.py
@@ -284,6 +284,30 @@ class HeaterParams:
         """Return field names for dict-like iteration."""
         return (f.name for f in fields(self))
 
+    def values(self):
+        """Return field values for dict-like iteration.
+
+        Returns:
+            Iterator over field values
+        """
+        return (getattr(self, f.name) for f in fields(self))
+
+    def items(self):
+        """Return (name, value) pairs for dict-like iteration.
+
+        Returns:
+            Iterator over (field_name, value) tuples
+        """
+        return ((f.name, getattr(self, f.name)) for f in fields(self))
+
+    def __iter__(self):
+        """Iterate over field names (like dict)."""
+        return (f.name for f in fields(self))
+
+    def __len__(self) -> int:
+        """Return number of fields."""
+        return len(fields(self))
+
     def asdict(self) -> dict:
         """Convert params to a dictionary."""
         return dc_asdict(self)
@@ -466,6 +490,30 @@ class CoolerParams:
         """Return field names for dict-like iteration."""
         return (f.name for f in fields(self))
 
+    def values(self):
+        """Return field values for dict-like iteration.
+
+        Returns:
+            Iterator over field values
+        """
+        return (getattr(self, f.name) for f in fields(self))
+
+    def items(self):
+        """Return (name, value) pairs for dict-like iteration.
+
+        Returns:
+            Iterator over (field_name, value) tuples
+        """
+        return ((f.name, getattr(self, f.name)) for f in fields(self))
+
+    def __iter__(self):
+        """Iterate over field names (like dict)."""
+        return (f.name for f in fields(self))
+
+    def __len__(self) -> int:
+        """Return number of fields."""
+        return len(fields(self))
+
     def asdict(self) -> dict:
         """Convert params to a dictionary."""
         return dc_asdict(self)
@@ -625,6 +673,30 @@ class HeatExchangerParams:
     def keys(self):
         """Return field names for dict-like iteration."""
         return (f.name for f in fields(self))
+
+    def values(self):
+        """Return field values for dict-like iteration.
+
+        Returns:
+            Iterator over field values
+        """
+        return (getattr(self, f.name) for f in fields(self))
+
+    def items(self):
+        """Return (name, value) pairs for dict-like iteration.
+
+        Returns:
+            Iterator over (field_name, value) tuples
+        """
+        return ((f.name, getattr(self, f.name)) for f in fields(self))
+
+    def __iter__(self):
+        """Iterate over field names (like dict)."""
+        return (f.name for f in fields(self))
+
+    def __len__(self) -> int:
+        """Return number of fields."""
+        return len(fields(self))
 
     def asdict(self) -> dict:
         """Convert params to a dictionary."""

--- a/src/difflow/units/heat_exchanger.py
+++ b/src/difflow/units/heat_exchanger.py
@@ -15,7 +15,7 @@ Numerical Considerations:
 - Cr = 1 edge case: Smooth blending between balanced and general formulas
 """
 
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, replace, fields, asdict as dc_asdict
 from typing import Callable
 import jax
 import jax.numpy as jnp
@@ -276,6 +276,18 @@ class HeaterParams:
         except AttributeError:
             raise KeyError(key)
 
+    def __contains__(self, key: str) -> bool:
+        """Check if a field exists in the params."""
+        return key in {f.name for f in fields(self)}
+
+    def keys(self):
+        """Return field names for dict-like iteration."""
+        return (f.name for f in fields(self))
+
+    def asdict(self) -> dict:
+        """Convert params to a dictionary."""
+        return dc_asdict(self)
+
 
 class Heater:
     """Single-stream heater with utility (steam, hot oil, etc).
@@ -426,6 +438,18 @@ class CoolerParams:
         except AttributeError:
             raise KeyError(key)
 
+    def __contains__(self, key: str) -> bool:
+        """Check if a field exists in the params."""
+        return key in {f.name for f in fields(self)}
+
+    def keys(self):
+        """Return field names for dict-like iteration."""
+        return (f.name for f in fields(self))
+
+    def asdict(self) -> dict:
+        """Convert params to a dictionary."""
+        return dc_asdict(self)
+
 
 class Cooler:
     """Single-stream cooler with utility (cooling water, refrigerant, etc).
@@ -553,6 +577,18 @@ class HeatExchangerParams:
             return getattr(self, key)
         except AttributeError:
             raise KeyError(key)
+
+    def __contains__(self, key: str) -> bool:
+        """Check if a field exists in the params."""
+        return key in {f.name for f in fields(self)}
+
+    def keys(self):
+        """Return field names for dict-like iteration."""
+        return (f.name for f in fields(self))
+
+    def asdict(self) -> dict:
+        """Convert params to a dictionary."""
+        return dc_asdict(self)
 
 
 class CounterCurrentHX:

--- a/src/difflow/units/heat_exchanger.py
+++ b/src/difflow/units/heat_exchanger.py
@@ -288,6 +288,26 @@ class HeaterParams:
         """Convert params to a dictionary."""
         return dc_asdict(self)
 
+    def __repr__(self) -> str:
+        """Concise string representation."""
+        def fmt(v):
+            if v is None:
+                return "None"
+            if callable(v) and hasattr(v, '__name__'):
+                return v.__name__
+            if hasattr(v, 'shape'):
+                if v.ndim == 0:
+                    return f"{float(v):.4g}"
+                return f"Array{list(v.shape)}"
+            if isinstance(v, dict):
+                items = ", ".join(f"{k}: {fmt(val)}" for k, val in v.items())
+                return "{" + items + "}"
+            if isinstance(v, (list, tuple)) and len(v) > 5:
+                return f"{type(v).__name__}[{len(v)}]"
+            return repr(v)
+        items = ", ".join(f"{f.name}={fmt(getattr(self, f.name))}" for f in fields(self))
+        return f"{self.__class__.__name__}({items})"
+
 
 class Heater:
     """Single-stream heater with utility (steam, hot oil, etc).
@@ -450,6 +470,26 @@ class CoolerParams:
         """Convert params to a dictionary."""
         return dc_asdict(self)
 
+    def __repr__(self) -> str:
+        """Concise string representation."""
+        def fmt(v):
+            if v is None:
+                return "None"
+            if callable(v) and hasattr(v, '__name__'):
+                return v.__name__
+            if hasattr(v, 'shape'):
+                if v.ndim == 0:
+                    return f"{float(v):.4g}"
+                return f"Array{list(v.shape)}"
+            if isinstance(v, dict):
+                items = ", ".join(f"{k}: {fmt(val)}" for k, val in v.items())
+                return "{" + items + "}"
+            if isinstance(v, (list, tuple)) and len(v) > 5:
+                return f"{type(v).__name__}[{len(v)}]"
+            return repr(v)
+        items = ", ".join(f"{f.name}={fmt(getattr(self, f.name))}" for f in fields(self))
+        return f"{self.__class__.__name__}({items})"
+
 
 class Cooler:
     """Single-stream cooler with utility (cooling water, refrigerant, etc).
@@ -589,6 +629,26 @@ class HeatExchangerParams:
     def asdict(self) -> dict:
         """Convert params to a dictionary."""
         return dc_asdict(self)
+
+    def __repr__(self) -> str:
+        """Concise string representation."""
+        def fmt(v):
+            if v is None:
+                return "None"
+            if callable(v) and hasattr(v, '__name__'):
+                return v.__name__
+            if hasattr(v, 'shape'):
+                if v.ndim == 0:
+                    return f"{float(v):.4g}"
+                return f"Array{list(v.shape)}"
+            if isinstance(v, dict):
+                items = ", ".join(f"{k}: {fmt(val)}" for k, val in v.items())
+                return "{" + items + "}"
+            if isinstance(v, (list, tuple)) and len(v) > 5:
+                return f"{type(v).__name__}[{len(v)}]"
+            return repr(v)
+        items = ", ".join(f"{f.name}={fmt(getattr(self, f.name))}" for f in fields(self))
+        return f"{self.__class__.__name__}({items})"
 
 
 class CounterCurrentHX:

--- a/src/difflow/units/heat_exchanger.py
+++ b/src/difflow/units/heat_exchanger.py
@@ -269,6 +269,13 @@ class HeaterParams:
         """
         return replace(self, **kwargs)
 
+    def __getitem__(self, key: str):
+        """Get parameter value by name for dict-like access."""
+        try:
+            return getattr(self, key)
+        except AttributeError:
+            raise KeyError(key)
+
 
 class Heater:
     """Single-stream heater with utility (steam, hot oil, etc).
@@ -412,6 +419,13 @@ class CoolerParams:
         """
         return replace(self, **kwargs)
 
+    def __getitem__(self, key: str):
+        """Get parameter value by name for dict-like access."""
+        try:
+            return getattr(self, key)
+        except AttributeError:
+            raise KeyError(key)
+
 
 class Cooler:
     """Single-stream cooler with utility (cooling water, refrigerant, etc).
@@ -532,6 +546,13 @@ class HeatExchangerParams:
             New HeatExchangerParams with updated fields
         """
         return replace(self, **kwargs)
+
+    def __getitem__(self, key: str):
+        """Get parameter value by name for dict-like access."""
+        try:
+            return getattr(self, key)
+        except AttributeError:
+            raise KeyError(key)
 
 
 class CounterCurrentHX:

--- a/src/difflow/units/heat_exchanger.py
+++ b/src/difflow/units/heat_exchanger.py
@@ -15,7 +15,7 @@ Numerical Considerations:
 - Cr = 1 edge case: Smooth blending between balanced and general formulas
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Callable
 import jax
 import jax.numpy as jnp
@@ -256,6 +256,19 @@ class HeaterParams:
     T_utility: Array | float | None = None
     Cp: float | None = None
 
+    def update(self, **kwargs) -> "HeaterParams":
+        """Return a new HeaterParams with specified fields replaced.
+
+        This enables JAX-compatible parameter updates for differentiation.
+
+        Args:
+            **kwargs: Fields to update (e.g., duty=1000.0, T_out=350.0)
+
+        Returns:
+            New HeaterParams with updated fields
+        """
+        return replace(self, **kwargs)
+
 
 class Heater:
     """Single-stream heater with utility (steam, hot oil, etc).
@@ -386,6 +399,19 @@ class CoolerParams:
     T_utility: Array | float | None = None
     Cp: float | None = None
 
+    def update(self, **kwargs) -> "CoolerParams":
+        """Return a new CoolerParams with specified fields replaced.
+
+        This enables JAX-compatible parameter updates for differentiation.
+
+        Args:
+            **kwargs: Fields to update (e.g., duty=1000.0, T_out=300.0)
+
+        Returns:
+            New CoolerParams with updated fields
+        """
+        return replace(self, **kwargs)
+
 
 class Cooler:
     """Single-stream cooler with utility (cooling water, refrigerant, etc).
@@ -493,6 +519,19 @@ class HeatExchangerParams:
     Cp_hot: float | None = None
     Cp_cold: float | None = None
     min_approach: float = 10.0
+
+    def update(self, **kwargs) -> "HeatExchangerParams":
+        """Return a new HeatExchangerParams with specified fields replaced.
+
+        This enables JAX-compatible parameter updates for differentiation.
+
+        Args:
+            **kwargs: Fields to update (e.g., UA=500.0)
+
+        Returns:
+            New HeatExchangerParams with updated fields
+        """
+        return replace(self, **kwargs)
 
 
 class CounterCurrentHX:

--- a/src/difflow/units/lle.py
+++ b/src/difflow/units/lle.py
@@ -365,6 +365,13 @@ class CascadeParams:
         """
         return replace(self, **kwargs)
 
+    def __getitem__(self, key: str):
+        """Get parameter value by name for dict-like access."""
+        try:
+            return getattr(self, key)
+        except AttributeError:
+            raise KeyError(key)
+
 
 class MultistageCascade:
     """Multi-stage liquid-liquid extraction cascade.
@@ -639,6 +646,13 @@ class ContactorParams:
             New ContactorParams with updated fields
         """
         return replace(self, **kwargs)
+
+    def __getitem__(self, key: str):
+        """Get parameter value by name for dict-like access."""
+        try:
+            return getattr(self, key)
+        except AttributeError:
+            raise KeyError(key)
 
 
 class DifferentialContactor:

--- a/src/difflow/units/lle.py
+++ b/src/difflow/units/lle.py
@@ -384,6 +384,26 @@ class CascadeParams:
         """Convert params to a dictionary."""
         return dc_asdict(self)
 
+    def __repr__(self) -> str:
+        """Concise string representation."""
+        def fmt(v):
+            if v is None:
+                return "None"
+            if callable(v) and hasattr(v, '__name__'):
+                return v.__name__
+            if hasattr(v, 'shape'):
+                if v.ndim == 0:
+                    return f"{float(v):.4g}"
+                return f"Array{list(v.shape)}"
+            if isinstance(v, dict):
+                items = ", ".join(f"{k}: {fmt(val)}" for k, val in v.items())
+                return "{" + items + "}"
+            if isinstance(v, (list, tuple)) and len(v) > 5:
+                return f"{type(v).__name__}[{len(v)}]"
+            return repr(v)
+        items = ", ".join(f"{f.name}={fmt(getattr(self, f.name))}" for f in fields(self))
+        return f"{self.__class__.__name__}({items})"
+
 
 class MultistageCascade:
     """Multi-stage liquid-liquid extraction cascade.
@@ -677,6 +697,26 @@ class ContactorParams:
     def asdict(self) -> dict:
         """Convert params to a dictionary."""
         return dc_asdict(self)
+
+    def __repr__(self) -> str:
+        """Concise string representation."""
+        def fmt(v):
+            if v is None:
+                return "None"
+            if callable(v) and hasattr(v, '__name__'):
+                return v.__name__
+            if hasattr(v, 'shape'):
+                if v.ndim == 0:
+                    return f"{float(v):.4g}"
+                return f"Array{list(v.shape)}"
+            if isinstance(v, dict):
+                items = ", ".join(f"{k}: {fmt(val)}" for k, val in v.items())
+                return "{" + items + "}"
+            if isinstance(v, (list, tuple)) and len(v) > 5:
+                return f"{type(v).__name__}[{len(v)}]"
+            return repr(v)
+        items = ", ".join(f"{f.name}={fmt(getattr(self, f.name))}" for f in fields(self))
+        return f"{self.__class__.__name__}({items})"
 
 
 class DifferentialContactor:

--- a/src/difflow/units/lle.py
+++ b/src/difflow/units/lle.py
@@ -10,7 +10,7 @@ coefficient models (NRTL, UNIQUAC) for computing equilibrium.
 All operations are fully differentiable using JAX.
 """
 
-from dataclasses import dataclass, field, replace
+from dataclasses import dataclass, field, replace, fields, asdict as dc_asdict
 from typing import Callable, NamedTuple, Literal
 import jax
 import jax.numpy as jnp
@@ -372,6 +372,18 @@ class CascadeParams:
         except AttributeError:
             raise KeyError(key)
 
+    def __contains__(self, key: str) -> bool:
+        """Check if a field exists in the params."""
+        return key in {f.name for f in fields(self)}
+
+    def keys(self):
+        """Return field names for dict-like iteration."""
+        return (f.name for f in fields(self))
+
+    def asdict(self) -> dict:
+        """Convert params to a dictionary."""
+        return dc_asdict(self)
+
 
 class MultistageCascade:
     """Multi-stage liquid-liquid extraction cascade.
@@ -653,6 +665,18 @@ class ContactorParams:
             return getattr(self, key)
         except AttributeError:
             raise KeyError(key)
+
+    def __contains__(self, key: str) -> bool:
+        """Check if a field exists in the params."""
+        return key in {f.name for f in fields(self)}
+
+    def keys(self):
+        """Return field names for dict-like iteration."""
+        return (f.name for f in fields(self))
+
+    def asdict(self) -> dict:
+        """Convert params to a dictionary."""
+        return dc_asdict(self)
 
 
 class DifferentialContactor:

--- a/src/difflow/units/lle.py
+++ b/src/difflow/units/lle.py
@@ -10,7 +10,7 @@ coefficient models (NRTL, UNIQUAC) for computing equilibrium.
 All operations are fully differentiable using JAX.
 """
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import Callable, NamedTuple, Literal
 import jax
 import jax.numpy as jnp
@@ -352,6 +352,19 @@ class CascadeParams:
     flow_config: Literal["counter_current", "co_current"] = "counter_current"
     stage_efficiency: float = 0.8
 
+    def update(self, **kwargs) -> "CascadeParams":
+        """Return a new CascadeParams with specified fields replaced.
+
+        This enables JAX-compatible parameter updates for differentiation.
+
+        Args:
+            **kwargs: Fields to update (e.g., n_stages=10)
+
+        Returns:
+            New CascadeParams with updated fields
+        """
+        return replace(self, **kwargs)
+
 
 class MultistageCascade:
     """Multi-stage liquid-liquid extraction cascade.
@@ -613,6 +626,19 @@ class ContactorParams:
     mass_transfer_model: Literal["equilibrium", "rate_based"] = "equilibrium"
     Kla: float | Array | dict[str, float] = 0.01  # 1/s, per solute or global
     HETP: float | Array = 0.5  # m
+
+    def update(self, **kwargs) -> "ContactorParams":
+        """Return a new ContactorParams with specified fields replaced.
+
+        This enables JAX-compatible parameter updates for differentiation.
+
+        Args:
+            **kwargs: Fields to update (e.g., length=5.0, HETP=0.3)
+
+        Returns:
+            New ContactorParams with updated fields
+        """
+        return replace(self, **kwargs)
 
 
 class DifferentialContactor:

--- a/src/difflow/units/lle.py
+++ b/src/difflow/units/lle.py
@@ -380,6 +380,30 @@ class CascadeParams:
         """Return field names for dict-like iteration."""
         return (f.name for f in fields(self))
 
+    def values(self):
+        """Return field values for dict-like iteration.
+
+        Returns:
+            Iterator over field values
+        """
+        return (getattr(self, f.name) for f in fields(self))
+
+    def items(self):
+        """Return (name, value) pairs for dict-like iteration.
+
+        Returns:
+            Iterator over (field_name, value) tuples
+        """
+        return ((f.name, getattr(self, f.name)) for f in fields(self))
+
+    def __iter__(self):
+        """Iterate over field names (like dict)."""
+        return (f.name for f in fields(self))
+
+    def __len__(self) -> int:
+        """Return number of fields."""
+        return len(fields(self))
+
     def asdict(self) -> dict:
         """Convert params to a dictionary."""
         return dc_asdict(self)
@@ -693,6 +717,30 @@ class ContactorParams:
     def keys(self):
         """Return field names for dict-like iteration."""
         return (f.name for f in fields(self))
+
+    def values(self):
+        """Return field values for dict-like iteration.
+
+        Returns:
+            Iterator over field values
+        """
+        return (getattr(self, f.name) for f in fields(self))
+
+    def items(self):
+        """Return (name, value) pairs for dict-like iteration.
+
+        Returns:
+            Iterator over (field_name, value) tuples
+        """
+        return ((f.name, getattr(self, f.name)) for f in fields(self))
+
+    def __iter__(self):
+        """Iterate over field names (like dict)."""
+        return (f.name for f in fields(self))
+
+    def __len__(self) -> int:
+        """Return number of fields."""
+        return len(fields(self))
 
     def asdict(self) -> dict:
         """Convert params to a dictionary."""

--- a/src/difflow/units/pfr.py
+++ b/src/difflow/units/pfr.py
@@ -33,7 +33,7 @@ a JAX-native differentiable ODE solver library.
 """
 
 from typing import Callable, Literal, Any
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 import jax.numpy as jnp
 from jax import Array
 import diffrax
@@ -82,6 +82,19 @@ class PFRParams:
     rtol: float = 1e-6
     atol: float = 1e-8
     n_save_points: int = 101
+
+    def update(self, **kwargs) -> "PFRParams":
+        """Return a new PFRParams with specified fields replaced.
+
+        This enables JAX-compatible parameter updates for differentiation.
+
+        Args:
+            **kwargs: Fields to update (e.g., V=2.0, rate_params={...})
+
+        Returns:
+            New PFRParams with updated fields
+        """
+        return replace(self, **kwargs)
 
 
 class PFR:
@@ -597,6 +610,19 @@ class GasPFRParams:
     rtol: float = 1e-6
     atol: float = 1e-8
     n_save_points: int = 101
+
+    def update(self, **kwargs) -> "GasPFRParams":
+        """Return a new GasPFRParams with specified fields replaced.
+
+        This enables JAX-compatible parameter updates for differentiation.
+
+        Args:
+            **kwargs: Fields to update (e.g., V=2.0, alpha=0.1)
+
+        Returns:
+            New GasPFRParams with updated fields
+        """
+        return replace(self, **kwargs)
 
 
 class GasPFR:

--- a/src/difflow/units/pfr.py
+++ b/src/difflow/units/pfr.py
@@ -96,6 +96,13 @@ class PFRParams:
         """
         return replace(self, **kwargs)
 
+    def __getitem__(self, key: str):
+        """Get parameter value by name for dict-like access."""
+        try:
+            return getattr(self, key)
+        except AttributeError:
+            raise KeyError(key)
+
 
 class PFR:
     """Plug Flow Reactor with multiple reactions.
@@ -623,6 +630,13 @@ class GasPFRParams:
             New GasPFRParams with updated fields
         """
         return replace(self, **kwargs)
+
+    def __getitem__(self, key: str):
+        """Get parameter value by name for dict-like access."""
+        try:
+            return getattr(self, key)
+        except AttributeError:
+            raise KeyError(key)
 
 
 class GasPFR:

--- a/src/difflow/units/pfr.py
+++ b/src/difflow/units/pfr.py
@@ -115,6 +115,26 @@ class PFRParams:
         """Convert params to a dictionary."""
         return dc_asdict(self)
 
+    def __repr__(self) -> str:
+        """Concise string representation."""
+        def fmt(v):
+            if v is None:
+                return "None"
+            if callable(v) and hasattr(v, '__name__'):
+                return v.__name__
+            if hasattr(v, 'shape'):
+                if v.ndim == 0:
+                    return f"{float(v):.4g}"
+                return f"Array{list(v.shape)}"
+            if isinstance(v, dict):
+                items = ", ".join(f"{k}: {fmt(val)}" for k, val in v.items())
+                return "{" + items + "}"
+            if isinstance(v, (list, tuple)) and len(v) > 5:
+                return f"{type(v).__name__}[{len(v)}]"
+            return repr(v)
+        items = ", ".join(f"{f.name}={fmt(getattr(self, f.name))}" for f in fields(self))
+        return f"{self.__class__.__name__}({items})"
+
 
 class PFR:
     """Plug Flow Reactor with multiple reactions.
@@ -661,6 +681,26 @@ class GasPFRParams:
     def asdict(self) -> dict:
         """Convert params to a dictionary."""
         return dc_asdict(self)
+
+    def __repr__(self) -> str:
+        """Concise string representation."""
+        def fmt(v):
+            if v is None:
+                return "None"
+            if callable(v) and hasattr(v, '__name__'):
+                return v.__name__
+            if hasattr(v, 'shape'):
+                if v.ndim == 0:
+                    return f"{float(v):.4g}"
+                return f"Array{list(v.shape)}"
+            if isinstance(v, dict):
+                items = ", ".join(f"{k}: {fmt(val)}" for k, val in v.items())
+                return "{" + items + "}"
+            if isinstance(v, (list, tuple)) and len(v) > 5:
+                return f"{type(v).__name__}[{len(v)}]"
+            return repr(v)
+        items = ", ".join(f"{f.name}={fmt(getattr(self, f.name))}" for f in fields(self))
+        return f"{self.__class__.__name__}({items})"
 
 
 class GasPFR:

--- a/src/difflow/units/pfr.py
+++ b/src/difflow/units/pfr.py
@@ -33,7 +33,7 @@ a JAX-native differentiable ODE solver library.
 """
 
 from typing import Callable, Literal, Any
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, replace, fields, asdict as dc_asdict
 import jax.numpy as jnp
 from jax import Array
 import diffrax
@@ -102,6 +102,18 @@ class PFRParams:
             return getattr(self, key)
         except AttributeError:
             raise KeyError(key)
+
+    def __contains__(self, key: str) -> bool:
+        """Check if a field exists in the params."""
+        return key in {f.name for f in fields(self)}
+
+    def keys(self):
+        """Return field names for dict-like iteration."""
+        return (f.name for f in fields(self))
+
+    def asdict(self) -> dict:
+        """Convert params to a dictionary."""
+        return dc_asdict(self)
 
 
 class PFR:
@@ -637,6 +649,18 @@ class GasPFRParams:
             return getattr(self, key)
         except AttributeError:
             raise KeyError(key)
+
+    def __contains__(self, key: str) -> bool:
+        """Check if a field exists in the params."""
+        return key in {f.name for f in fields(self)}
+
+    def keys(self):
+        """Return field names for dict-like iteration."""
+        return (f.name for f in fields(self))
+
+    def asdict(self) -> dict:
+        """Convert params to a dictionary."""
+        return dc_asdict(self)
 
 
 class GasPFR:

--- a/src/difflow/units/pfr.py
+++ b/src/difflow/units/pfr.py
@@ -111,6 +111,30 @@ class PFRParams:
         """Return field names for dict-like iteration."""
         return (f.name for f in fields(self))
 
+    def values(self):
+        """Return field values for dict-like iteration.
+
+        Returns:
+            Iterator over field values
+        """
+        return (getattr(self, f.name) for f in fields(self))
+
+    def items(self):
+        """Return (name, value) pairs for dict-like iteration.
+
+        Returns:
+            Iterator over (field_name, value) tuples
+        """
+        return ((f.name, getattr(self, f.name)) for f in fields(self))
+
+    def __iter__(self):
+        """Iterate over field names (like dict)."""
+        return (f.name for f in fields(self))
+
+    def __len__(self) -> int:
+        """Return number of fields."""
+        return len(fields(self))
+
     def asdict(self) -> dict:
         """Convert params to a dictionary."""
         return dc_asdict(self)
@@ -677,6 +701,30 @@ class GasPFRParams:
     def keys(self):
         """Return field names for dict-like iteration."""
         return (f.name for f in fields(self))
+
+    def values(self):
+        """Return field values for dict-like iteration.
+
+        Returns:
+            Iterator over field values
+        """
+        return (getattr(self, f.name) for f in fields(self))
+
+    def items(self):
+        """Return (name, value) pairs for dict-like iteration.
+
+        Returns:
+            Iterator over (field_name, value) tuples
+        """
+        return ((f.name, getattr(self, f.name)) for f in fields(self))
+
+    def __iter__(self):
+        """Iterate over field names (like dict)."""
+        return (f.name for f in fields(self))
+
+    def __len__(self) -> int:
+        """Return number of fields."""
+        return len(fields(self))
 
     def asdict(self) -> dict:
         """Convert params to a dictionary."""

--- a/src/difflow_bio/units/bioreactors.py
+++ b/src/difflow_bio/units/bioreactors.py
@@ -257,6 +257,13 @@ class BioreactorParams:
         """
         return replace(self, **kwargs)
 
+    def __getitem__(self, key: str):
+        """Get parameter value by name for dict-like access."""
+        try:
+            return getattr(self, key)
+        except AttributeError:
+            raise KeyError(key)
+
 
 # =============================================================================
 # Continuous Bioreactor (Chemostat)
@@ -481,6 +488,13 @@ class FedBatchParams:
             New FedBatchParams with updated fields
         """
         return replace(self, **kwargs)
+
+    def __getitem__(self, key: str):
+        """Get parameter value by name for dict-like access."""
+        try:
+            return getattr(self, key)
+        except AttributeError:
+            raise KeyError(key)
 
 
 class FedBatchBioreactor:

--- a/src/difflow_bio/units/bioreactors.py
+++ b/src/difflow_bio/units/bioreactors.py
@@ -272,6 +272,30 @@ class BioreactorParams:
         """Return field names for dict-like iteration."""
         return (f.name for f in fields(self))
 
+    def values(self):
+        """Return field values for dict-like iteration.
+
+        Returns:
+            Iterator over field values
+        """
+        return (getattr(self, f.name) for f in fields(self))
+
+    def items(self):
+        """Return (name, value) pairs for dict-like iteration.
+
+        Returns:
+            Iterator over (field_name, value) tuples
+        """
+        return ((f.name, getattr(self, f.name)) for f in fields(self))
+
+    def __iter__(self):
+        """Iterate over field names (like dict)."""
+        return (f.name for f in fields(self))
+
+    def __len__(self) -> int:
+        """Return number of fields."""
+        return len(fields(self))
+
     def asdict(self) -> dict:
         """Convert params to a dictionary."""
         return dc_asdict(self)
@@ -535,6 +559,30 @@ class FedBatchParams:
     def keys(self):
         """Return field names for dict-like iteration."""
         return (f.name for f in fields(self))
+
+    def values(self):
+        """Return field values for dict-like iteration.
+
+        Returns:
+            Iterator over field values
+        """
+        return (getattr(self, f.name) for f in fields(self))
+
+    def items(self):
+        """Return (name, value) pairs for dict-like iteration.
+
+        Returns:
+            Iterator over (field_name, value) tuples
+        """
+        return ((f.name, getattr(self, f.name)) for f in fields(self))
+
+    def __iter__(self):
+        """Iterate over field names (like dict)."""
+        return (f.name for f in fields(self))
+
+    def __len__(self) -> int:
+        """Return number of fields."""
+        return len(fields(self))
 
     def asdict(self) -> dict:
         """Convert params to a dictionary."""

--- a/src/difflow_bio/units/bioreactors.py
+++ b/src/difflow_bio/units/bioreactors.py
@@ -25,7 +25,7 @@ Numerical Considerations:
 """
 
 from typing import Callable, Literal
-from dataclasses import dataclass, field, replace
+from dataclasses import dataclass, field, replace, fields, asdict as dc_asdict
 import inspect
 import jax
 import jax.numpy as jnp
@@ -264,6 +264,18 @@ class BioreactorParams:
         except AttributeError:
             raise KeyError(key)
 
+    def __contains__(self, key: str) -> bool:
+        """Check if a field exists in the params."""
+        return key in {f.name for f in fields(self)}
+
+    def keys(self):
+        """Return field names for dict-like iteration."""
+        return (f.name for f in fields(self))
+
+    def asdict(self) -> dict:
+        """Convert params to a dictionary."""
+        return dc_asdict(self)
+
 
 # =============================================================================
 # Continuous Bioreactor (Chemostat)
@@ -495,6 +507,18 @@ class FedBatchParams:
             return getattr(self, key)
         except AttributeError:
             raise KeyError(key)
+
+    def __contains__(self, key: str) -> bool:
+        """Check if a field exists in the params."""
+        return key in {f.name for f in fields(self)}
+
+    def keys(self):
+        """Return field names for dict-like iteration."""
+        return (f.name for f in fields(self))
+
+    def asdict(self) -> dict:
+        """Convert params to a dictionary."""
+        return dc_asdict(self)
 
 
 class FedBatchBioreactor:

--- a/src/difflow_bio/units/bioreactors.py
+++ b/src/difflow_bio/units/bioreactors.py
@@ -276,6 +276,26 @@ class BioreactorParams:
         """Convert params to a dictionary."""
         return dc_asdict(self)
 
+    def __repr__(self) -> str:
+        """Concise string representation."""
+        def fmt(v):
+            if v is None:
+                return "None"
+            if callable(v) and hasattr(v, '__name__'):
+                return v.__name__
+            if hasattr(v, 'shape'):
+                if v.ndim == 0:
+                    return f"{float(v):.4g}"
+                return f"Array{list(v.shape)}"
+            if isinstance(v, dict):
+                items = ", ".join(f"{k}: {fmt(val)}" for k, val in v.items())
+                return "{" + items + "}"
+            if isinstance(v, (list, tuple)) and len(v) > 5:
+                return f"{type(v).__name__}[{len(v)}]"
+            return repr(v)
+        items = ", ".join(f"{f.name}={fmt(getattr(self, f.name))}" for f in fields(self))
+        return f"{self.__class__.__name__}({items})"
+
 
 # =============================================================================
 # Continuous Bioreactor (Chemostat)
@@ -519,6 +539,26 @@ class FedBatchParams:
     def asdict(self) -> dict:
         """Convert params to a dictionary."""
         return dc_asdict(self)
+
+    def __repr__(self) -> str:
+        """Concise string representation."""
+        def fmt(v):
+            if v is None:
+                return "None"
+            if callable(v) and hasattr(v, '__name__'):
+                return v.__name__
+            if hasattr(v, 'shape'):
+                if v.ndim == 0:
+                    return f"{float(v):.4g}"
+                return f"Array{list(v.shape)}"
+            if isinstance(v, dict):
+                items = ", ".join(f"{k}: {fmt(val)}" for k, val in v.items())
+                return "{" + items + "}"
+            if isinstance(v, (list, tuple)) and len(v) > 5:
+                return f"{type(v).__name__}[{len(v)}]"
+            return repr(v)
+        items = ", ".join(f"{f.name}={fmt(getattr(self, f.name))}" for f in fields(self))
+        return f"{self.__class__.__name__}({items})"
 
 
 class FedBatchBioreactor:

--- a/src/difflow_bio/units/bioreactors.py
+++ b/src/difflow_bio/units/bioreactors.py
@@ -25,7 +25,7 @@ Numerical Considerations:
 """
 
 from typing import Callable, Literal
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 import inspect
 import jax
 import jax.numpy as jnp
@@ -244,6 +244,19 @@ class BioreactorParams:
         if self._kinetic_arity < 0:
             object.__setattr__(self, '_kinetic_arity', get_kinetic_arity(self.kinetic_fn))
 
+    def update(self, **kwargs) -> "BioreactorParams":
+        """Return a new BioreactorParams with specified fields replaced.
+
+        This enables JAX-compatible parameter updates for differentiation.
+
+        Args:
+            **kwargs: Fields to update (e.g., V=10.0, Y_xs=0.5)
+
+        Returns:
+            New BioreactorParams with updated fields
+        """
+        return replace(self, **kwargs)
+
 
 # =============================================================================
 # Continuous Bioreactor (Chemostat)
@@ -455,6 +468,19 @@ class FedBatchParams:
         """Auto-detect kinetic function arity."""
         if self._kinetic_arity < 0:
             object.__setattr__(self, '_kinetic_arity', get_kinetic_arity(self.kinetic_fn))
+
+    def update(self, **kwargs) -> "FedBatchParams":
+        """Return a new FedBatchParams with specified fields replaced.
+
+        This enables JAX-compatible parameter updates for differentiation.
+
+        Args:
+            **kwargs: Fields to update (e.g., V0=5.0, Y_xs=0.4)
+
+        Returns:
+            New FedBatchParams with updated fields
+        """
+        return replace(self, **kwargs)
 
 
 class FedBatchBioreactor:

--- a/src/difflow_bio/units/centrifuge.py
+++ b/src/difflow_bio/units/centrifuge.py
@@ -17,7 +17,7 @@ where:
     μ = fluid viscosity (Pa·s)
 """
 
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, replace, fields, asdict as dc_asdict
 import jax.numpy as jnp
 from jax import Array
 
@@ -72,6 +72,18 @@ class CentrifugeParams:
         except AttributeError:
             raise KeyError(key)
 
+    def __contains__(self, key: str) -> bool:
+        """Check if a field exists in the params."""
+        return key in {f.name for f in fields(self)}
+
+    def keys(self):
+        """Return field names for dict-like iteration."""
+        return (f.name for f in fields(self))
+
+    def asdict(self) -> dict:
+        """Convert params to a dictionary."""
+        return dc_asdict(self)
+
 
 @dataclass
 class DiscStackParams:
@@ -117,6 +129,18 @@ class DiscStackParams:
             return getattr(self, key)
         except AttributeError:
             raise KeyError(key)
+
+    def __contains__(self, key: str) -> bool:
+        """Check if a field exists in the params."""
+        return key in {f.name for f in fields(self)}
+
+    def keys(self):
+        """Return field names for dict-like iteration."""
+        return (f.name for f in fields(self))
+
+    def asdict(self) -> dict:
+        """Convert params to a dictionary."""
+        return dc_asdict(self)
 
 
 # =============================================================================

--- a/src/difflow_bio/units/centrifuge.py
+++ b/src/difflow_bio/units/centrifuge.py
@@ -84,6 +84,26 @@ class CentrifugeParams:
         """Convert params to a dictionary."""
         return dc_asdict(self)
 
+    def __repr__(self) -> str:
+        """Concise string representation."""
+        def fmt(v):
+            if v is None:
+                return "None"
+            if callable(v) and hasattr(v, '__name__'):
+                return v.__name__
+            if hasattr(v, 'shape'):
+                if v.ndim == 0:
+                    return f"{float(v):.4g}"
+                return f"Array{list(v.shape)}"
+            if isinstance(v, dict):
+                items = ", ".join(f"{k}: {fmt(val)}" for k, val in v.items())
+                return "{" + items + "}"
+            if isinstance(v, (list, tuple)) and len(v) > 5:
+                return f"{type(v).__name__}[{len(v)}]"
+            return repr(v)
+        items = ", ".join(f"{f.name}={fmt(getattr(self, f.name))}" for f in fields(self))
+        return f"{self.__class__.__name__}({items})"
+
 
 @dataclass
 class DiscStackParams:
@@ -141,6 +161,26 @@ class DiscStackParams:
     def asdict(self) -> dict:
         """Convert params to a dictionary."""
         return dc_asdict(self)
+
+    def __repr__(self) -> str:
+        """Concise string representation."""
+        def fmt(v):
+            if v is None:
+                return "None"
+            if callable(v) and hasattr(v, '__name__'):
+                return v.__name__
+            if hasattr(v, 'shape'):
+                if v.ndim == 0:
+                    return f"{float(v):.4g}"
+                return f"Array{list(v.shape)}"
+            if isinstance(v, dict):
+                items = ", ".join(f"{k}: {fmt(val)}" for k, val in v.items())
+                return "{" + items + "}"
+            if isinstance(v, (list, tuple)) and len(v) > 5:
+                return f"{type(v).__name__}[{len(v)}]"
+            return repr(v)
+        items = ", ".join(f"{f.name}={fmt(getattr(self, f.name))}" for f in fields(self))
+        return f"{self.__class__.__name__}({items})"
 
 
 # =============================================================================

--- a/src/difflow_bio/units/centrifuge.py
+++ b/src/difflow_bio/units/centrifuge.py
@@ -80,6 +80,30 @@ class CentrifugeParams:
         """Return field names for dict-like iteration."""
         return (f.name for f in fields(self))
 
+    def values(self):
+        """Return field values for dict-like iteration.
+
+        Returns:
+            Iterator over field values
+        """
+        return (getattr(self, f.name) for f in fields(self))
+
+    def items(self):
+        """Return (name, value) pairs for dict-like iteration.
+
+        Returns:
+            Iterator over (field_name, value) tuples
+        """
+        return ((f.name, getattr(self, f.name)) for f in fields(self))
+
+    def __iter__(self):
+        """Iterate over field names (like dict)."""
+        return (f.name for f in fields(self))
+
+    def __len__(self) -> int:
+        """Return number of fields."""
+        return len(fields(self))
+
     def asdict(self) -> dict:
         """Convert params to a dictionary."""
         return dc_asdict(self)
@@ -157,6 +181,30 @@ class DiscStackParams:
     def keys(self):
         """Return field names for dict-like iteration."""
         return (f.name for f in fields(self))
+
+    def values(self):
+        """Return field values for dict-like iteration.
+
+        Returns:
+            Iterator over field values
+        """
+        return (getattr(self, f.name) for f in fields(self))
+
+    def items(self):
+        """Return (name, value) pairs for dict-like iteration.
+
+        Returns:
+            Iterator over (field_name, value) tuples
+        """
+        return ((f.name, getattr(self, f.name)) for f in fields(self))
+
+    def __iter__(self):
+        """Iterate over field names (like dict)."""
+        return (f.name for f in fields(self))
+
+    def __len__(self) -> int:
+        """Return number of fields."""
+        return len(fields(self))
 
     def asdict(self) -> dict:
         """Convert params to a dictionary."""

--- a/src/difflow_bio/units/centrifuge.py
+++ b/src/difflow_bio/units/centrifuge.py
@@ -65,6 +65,13 @@ class CentrifugeParams:
         """
         return replace(self, **kwargs)
 
+    def __getitem__(self, key: str):
+        """Get parameter value by name for dict-like access."""
+        try:
+            return getattr(self, key)
+        except AttributeError:
+            raise KeyError(key)
+
 
 @dataclass
 class DiscStackParams:
@@ -103,6 +110,13 @@ class DiscStackParams:
             New DiscStackParams with updated fields
         """
         return replace(self, **kwargs)
+
+    def __getitem__(self, key: str):
+        """Get parameter value by name for dict-like access."""
+        try:
+            return getattr(self, key)
+        except AttributeError:
+            raise KeyError(key)
 
 
 # =============================================================================

--- a/src/difflow_bio/units/centrifuge.py
+++ b/src/difflow_bio/units/centrifuge.py
@@ -17,7 +17,7 @@ where:
     μ = fluid viscosity (Pa·s)
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 import jax.numpy as jnp
 from jax import Array
 
@@ -52,6 +52,19 @@ class CentrifugeParams:
     species_order: list[str] = None
     cell_species: str = "cells"
 
+    def update(self, **kwargs) -> "CentrifugeParams":
+        """Return a new CentrifugeParams with specified fields replaced.
+
+        This enables JAX-compatible parameter updates for differentiation.
+
+        Args:
+            **kwargs: Fields to update (e.g., sigma=1000.0)
+
+        Returns:
+            New CentrifugeParams with updated fields
+        """
+        return replace(self, **kwargs)
+
 
 @dataclass
 class DiscStackParams:
@@ -77,6 +90,19 @@ class DiscStackParams:
     efficiency: float | Array = 0.7
     species_order: list[str] = None
     cell_species: str = "cells"
+
+    def update(self, **kwargs) -> "DiscStackParams":
+        """Return a new DiscStackParams with specified fields replaced.
+
+        This enables JAX-compatible parameter updates for differentiation.
+
+        Args:
+            **kwargs: Fields to update (e.g., n_discs=100, rpm=8000.0)
+
+        Returns:
+            New DiscStackParams with updated fields
+        """
+        return replace(self, **kwargs)
 
 
 # =============================================================================

--- a/src/difflow_bio/units/chromatography.py
+++ b/src/difflow_bio/units/chromatography.py
@@ -18,7 +18,7 @@ where:
 """
 
 from typing import Literal
-from dataclasses import dataclass, field, replace
+from dataclasses import dataclass, field, replace, fields, asdict as dc_asdict
 import jax.numpy as jnp
 from jax import Array
 
@@ -141,6 +141,18 @@ class ProteinAParams:
         except AttributeError:
             raise KeyError(key)
 
+    def __contains__(self, key: str) -> bool:
+        """Check if a field exists in the params."""
+        return key in {f.name for f in fields(self)}
+
+    def keys(self):
+        """Return field names for dict-like iteration."""
+        return (f.name for f in fields(self))
+
+    def asdict(self) -> dict:
+        """Convert params to a dictionary."""
+        return dc_asdict(self)
+
 
 @dataclass
 class IEXParams:
@@ -185,6 +197,18 @@ class IEXParams:
         except AttributeError:
             raise KeyError(key)
 
+    def __contains__(self, key: str) -> bool:
+        """Check if a field exists in the params."""
+        return key in {f.name for f in fields(self)}
+
+    def keys(self):
+        """Return field names for dict-like iteration."""
+        return (f.name for f in fields(self))
+
+    def asdict(self) -> dict:
+        """Convert params to a dictionary."""
+        return dc_asdict(self)
+
 
 @dataclass
 class SECParams:
@@ -227,6 +251,18 @@ class SECParams:
             return getattr(self, key)
         except AttributeError:
             raise KeyError(key)
+
+    def __contains__(self, key: str) -> bool:
+        """Check if a field exists in the params."""
+        return key in {f.name for f in fields(self)}
+
+    def keys(self):
+        """Return field names for dict-like iteration."""
+        return (f.name for f in fields(self))
+
+    def asdict(self) -> dict:
+        """Convert params to a dictionary."""
+        return dc_asdict(self)
 
 
 # =============================================================================

--- a/src/difflow_bio/units/chromatography.py
+++ b/src/difflow_bio/units/chromatography.py
@@ -149,6 +149,30 @@ class ProteinAParams:
         """Return field names for dict-like iteration."""
         return (f.name for f in fields(self))
 
+    def values(self):
+        """Return field values for dict-like iteration.
+
+        Returns:
+            Iterator over field values
+        """
+        return (getattr(self, f.name) for f in fields(self))
+
+    def items(self):
+        """Return (name, value) pairs for dict-like iteration.
+
+        Returns:
+            Iterator over (field_name, value) tuples
+        """
+        return ((f.name, getattr(self, f.name)) for f in fields(self))
+
+    def __iter__(self):
+        """Iterate over field names (like dict)."""
+        return (f.name for f in fields(self))
+
+    def __len__(self) -> int:
+        """Return number of fields."""
+        return len(fields(self))
+
     def asdict(self) -> dict:
         """Convert params to a dictionary."""
         return dc_asdict(self)
@@ -225,6 +249,30 @@ class IEXParams:
         """Return field names for dict-like iteration."""
         return (f.name for f in fields(self))
 
+    def values(self):
+        """Return field values for dict-like iteration.
+
+        Returns:
+            Iterator over field values
+        """
+        return (getattr(self, f.name) for f in fields(self))
+
+    def items(self):
+        """Return (name, value) pairs for dict-like iteration.
+
+        Returns:
+            Iterator over (field_name, value) tuples
+        """
+        return ((f.name, getattr(self, f.name)) for f in fields(self))
+
+    def __iter__(self):
+        """Iterate over field names (like dict)."""
+        return (f.name for f in fields(self))
+
+    def __len__(self) -> int:
+        """Return number of fields."""
+        return len(fields(self))
+
     def asdict(self) -> dict:
         """Convert params to a dictionary."""
         return dc_asdict(self)
@@ -299,6 +347,30 @@ class SECParams:
     def keys(self):
         """Return field names for dict-like iteration."""
         return (f.name for f in fields(self))
+
+    def values(self):
+        """Return field values for dict-like iteration.
+
+        Returns:
+            Iterator over field values
+        """
+        return (getattr(self, f.name) for f in fields(self))
+
+    def items(self):
+        """Return (name, value) pairs for dict-like iteration.
+
+        Returns:
+            Iterator over (field_name, value) tuples
+        """
+        return ((f.name, getattr(self, f.name)) for f in fields(self))
+
+    def __iter__(self):
+        """Iterate over field names (like dict)."""
+        return (f.name for f in fields(self))
+
+    def __len__(self) -> int:
+        """Return number of fields."""
+        return len(fields(self))
 
     def asdict(self) -> dict:
         """Convert params to a dictionary."""

--- a/src/difflow_bio/units/chromatography.py
+++ b/src/difflow_bio/units/chromatography.py
@@ -18,7 +18,7 @@ where:
 """
 
 from typing import Literal
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 import jax.numpy as jnp
 from jax import Array
 
@@ -121,6 +121,19 @@ class ProteinAParams:
     })
     species_order: list[str] = None
 
+    def update(self, **kwargs) -> "ProteinAParams":
+        """Return a new ProteinAParams with specified fields replaced.
+
+        This enables JAX-compatible parameter updates for differentiation.
+
+        Args:
+            **kwargs: Fields to update (e.g., column_volume=5.0, q_max=40.0)
+
+        Returns:
+            New ProteinAParams with updated fields
+        """
+        return replace(self, **kwargs)
+
 
 @dataclass
 class IEXParams:
@@ -145,6 +158,19 @@ class IEXParams:
     yield_factor: float | Array = 0.90
     species_order: list[str] = None
 
+    def update(self, **kwargs) -> "IEXParams":
+        """Return a new IEXParams with specified fields replaced.
+
+        This enables JAX-compatible parameter updates for differentiation.
+
+        Args:
+            **kwargs: Fields to update (e.g., column_volume=10.0, q_max=60.0)
+
+        Returns:
+            New IEXParams with updated fields
+        """
+        return replace(self, **kwargs)
+
 
 @dataclass
 class SECParams:
@@ -167,6 +193,19 @@ class SECParams:
     yield_factor: float | Array = 0.95
     resolution: float | Array = 1.5  # Baseline resolution
     species_order: list[str] = None
+
+    def update(self, **kwargs) -> "SECParams":
+        """Return a new SECParams with specified fields replaced.
+
+        This enables JAX-compatible parameter updates for differentiation.
+
+        Args:
+            **kwargs: Fields to update (e.g., column_volume=2.0)
+
+        Returns:
+            New SECParams with updated fields
+        """
+        return replace(self, **kwargs)
 
 
 # =============================================================================

--- a/src/difflow_bio/units/chromatography.py
+++ b/src/difflow_bio/units/chromatography.py
@@ -134,6 +134,13 @@ class ProteinAParams:
         """
         return replace(self, **kwargs)
 
+    def __getitem__(self, key: str):
+        """Get parameter value by name for dict-like access."""
+        try:
+            return getattr(self, key)
+        except AttributeError:
+            raise KeyError(key)
+
 
 @dataclass
 class IEXParams:
@@ -171,6 +178,13 @@ class IEXParams:
         """
         return replace(self, **kwargs)
 
+    def __getitem__(self, key: str):
+        """Get parameter value by name for dict-like access."""
+        try:
+            return getattr(self, key)
+        except AttributeError:
+            raise KeyError(key)
+
 
 @dataclass
 class SECParams:
@@ -206,6 +220,13 @@ class SECParams:
             New SECParams with updated fields
         """
         return replace(self, **kwargs)
+
+    def __getitem__(self, key: str):
+        """Get parameter value by name for dict-like access."""
+        try:
+            return getattr(self, key)
+        except AttributeError:
+            raise KeyError(key)
 
 
 # =============================================================================

--- a/src/difflow_bio/units/chromatography.py
+++ b/src/difflow_bio/units/chromatography.py
@@ -153,6 +153,26 @@ class ProteinAParams:
         """Convert params to a dictionary."""
         return dc_asdict(self)
 
+    def __repr__(self) -> str:
+        """Concise string representation."""
+        def fmt(v):
+            if v is None:
+                return "None"
+            if callable(v) and hasattr(v, '__name__'):
+                return v.__name__
+            if hasattr(v, 'shape'):
+                if v.ndim == 0:
+                    return f"{float(v):.4g}"
+                return f"Array{list(v.shape)}"
+            if isinstance(v, dict):
+                items = ", ".join(f"{k}: {fmt(val)}" for k, val in v.items())
+                return "{" + items + "}"
+            if isinstance(v, (list, tuple)) and len(v) > 5:
+                return f"{type(v).__name__}[{len(v)}]"
+            return repr(v)
+        items = ", ".join(f"{f.name}={fmt(getattr(self, f.name))}" for f in fields(self))
+        return f"{self.__class__.__name__}({items})"
+
 
 @dataclass
 class IEXParams:
@@ -209,6 +229,26 @@ class IEXParams:
         """Convert params to a dictionary."""
         return dc_asdict(self)
 
+    def __repr__(self) -> str:
+        """Concise string representation."""
+        def fmt(v):
+            if v is None:
+                return "None"
+            if callable(v) and hasattr(v, '__name__'):
+                return v.__name__
+            if hasattr(v, 'shape'):
+                if v.ndim == 0:
+                    return f"{float(v):.4g}"
+                return f"Array{list(v.shape)}"
+            if isinstance(v, dict):
+                items = ", ".join(f"{k}: {fmt(val)}" for k, val in v.items())
+                return "{" + items + "}"
+            if isinstance(v, (list, tuple)) and len(v) > 5:
+                return f"{type(v).__name__}[{len(v)}]"
+            return repr(v)
+        items = ", ".join(f"{f.name}={fmt(getattr(self, f.name))}" for f in fields(self))
+        return f"{self.__class__.__name__}({items})"
+
 
 @dataclass
 class SECParams:
@@ -263,6 +303,26 @@ class SECParams:
     def asdict(self) -> dict:
         """Convert params to a dictionary."""
         return dc_asdict(self)
+
+    def __repr__(self) -> str:
+        """Concise string representation."""
+        def fmt(v):
+            if v is None:
+                return "None"
+            if callable(v) and hasattr(v, '__name__'):
+                return v.__name__
+            if hasattr(v, 'shape'):
+                if v.ndim == 0:
+                    return f"{float(v):.4g}"
+                return f"Array{list(v.shape)}"
+            if isinstance(v, dict):
+                items = ", ".join(f"{k}: {fmt(val)}" for k, val in v.items())
+                return "{" + items + "}"
+            if isinstance(v, (list, tuple)) and len(v) > 5:
+                return f"{type(v).__name__}[{len(v)}]"
+            return repr(v)
+        items = ", ".join(f"{f.name}={fmt(getattr(self, f.name))}" for f in fields(self))
+        return f"{self.__class__.__name__}({items})"
 
 
 # =============================================================================

--- a/src/difflow_bio/units/filtration.py
+++ b/src/difflow_bio/units/filtration.py
@@ -59,6 +59,13 @@ class UltrafiltrationParams:
         """
         return replace(self, **kwargs)
 
+    def __getitem__(self, key: str):
+        """Get parameter value by name for dict-like access."""
+        try:
+            return getattr(self, key)
+        except AttributeError:
+            raise KeyError(key)
+
 
 @dataclass
 class DiafiltrationParams:
@@ -89,6 +96,13 @@ class DiafiltrationParams:
             New DiafiltrationParams with updated fields
         """
         return replace(self, **kwargs)
+
+    def __getitem__(self, key: str):
+        """Get parameter value by name for dict-like access."""
+        try:
+            return getattr(self, key)
+        except AttributeError:
+            raise KeyError(key)
 
 
 # =============================================================================

--- a/src/difflow_bio/units/filtration.py
+++ b/src/difflow_bio/units/filtration.py
@@ -78,6 +78,26 @@ class UltrafiltrationParams:
         """Convert params to a dictionary."""
         return dc_asdict(self)
 
+    def __repr__(self) -> str:
+        """Concise string representation."""
+        def fmt(v):
+            if v is None:
+                return "None"
+            if callable(v) and hasattr(v, '__name__'):
+                return v.__name__
+            if hasattr(v, 'shape'):
+                if v.ndim == 0:
+                    return f"{float(v):.4g}"
+                return f"Array{list(v.shape)}"
+            if isinstance(v, dict):
+                items = ", ".join(f"{k}: {fmt(val)}" for k, val in v.items())
+                return "{" + items + "}"
+            if isinstance(v, (list, tuple)) and len(v) > 5:
+                return f"{type(v).__name__}[{len(v)}]"
+            return repr(v)
+        items = ", ".join(f"{f.name}={fmt(getattr(self, f.name))}" for f in fields(self))
+        return f"{self.__class__.__name__}({items})"
+
 
 @dataclass
 class DiafiltrationParams:
@@ -127,6 +147,26 @@ class DiafiltrationParams:
     def asdict(self) -> dict:
         """Convert params to a dictionary."""
         return dc_asdict(self)
+
+    def __repr__(self) -> str:
+        """Concise string representation."""
+        def fmt(v):
+            if v is None:
+                return "None"
+            if callable(v) and hasattr(v, '__name__'):
+                return v.__name__
+            if hasattr(v, 'shape'):
+                if v.ndim == 0:
+                    return f"{float(v):.4g}"
+                return f"Array{list(v.shape)}"
+            if isinstance(v, dict):
+                items = ", ".join(f"{k}: {fmt(val)}" for k, val in v.items())
+                return "{" + items + "}"
+            if isinstance(v, (list, tuple)) and len(v) > 5:
+                return f"{type(v).__name__}[{len(v)}]"
+            return repr(v)
+        items = ", ".join(f"{f.name}={fmt(getattr(self, f.name))}" for f in fields(self))
+        return f"{self.__class__.__name__}({items})"
 
 
 # =============================================================================

--- a/src/difflow_bio/units/filtration.py
+++ b/src/difflow_bio/units/filtration.py
@@ -17,7 +17,7 @@ where:
     N_dv = number of diavolumes
 """
 
-from dataclasses import dataclass, field, replace
+from dataclasses import dataclass, field, replace, fields, asdict as dc_asdict
 import jax.numpy as jnp
 from jax import Array, lax
 
@@ -66,6 +66,18 @@ class UltrafiltrationParams:
         except AttributeError:
             raise KeyError(key)
 
+    def __contains__(self, key: str) -> bool:
+        """Check if a field exists in the params."""
+        return key in {f.name for f in fields(self)}
+
+    def keys(self):
+        """Return field names for dict-like iteration."""
+        return (f.name for f in fields(self))
+
+    def asdict(self) -> dict:
+        """Convert params to a dictionary."""
+        return dc_asdict(self)
+
 
 @dataclass
 class DiafiltrationParams:
@@ -103,6 +115,18 @@ class DiafiltrationParams:
             return getattr(self, key)
         except AttributeError:
             raise KeyError(key)
+
+    def __contains__(self, key: str) -> bool:
+        """Check if a field exists in the params."""
+        return key in {f.name for f in fields(self)}
+
+    def keys(self):
+        """Return field names for dict-like iteration."""
+        return (f.name for f in fields(self))
+
+    def asdict(self) -> dict:
+        """Convert params to a dictionary."""
+        return dc_asdict(self)
 
 
 # =============================================================================

--- a/src/difflow_bio/units/filtration.py
+++ b/src/difflow_bio/units/filtration.py
@@ -74,6 +74,30 @@ class UltrafiltrationParams:
         """Return field names for dict-like iteration."""
         return (f.name for f in fields(self))
 
+    def values(self):
+        """Return field values for dict-like iteration.
+
+        Returns:
+            Iterator over field values
+        """
+        return (getattr(self, f.name) for f in fields(self))
+
+    def items(self):
+        """Return (name, value) pairs for dict-like iteration.
+
+        Returns:
+            Iterator over (field_name, value) tuples
+        """
+        return ((f.name, getattr(self, f.name)) for f in fields(self))
+
+    def __iter__(self):
+        """Iterate over field names (like dict)."""
+        return (f.name for f in fields(self))
+
+    def __len__(self) -> int:
+        """Return number of fields."""
+        return len(fields(self))
+
     def asdict(self) -> dict:
         """Convert params to a dictionary."""
         return dc_asdict(self)
@@ -143,6 +167,30 @@ class DiafiltrationParams:
     def keys(self):
         """Return field names for dict-like iteration."""
         return (f.name for f in fields(self))
+
+    def values(self):
+        """Return field values for dict-like iteration.
+
+        Returns:
+            Iterator over field values
+        """
+        return (getattr(self, f.name) for f in fields(self))
+
+    def items(self):
+        """Return (name, value) pairs for dict-like iteration.
+
+        Returns:
+            Iterator over (field_name, value) tuples
+        """
+        return ((f.name, getattr(self, f.name)) for f in fields(self))
+
+    def __iter__(self):
+        """Iterate over field names (like dict)."""
+        return (f.name for f in fields(self))
+
+    def __len__(self) -> int:
+        """Return number of fields."""
+        return len(fields(self))
 
     def asdict(self) -> dict:
         """Convert params to a dictionary."""

--- a/src/difflow_bio/units/filtration.py
+++ b/src/difflow_bio/units/filtration.py
@@ -17,7 +17,7 @@ where:
     N_dv = number of diavolumes
 """
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 import jax.numpy as jnp
 from jax import Array, lax
 
@@ -46,6 +46,19 @@ class UltrafiltrationParams:
     Lp: float | Array = 50.0  # L/m²/h/bar, typical for UF membrane
     species_order: list[str] = None
 
+    def update(self, **kwargs) -> "UltrafiltrationParams":
+        """Return a new UltrafiltrationParams with specified fields replaced.
+
+        This enables JAX-compatible parameter updates for differentiation.
+
+        Args:
+            **kwargs: Fields to update (e.g., membrane_area=10.0)
+
+        Returns:
+            New UltrafiltrationParams with updated fields
+        """
+        return replace(self, **kwargs)
+
 
 @dataclass
 class DiafiltrationParams:
@@ -63,6 +76,19 @@ class DiafiltrationParams:
     rejection: dict = field(default_factory=dict)
     Lp: float | Array = 50.0
     species_order: list[str] = None
+
+    def update(self, **kwargs) -> "DiafiltrationParams":
+        """Return a new DiafiltrationParams with specified fields replaced.
+
+        This enables JAX-compatible parameter updates for differentiation.
+
+        Args:
+            **kwargs: Fields to update (e.g., membrane_area=10.0)
+
+        Returns:
+            New DiafiltrationParams with updated fields
+        """
+        return replace(self, **kwargs)
 
 
 # =============================================================================

--- a/src/difflow_ree/flowsheets/extract_scrub_strip.py
+++ b/src/difflow_ree/flowsheets/extract_scrub_strip.py
@@ -95,6 +95,30 @@ class ExtractScrubStripParams:
         """Return field names for dict-like iteration."""
         return (f.name for f in fields(self))
 
+    def values(self):
+        """Return field values for dict-like iteration.
+
+        Returns:
+            Iterator over field values
+        """
+        return (getattr(self, f.name) for f in fields(self))
+
+    def items(self):
+        """Return (name, value) pairs for dict-like iteration.
+
+        Returns:
+            Iterator over (field_name, value) tuples
+        """
+        return ((f.name, getattr(self, f.name)) for f in fields(self))
+
+    def __iter__(self):
+        """Iterate over field names (like dict)."""
+        return (f.name for f in fields(self))
+
+    def __len__(self) -> int:
+        """Return number of fields."""
+        return len(fields(self))
+
     def asdict(self) -> dict:
         """Convert params to a dictionary."""
         return dc_asdict(self)

--- a/src/difflow_ree/flowsheets/extract_scrub_strip.py
+++ b/src/difflow_ree/flowsheets/extract_scrub_strip.py
@@ -99,6 +99,26 @@ class ExtractScrubStripParams:
         """Convert params to a dictionary."""
         return dc_asdict(self)
 
+    def __repr__(self) -> str:
+        """Concise string representation."""
+        def fmt(v):
+            if v is None:
+                return "None"
+            if callable(v) and hasattr(v, '__name__'):
+                return v.__name__
+            if hasattr(v, 'shape'):
+                if v.ndim == 0:
+                    return f"{float(v):.4g}"
+                return f"Array{list(v.shape)}"
+            if isinstance(v, dict):
+                items = ", ".join(f"{k}: {fmt(val)}" for k, val in v.items())
+                return "{" + items + "}"
+            if isinstance(v, (list, tuple)) and len(v) > 5:
+                return f"{type(v).__name__}[{len(v)}]"
+            return repr(v)
+        items = ", ".join(f"{f.name}={fmt(getattr(self, f.name))}" for f in fields(self))
+        return f"{self.__class__.__name__}({items})"
+
 
 class ExtractScrubStripCircuit:
     """Industrial 3-section REE separation circuit.

--- a/src/difflow_ree/flowsheets/extract_scrub_strip.py
+++ b/src/difflow_ree/flowsheets/extract_scrub_strip.py
@@ -22,7 +22,7 @@ recycled back to the feed or processed in a separate circuit.
 All operations are fully differentiable using JAX.
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Literal
 
 import jax.numpy as jnp
@@ -66,6 +66,19 @@ class ExtractScrubStripParams:
     solvent_to_feed_ratio: float = 1.0
     scrub_to_solvent_ratio: float = 0.2
     strip_to_solvent_ratio: float = 0.5
+
+    def update(self, **kwargs) -> "ExtractScrubStripParams":
+        """Return a new ExtractScrubStripParams with specified fields replaced.
+
+        This enables JAX-compatible parameter updates for differentiation.
+
+        Args:
+            **kwargs: Fields to update (e.g., n_extraction_stages=12)
+
+        Returns:
+            New ExtractScrubStripParams with updated fields
+        """
+        return replace(self, **kwargs)
 
 
 class ExtractScrubStripCircuit:

--- a/src/difflow_ree/flowsheets/extract_scrub_strip.py
+++ b/src/difflow_ree/flowsheets/extract_scrub_strip.py
@@ -22,7 +22,7 @@ recycled back to the feed or processed in a separate circuit.
 All operations are fully differentiable using JAX.
 """
 
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, replace, fields, asdict as dc_asdict
 from typing import Literal
 
 import jax.numpy as jnp
@@ -86,6 +86,18 @@ class ExtractScrubStripParams:
             return getattr(self, key)
         except AttributeError:
             raise KeyError(key)
+
+    def __contains__(self, key: str) -> bool:
+        """Check if a field exists in the params."""
+        return key in {f.name for f in fields(self)}
+
+    def keys(self):
+        """Return field names for dict-like iteration."""
+        return (f.name for f in fields(self))
+
+    def asdict(self) -> dict:
+        """Convert params to a dictionary."""
+        return dc_asdict(self)
 
 
 class ExtractScrubStripCircuit:

--- a/src/difflow_ree/flowsheets/extract_scrub_strip.py
+++ b/src/difflow_ree/flowsheets/extract_scrub_strip.py
@@ -80,6 +80,13 @@ class ExtractScrubStripParams:
         """
         return replace(self, **kwargs)
 
+    def __getitem__(self, key: str):
+        """Get parameter value by name for dict-like access."""
+        try:
+            return getattr(self, key)
+        except AttributeError:
+            raise KeyError(key)
+
 
 class ExtractScrubStripCircuit:
     """Industrial 3-section REE separation circuit.

--- a/src/difflow_ree/flowsheets/extract_strip.py
+++ b/src/difflow_ree/flowsheets/extract_strip.py
@@ -17,7 +17,7 @@ Two-section flowsheet:
 All operations are fully differentiable using JAX.
 """
 
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, replace, fields, asdict as dc_asdict
 from typing import Literal
 
 import jax.numpy as jnp
@@ -72,6 +72,18 @@ class ExtractStripParams:
             return getattr(self, key)
         except AttributeError:
             raise KeyError(key)
+
+    def __contains__(self, key: str) -> bool:
+        """Check if a field exists in the params."""
+        return key in {f.name for f in fields(self)}
+
+    def keys(self):
+        """Return field names for dict-like iteration."""
+        return (f.name for f in fields(self))
+
+    def asdict(self) -> dict:
+        """Convert params to a dictionary."""
+        return dc_asdict(self)
 
 
 class ExtractStripCircuit:

--- a/src/difflow_ree/flowsheets/extract_strip.py
+++ b/src/difflow_ree/flowsheets/extract_strip.py
@@ -85,6 +85,26 @@ class ExtractStripParams:
         """Convert params to a dictionary."""
         return dc_asdict(self)
 
+    def __repr__(self) -> str:
+        """Concise string representation."""
+        def fmt(v):
+            if v is None:
+                return "None"
+            if callable(v) and hasattr(v, '__name__'):
+                return v.__name__
+            if hasattr(v, 'shape'):
+                if v.ndim == 0:
+                    return f"{float(v):.4g}"
+                return f"Array{list(v.shape)}"
+            if isinstance(v, dict):
+                items = ", ".join(f"{k}: {fmt(val)}" for k, val in v.items())
+                return "{" + items + "}"
+            if isinstance(v, (list, tuple)) and len(v) > 5:
+                return f"{type(v).__name__}[{len(v)}]"
+            return repr(v)
+        items = ", ".join(f"{f.name}={fmt(getattr(self, f.name))}" for f in fields(self))
+        return f"{self.__class__.__name__}({items})"
+
 
 class ExtractStripCircuit:
     """Basic extract-strip circuit.

--- a/src/difflow_ree/flowsheets/extract_strip.py
+++ b/src/difflow_ree/flowsheets/extract_strip.py
@@ -66,6 +66,13 @@ class ExtractStripParams:
         """
         return replace(self, **kwargs)
 
+    def __getitem__(self, key: str):
+        """Get parameter value by name for dict-like access."""
+        try:
+            return getattr(self, key)
+        except AttributeError:
+            raise KeyError(key)
+
 
 class ExtractStripCircuit:
     """Basic extract-strip circuit.

--- a/src/difflow_ree/flowsheets/extract_strip.py
+++ b/src/difflow_ree/flowsheets/extract_strip.py
@@ -17,7 +17,7 @@ Two-section flowsheet:
 All operations are fully differentiable using JAX.
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Literal
 
 import jax.numpy as jnp
@@ -52,6 +52,19 @@ class ExtractStripParams:
     extractant_conc: float = 0.5
     solvent_to_feed_ratio: float = 1.0
     strip_to_solvent_ratio: float = 0.5
+
+    def update(self, **kwargs) -> "ExtractStripParams":
+        """Return a new ExtractStripParams with specified fields replaced.
+
+        This enables JAX-compatible parameter updates for differentiation.
+
+        Args:
+            **kwargs: Fields to update (e.g., n_extraction_stages=12)
+
+        Returns:
+            New ExtractStripParams with updated fields
+        """
+        return replace(self, **kwargs)
 
 
 class ExtractStripCircuit:

--- a/src/difflow_ree/flowsheets/extract_strip.py
+++ b/src/difflow_ree/flowsheets/extract_strip.py
@@ -81,6 +81,30 @@ class ExtractStripParams:
         """Return field names for dict-like iteration."""
         return (f.name for f in fields(self))
 
+    def values(self):
+        """Return field values for dict-like iteration.
+
+        Returns:
+            Iterator over field values
+        """
+        return (getattr(self, f.name) for f in fields(self))
+
+    def items(self):
+        """Return (name, value) pairs for dict-like iteration.
+
+        Returns:
+            Iterator over (field_name, value) tuples
+        """
+        return ((f.name, getattr(self, f.name)) for f in fields(self))
+
+    def __iter__(self):
+        """Iterate over field names (like dict)."""
+        return (f.name for f in fields(self))
+
+    def __len__(self) -> int:
+        """Return number of fields."""
+        return len(fields(self))
+
     def asdict(self) -> dict:
         """Convert params to a dictionary."""
         return dc_asdict(self)

--- a/src/difflow_ree/flowsheets/full_train.py
+++ b/src/difflow_ree/flowsheets/full_train.py
@@ -89,6 +89,30 @@ class SeparationTrainParams:
         """Return field names for dict-like iteration."""
         return (f.name for f in fields(self))
 
+    def values(self):
+        """Return field values for dict-like iteration.
+
+        Returns:
+            Iterator over field values
+        """
+        return (getattr(self, f.name) for f in fields(self))
+
+    def items(self):
+        """Return (name, value) pairs for dict-like iteration.
+
+        Returns:
+            Iterator over (field_name, value) tuples
+        """
+        return ((f.name, getattr(self, f.name)) for f in fields(self))
+
+    def __iter__(self):
+        """Iterate over field names (like dict)."""
+        return (f.name for f in fields(self))
+
+    def __len__(self) -> int:
+        """Return number of fields."""
+        return len(fields(self))
+
     def asdict(self) -> dict:
         """Convert params to a dictionary."""
         return dc_asdict(self)

--- a/src/difflow_ree/flowsheets/full_train.py
+++ b/src/difflow_ree/flowsheets/full_train.py
@@ -93,6 +93,26 @@ class SeparationTrainParams:
         """Convert params to a dictionary."""
         return dc_asdict(self)
 
+    def __repr__(self) -> str:
+        """Concise string representation."""
+        def fmt(v):
+            if v is None:
+                return "None"
+            if callable(v) and hasattr(v, '__name__'):
+                return v.__name__
+            if hasattr(v, 'shape'):
+                if v.ndim == 0:
+                    return f"{float(v):.4g}"
+                return f"Array{list(v.shape)}"
+            if isinstance(v, dict):
+                items = ", ".join(f"{k}: {fmt(val)}" for k, val in v.items())
+                return "{" + items + "}"
+            if isinstance(v, (list, tuple)) and len(v) > 5:
+                return f"{type(v).__name__}[{len(v)}]"
+            return repr(v)
+        items = ", ".join(f"{f.name}={fmt(getattr(self, f.name))}" for f in fields(self))
+        return f"{self.__class__.__name__}({items})"
+
 
 class GroupSeparator:
     """Separates REE into light, middle, and heavy groups.

--- a/src/difflow_ree/flowsheets/full_train.py
+++ b/src/difflow_ree/flowsheets/full_train.py
@@ -22,7 +22,7 @@ Typical sequence:
     Individual separations...
 """
 
-from dataclasses import dataclass, field, replace
+from dataclasses import dataclass, field, replace, fields, asdict as dc_asdict
 from typing import Literal
 
 import jax.numpy as jnp
@@ -80,6 +80,18 @@ class SeparationTrainParams:
             return getattr(self, key)
         except AttributeError:
             raise KeyError(key)
+
+    def __contains__(self, key: str) -> bool:
+        """Check if a field exists in the params."""
+        return key in {f.name for f in fields(self)}
+
+    def keys(self):
+        """Return field names for dict-like iteration."""
+        return (f.name for f in fields(self))
+
+    def asdict(self) -> dict:
+        """Convert params to a dictionary."""
+        return dc_asdict(self)
 
 
 class GroupSeparator:

--- a/src/difflow_ree/flowsheets/full_train.py
+++ b/src/difflow_ree/flowsheets/full_train.py
@@ -74,6 +74,13 @@ class SeparationTrainParams:
         """
         return replace(self, **kwargs)
 
+    def __getitem__(self, key: str):
+        """Get parameter value by name for dict-like access."""
+        try:
+            return getattr(self, key)
+        except AttributeError:
+            raise KeyError(key)
+
 
 class GroupSeparator:
     """Separates REE into light, middle, and heavy groups.

--- a/src/difflow_ree/flowsheets/full_train.py
+++ b/src/difflow_ree/flowsheets/full_train.py
@@ -22,7 +22,7 @@ Typical sequence:
     Individual separations...
 """
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import Literal
 
 import jax.numpy as jnp
@@ -60,6 +60,19 @@ class SeparationTrainParams:
         "Dy": 0.99,
         "Y": 0.95,
     })
+
+    def update(self, **kwargs) -> "SeparationTrainParams":
+        """Return a new SeparationTrainParams with specified fields replaced.
+
+        This enables JAX-compatible parameter updates for differentiation.
+
+        Args:
+            **kwargs: Fields to update (e.g., include_ce_removal=False)
+
+        Returns:
+            New SeparationTrainParams with updated fields
+        """
+        return replace(self, **kwargs)
 
 
 class GroupSeparator:

--- a/src/difflow_ree/units/cerium.py
+++ b/src/difflow_ree/units/cerium.py
@@ -59,6 +59,13 @@ class CeriumOxidizerParams:
         """
         return replace(self, **kwargs)
 
+    def __getitem__(self, key: str):
+        """Get parameter value by name for dict-like access."""
+        try:
+            return getattr(self, key)
+        except AttributeError:
+            raise KeyError(key)
+
 
 class CeriumOxidizer:
     """Cerium oxidation and precipitation unit.

--- a/src/difflow_ree/units/cerium.py
+++ b/src/difflow_ree/units/cerium.py
@@ -14,7 +14,7 @@ This is industrially important because:
 All operations are fully differentiable using JAX.
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Literal
 
 import jax.numpy as jnp
@@ -45,6 +45,19 @@ class CeriumOxidizerParams:
     pH: float = 8.0  # Alkaline conditions favor Ce oxidation
     temperature: float = 353.15  # 80°C typical
     ce_conversion: float = 0.95
+
+    def update(self, **kwargs) -> "CeriumOxidizerParams":
+        """Return a new CeriumOxidizerParams with specified fields replaced.
+
+        This enables JAX-compatible parameter updates for differentiation.
+
+        Args:
+            **kwargs: Fields to update (e.g., pH=9.0, ce_conversion=0.98)
+
+        Returns:
+            New CeriumOxidizerParams with updated fields
+        """
+        return replace(self, **kwargs)
 
 
 class CeriumOxidizer:

--- a/src/difflow_ree/units/cerium.py
+++ b/src/difflow_ree/units/cerium.py
@@ -78,6 +78,26 @@ class CeriumOxidizerParams:
         """Convert params to a dictionary."""
         return dc_asdict(self)
 
+    def __repr__(self) -> str:
+        """Concise string representation."""
+        def fmt(v):
+            if v is None:
+                return "None"
+            if callable(v) and hasattr(v, '__name__'):
+                return v.__name__
+            if hasattr(v, 'shape'):
+                if v.ndim == 0:
+                    return f"{float(v):.4g}"
+                return f"Array{list(v.shape)}"
+            if isinstance(v, dict):
+                items = ", ".join(f"{k}: {fmt(val)}" for k, val in v.items())
+                return "{" + items + "}"
+            if isinstance(v, (list, tuple)) and len(v) > 5:
+                return f"{type(v).__name__}[{len(v)}]"
+            return repr(v)
+        items = ", ".join(f"{f.name}={fmt(getattr(self, f.name))}" for f in fields(self))
+        return f"{self.__class__.__name__}({items})"
+
 
 class CeriumOxidizer:
     """Cerium oxidation and precipitation unit.

--- a/src/difflow_ree/units/cerium.py
+++ b/src/difflow_ree/units/cerium.py
@@ -74,6 +74,30 @@ class CeriumOxidizerParams:
         """Return field names for dict-like iteration."""
         return (f.name for f in fields(self))
 
+    def values(self):
+        """Return field values for dict-like iteration.
+
+        Returns:
+            Iterator over field values
+        """
+        return (getattr(self, f.name) for f in fields(self))
+
+    def items(self):
+        """Return (name, value) pairs for dict-like iteration.
+
+        Returns:
+            Iterator over (field_name, value) tuples
+        """
+        return ((f.name, getattr(self, f.name)) for f in fields(self))
+
+    def __iter__(self):
+        """Iterate over field names (like dict)."""
+        return (f.name for f in fields(self))
+
+    def __len__(self) -> int:
+        """Return number of fields."""
+        return len(fields(self))
+
     def asdict(self) -> dict:
         """Convert params to a dictionary."""
         return dc_asdict(self)

--- a/src/difflow_ree/units/cerium.py
+++ b/src/difflow_ree/units/cerium.py
@@ -14,7 +14,7 @@ This is industrially important because:
 All operations are fully differentiable using JAX.
 """
 
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, replace, fields, asdict as dc_asdict
 from typing import Literal
 
 import jax.numpy as jnp
@@ -65,6 +65,18 @@ class CeriumOxidizerParams:
             return getattr(self, key)
         except AttributeError:
             raise KeyError(key)
+
+    def __contains__(self, key: str) -> bool:
+        """Check if a field exists in the params."""
+        return key in {f.name for f in fields(self)}
+
+    def keys(self):
+        """Return field names for dict-like iteration."""
+        return (f.name for f in fields(self))
+
+    def asdict(self) -> dict:
+        """Convert params to a dictionary."""
+        return dc_asdict(self)
 
 
 class CeriumOxidizer:

--- a/src/difflow_ree/units/extraction.py
+++ b/src/difflow_ree/units/extraction.py
@@ -5,7 +5,7 @@ Multi-stage counter-current extraction cascades for REE separation.
 All operations are fully differentiable using JAX.
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Literal
 
 import jax.numpy as jnp
@@ -45,6 +45,19 @@ class REEExtractorParams:
     include_speciation: bool = False
     speciation_medium: str = "sulfate"
     ligand_conc: float = 0.5
+
+    def update(self, **kwargs) -> "REEExtractorParams":
+        """Return a new REEExtractorParams with specified fields replaced.
+
+        This enables JAX-compatible parameter updates for differentiation.
+
+        Args:
+            **kwargs: Fields to update (e.g., n_stages=15, pH=3.5)
+
+        Returns:
+            New REEExtractorParams with updated fields
+        """
+        return replace(self, **kwargs)
 
 
 class REEExtractor:
@@ -217,6 +230,19 @@ class MixerSettlerParams:
     mixer_residence_time: float = 120.0  # 2 minutes typical
     settler_residence_time: float = 300.0  # 5 minutes typical
     stage_efficiency: float = 0.95
+
+    def update(self, **kwargs) -> "MixerSettlerParams":
+        """Return a new MixerSettlerParams with specified fields replaced.
+
+        This enables JAX-compatible parameter updates for differentiation.
+
+        Args:
+            **kwargs: Fields to update (e.g., pH=3.5, stage_efficiency=0.9)
+
+        Returns:
+            New MixerSettlerParams with updated fields
+        """
+        return replace(self, **kwargs)
 
 
 class REEMixerSettler:

--- a/src/difflow_ree/units/extraction.py
+++ b/src/difflow_ree/units/extraction.py
@@ -74,6 +74,30 @@ class REEExtractorParams:
         """Return field names for dict-like iteration."""
         return (f.name for f in fields(self))
 
+    def values(self):
+        """Return field values for dict-like iteration.
+
+        Returns:
+            Iterator over field values
+        """
+        return (getattr(self, f.name) for f in fields(self))
+
+    def items(self):
+        """Return (name, value) pairs for dict-like iteration.
+
+        Returns:
+            Iterator over (field_name, value) tuples
+        """
+        return ((f.name, getattr(self, f.name)) for f in fields(self))
+
+    def __iter__(self):
+        """Iterate over field names (like dict)."""
+        return (f.name for f in fields(self))
+
+    def __len__(self) -> int:
+        """Return number of fields."""
+        return len(fields(self))
+
     def asdict(self) -> dict:
         """Convert params to a dictionary."""
         return dc_asdict(self)
@@ -297,6 +321,30 @@ class MixerSettlerParams:
     def keys(self):
         """Return field names for dict-like iteration."""
         return (f.name for f in fields(self))
+
+    def values(self):
+        """Return field values for dict-like iteration.
+
+        Returns:
+            Iterator over field values
+        """
+        return (getattr(self, f.name) for f in fields(self))
+
+    def items(self):
+        """Return (name, value) pairs for dict-like iteration.
+
+        Returns:
+            Iterator over (field_name, value) tuples
+        """
+        return ((f.name, getattr(self, f.name)) for f in fields(self))
+
+    def __iter__(self):
+        """Iterate over field names (like dict)."""
+        return (f.name for f in fields(self))
+
+    def __len__(self) -> int:
+        """Return number of fields."""
+        return len(fields(self))
 
     def asdict(self) -> dict:
         """Convert params to a dictionary."""

--- a/src/difflow_ree/units/extraction.py
+++ b/src/difflow_ree/units/extraction.py
@@ -5,7 +5,7 @@ Multi-stage counter-current extraction cascades for REE separation.
 All operations are fully differentiable using JAX.
 """
 
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, replace, fields, asdict as dc_asdict
 from typing import Literal
 
 import jax.numpy as jnp
@@ -65,6 +65,18 @@ class REEExtractorParams:
             return getattr(self, key)
         except AttributeError:
             raise KeyError(key)
+
+    def __contains__(self, key: str) -> bool:
+        """Check if a field exists in the params."""
+        return key in {f.name for f in fields(self)}
+
+    def keys(self):
+        """Return field names for dict-like iteration."""
+        return (f.name for f in fields(self))
+
+    def asdict(self) -> dict:
+        """Convert params to a dictionary."""
+        return dc_asdict(self)
 
 
 class REEExtractor:
@@ -257,6 +269,18 @@ class MixerSettlerParams:
             return getattr(self, key)
         except AttributeError:
             raise KeyError(key)
+
+    def __contains__(self, key: str) -> bool:
+        """Check if a field exists in the params."""
+        return key in {f.name for f in fields(self)}
+
+    def keys(self):
+        """Return field names for dict-like iteration."""
+        return (f.name for f in fields(self))
+
+    def asdict(self) -> dict:
+        """Convert params to a dictionary."""
+        return dc_asdict(self)
 
 
 class REEMixerSettler:

--- a/src/difflow_ree/units/extraction.py
+++ b/src/difflow_ree/units/extraction.py
@@ -59,6 +59,13 @@ class REEExtractorParams:
         """
         return replace(self, **kwargs)
 
+    def __getitem__(self, key: str):
+        """Get parameter value by name for dict-like access."""
+        try:
+            return getattr(self, key)
+        except AttributeError:
+            raise KeyError(key)
+
 
 class REEExtractor:
     """Multi-stage REE extraction cascade.
@@ -243,6 +250,13 @@ class MixerSettlerParams:
             New MixerSettlerParams with updated fields
         """
         return replace(self, **kwargs)
+
+    def __getitem__(self, key: str):
+        """Get parameter value by name for dict-like access."""
+        try:
+            return getattr(self, key)
+        except AttributeError:
+            raise KeyError(key)
 
 
 class REEMixerSettler:

--- a/src/difflow_ree/units/extraction.py
+++ b/src/difflow_ree/units/extraction.py
@@ -78,6 +78,26 @@ class REEExtractorParams:
         """Convert params to a dictionary."""
         return dc_asdict(self)
 
+    def __repr__(self) -> str:
+        """Concise string representation."""
+        def fmt(v):
+            if v is None:
+                return "None"
+            if callable(v) and hasattr(v, '__name__'):
+                return v.__name__
+            if hasattr(v, 'shape'):
+                if v.ndim == 0:
+                    return f"{float(v):.4g}"
+                return f"Array{list(v.shape)}"
+            if isinstance(v, dict):
+                items = ", ".join(f"{k}: {fmt(val)}" for k, val in v.items())
+                return "{" + items + "}"
+            if isinstance(v, (list, tuple)) and len(v) > 5:
+                return f"{type(v).__name__}[{len(v)}]"
+            return repr(v)
+        items = ", ".join(f"{f.name}={fmt(getattr(self, f.name))}" for f in fields(self))
+        return f"{self.__class__.__name__}({items})"
+
 
 class REEExtractor:
     """Multi-stage REE extraction cascade.
@@ -281,6 +301,26 @@ class MixerSettlerParams:
     def asdict(self) -> dict:
         """Convert params to a dictionary."""
         return dc_asdict(self)
+
+    def __repr__(self) -> str:
+        """Concise string representation."""
+        def fmt(v):
+            if v is None:
+                return "None"
+            if callable(v) and hasattr(v, '__name__'):
+                return v.__name__
+            if hasattr(v, 'shape'):
+                if v.ndim == 0:
+                    return f"{float(v):.4g}"
+                return f"Array{list(v.shape)}"
+            if isinstance(v, dict):
+                items = ", ".join(f"{k}: {fmt(val)}" for k, val in v.items())
+                return "{" + items + "}"
+            if isinstance(v, (list, tuple)) and len(v) > 5:
+                return f"{type(v).__name__}[{len(v)}]"
+            return repr(v)
+        items = ", ".join(f"{f.name}={fmt(getattr(self, f.name))}" for f in fields(self))
+        return f"{self.__class__.__name__}({items})"
 
 
 class REEMixerSettler:

--- a/src/difflow_ree/units/precipitation.py
+++ b/src/difflow_ree/units/precipitation.py
@@ -83,6 +83,13 @@ class PrecipitatorParams:
         """
         return replace(self, **kwargs)
 
+    def __getitem__(self, key: str):
+        """Get parameter value by name for dict-like access."""
+        try:
+            return getattr(self, key)
+        except AttributeError:
+            raise KeyError(key)
+
 
 # =============================================================================
 # Oxalate Precipitation

--- a/src/difflow_ree/units/precipitation.py
+++ b/src/difflow_ree/units/precipitation.py
@@ -13,7 +13,7 @@ Common precipitants:
 All operations are fully differentiable using JAX.
 """
 
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, replace, fields, asdict as dc_asdict
 from typing import Literal
 
 import jax.numpy as jnp
@@ -89,6 +89,18 @@ class PrecipitatorParams:
             return getattr(self, key)
         except AttributeError:
             raise KeyError(key)
+
+    def __contains__(self, key: str) -> bool:
+        """Check if a field exists in the params."""
+        return key in {f.name for f in fields(self)}
+
+    def keys(self):
+        """Return field names for dict-like iteration."""
+        return (f.name for f in fields(self))
+
+    def asdict(self) -> dict:
+        """Convert params to a dictionary."""
+        return dc_asdict(self)
 
 
 # =============================================================================

--- a/src/difflow_ree/units/precipitation.py
+++ b/src/difflow_ree/units/precipitation.py
@@ -102,6 +102,26 @@ class PrecipitatorParams:
         """Convert params to a dictionary."""
         return dc_asdict(self)
 
+    def __repr__(self) -> str:
+        """Concise string representation."""
+        def fmt(v):
+            if v is None:
+                return "None"
+            if callable(v) and hasattr(v, '__name__'):
+                return v.__name__
+            if hasattr(v, 'shape'):
+                if v.ndim == 0:
+                    return f"{float(v):.4g}"
+                return f"Array{list(v.shape)}"
+            if isinstance(v, dict):
+                items = ", ".join(f"{k}: {fmt(val)}" for k, val in v.items())
+                return "{" + items + "}"
+            if isinstance(v, (list, tuple)) and len(v) > 5:
+                return f"{type(v).__name__}[{len(v)}]"
+            return repr(v)
+        items = ", ".join(f"{f.name}={fmt(getattr(self, f.name))}" for f in fields(self))
+        return f"{self.__class__.__name__}({items})"
+
 
 # =============================================================================
 # Oxalate Precipitation

--- a/src/difflow_ree/units/precipitation.py
+++ b/src/difflow_ree/units/precipitation.py
@@ -13,7 +13,7 @@ Common precipitants:
 All operations are fully differentiable using JAX.
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Literal
 
 import jax.numpy as jnp
@@ -69,6 +69,19 @@ class PrecipitatorParams:
     temperature: float = 298.15
     residence_time: float = 3600.0  # 1 hour typical
     target_conversion: float = 0.995
+
+    def update(self, **kwargs) -> "PrecipitatorParams":
+        """Return a new PrecipitatorParams with specified fields replaced.
+
+        This enables JAX-compatible parameter updates for differentiation.
+
+        Args:
+            **kwargs: Fields to update (e.g., precipitant_excess=2.0)
+
+        Returns:
+            New PrecipitatorParams with updated fields
+        """
+        return replace(self, **kwargs)
 
 
 # =============================================================================

--- a/src/difflow_ree/units/precipitation.py
+++ b/src/difflow_ree/units/precipitation.py
@@ -98,6 +98,30 @@ class PrecipitatorParams:
         """Return field names for dict-like iteration."""
         return (f.name for f in fields(self))
 
+    def values(self):
+        """Return field values for dict-like iteration.
+
+        Returns:
+            Iterator over field values
+        """
+        return (getattr(self, f.name) for f in fields(self))
+
+    def items(self):
+        """Return (name, value) pairs for dict-like iteration.
+
+        Returns:
+            Iterator over (field_name, value) tuples
+        """
+        return ((f.name, getattr(self, f.name)) for f in fields(self))
+
+    def __iter__(self):
+        """Iterate over field names (like dict)."""
+        return (f.name for f in fields(self))
+
+    def __len__(self) -> int:
+        """Return number of fields."""
+        return len(fields(self))
+
     def asdict(self) -> dict:
         """Convert params to a dictionary."""
         return dc_asdict(self)

--- a/src/difflow_ree/units/scrubbing.py
+++ b/src/difflow_ree/units/scrubbing.py
@@ -74,6 +74,26 @@ class ScrubberParams:
         """Convert params to a dictionary."""
         return dc_asdict(self)
 
+    def __repr__(self) -> str:
+        """Concise string representation."""
+        def fmt(v):
+            if v is None:
+                return "None"
+            if callable(v) and hasattr(v, '__name__'):
+                return v.__name__
+            if hasattr(v, 'shape'):
+                if v.ndim == 0:
+                    return f"{float(v):.4g}"
+                return f"Array{list(v.shape)}"
+            if isinstance(v, dict):
+                items = ", ".join(f"{k}: {fmt(val)}" for k, val in v.items())
+                return "{" + items + "}"
+            if isinstance(v, (list, tuple)) and len(v) > 5:
+                return f"{type(v).__name__}[{len(v)}]"
+            return repr(v)
+        items = ", ".join(f"{f.name}={fmt(getattr(self, f.name))}" for f in fields(self))
+        return f"{self.__class__.__name__}({items})"
+
 
 class REEScrubber:
     """Multi-stage REE scrubbing section.

--- a/src/difflow_ree/units/scrubbing.py
+++ b/src/difflow_ree/units/scrubbing.py
@@ -55,6 +55,13 @@ class ScrubberParams:
         """
         return replace(self, **kwargs)
 
+    def __getitem__(self, key: str):
+        """Get parameter value by name for dict-like access."""
+        try:
+            return getattr(self, key)
+        except AttributeError:
+            raise KeyError(key)
+
 
 class REEScrubber:
     """Multi-stage REE scrubbing section.

--- a/src/difflow_ree/units/scrubbing.py
+++ b/src/difflow_ree/units/scrubbing.py
@@ -11,7 +11,7 @@ The scrub solution is typically:
 All operations are fully differentiable using JAX.
 """
 
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, replace, fields, asdict as dc_asdict
 from typing import Literal
 
 import jax.numpy as jnp
@@ -61,6 +61,18 @@ class ScrubberParams:
             return getattr(self, key)
         except AttributeError:
             raise KeyError(key)
+
+    def __contains__(self, key: str) -> bool:
+        """Check if a field exists in the params."""
+        return key in {f.name for f in fields(self)}
+
+    def keys(self):
+        """Return field names for dict-like iteration."""
+        return (f.name for f in fields(self))
+
+    def asdict(self) -> dict:
+        """Convert params to a dictionary."""
+        return dc_asdict(self)
 
 
 class REEScrubber:

--- a/src/difflow_ree/units/scrubbing.py
+++ b/src/difflow_ree/units/scrubbing.py
@@ -70,6 +70,30 @@ class ScrubberParams:
         """Return field names for dict-like iteration."""
         return (f.name for f in fields(self))
 
+    def values(self):
+        """Return field values for dict-like iteration.
+
+        Returns:
+            Iterator over field values
+        """
+        return (getattr(self, f.name) for f in fields(self))
+
+    def items(self):
+        """Return (name, value) pairs for dict-like iteration.
+
+        Returns:
+            Iterator over (field_name, value) tuples
+        """
+        return ((f.name, getattr(self, f.name)) for f in fields(self))
+
+    def __iter__(self):
+        """Iterate over field names (like dict)."""
+        return (f.name for f in fields(self))
+
+    def __len__(self) -> int:
+        """Return number of fields."""
+        return len(fields(self))
+
     def asdict(self) -> dict:
         """Convert params to a dictionary."""
         return dc_asdict(self)

--- a/src/difflow_ree/units/scrubbing.py
+++ b/src/difflow_ree/units/scrubbing.py
@@ -11,7 +11,7 @@ The scrub solution is typically:
 All operations are fully differentiable using JAX.
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Literal
 
 import jax.numpy as jnp
@@ -41,6 +41,19 @@ class ScrubberParams:
     pH: float | Array = 2.0  # Lower pH than extraction to strip impurities
     extractant_conc: float = 0.5
     scrub_type: Literal["acid", "ree", "water"] = "acid"
+
+    def update(self, **kwargs) -> "ScrubberParams":
+        """Return a new ScrubberParams with specified fields replaced.
+
+        This enables JAX-compatible parameter updates for differentiation.
+
+        Args:
+            **kwargs: Fields to update (e.g., n_stages=6, pH=2.5)
+
+        Returns:
+            New ScrubberParams with updated fields
+        """
+        return replace(self, **kwargs)
 
 
 class REEScrubber:

--- a/src/difflow_ree/units/stripping.py
+++ b/src/difflow_ree/units/stripping.py
@@ -10,7 +10,7 @@ Strip solutions are typically:
 All operations are fully differentiable using JAX.
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Literal
 
 import jax.numpy as jnp
@@ -40,6 +40,19 @@ class StripperParams:
     extractant_conc: float = 0.5
     acid_type: Literal["HCl", "H2SO4", "HNO3"] = "HCl"
     acid_conc: float = 4.0  # M
+
+    def update(self, **kwargs) -> "StripperParams":
+        """Return a new StripperParams with specified fields replaced.
+
+        This enables JAX-compatible parameter updates for differentiation.
+
+        Args:
+            **kwargs: Fields to update (e.g., n_stages=6, pH=0.3)
+
+        Returns:
+            New StripperParams with updated fields
+        """
+        return replace(self, **kwargs)
 
 
 class REEStripper:

--- a/src/difflow_ree/units/stripping.py
+++ b/src/difflow_ree/units/stripping.py
@@ -54,6 +54,13 @@ class StripperParams:
         """
         return replace(self, **kwargs)
 
+    def __getitem__(self, key: str):
+        """Get parameter value by name for dict-like access."""
+        try:
+            return getattr(self, key)
+        except AttributeError:
+            raise KeyError(key)
+
 
 class REEStripper:
     """Multi-stage REE stripping section.

--- a/src/difflow_ree/units/stripping.py
+++ b/src/difflow_ree/units/stripping.py
@@ -73,6 +73,26 @@ class StripperParams:
         """Convert params to a dictionary."""
         return dc_asdict(self)
 
+    def __repr__(self) -> str:
+        """Concise string representation."""
+        def fmt(v):
+            if v is None:
+                return "None"
+            if callable(v) and hasattr(v, '__name__'):
+                return v.__name__
+            if hasattr(v, 'shape'):
+                if v.ndim == 0:
+                    return f"{float(v):.4g}"
+                return f"Array{list(v.shape)}"
+            if isinstance(v, dict):
+                items = ", ".join(f"{k}: {fmt(val)}" for k, val in v.items())
+                return "{" + items + "}"
+            if isinstance(v, (list, tuple)) and len(v) > 5:
+                return f"{type(v).__name__}[{len(v)}]"
+            return repr(v)
+        items = ", ".join(f"{f.name}={fmt(getattr(self, f.name))}" for f in fields(self))
+        return f"{self.__class__.__name__}({items})"
+
 
 class REEStripper:
     """Multi-stage REE stripping section.

--- a/src/difflow_ree/units/stripping.py
+++ b/src/difflow_ree/units/stripping.py
@@ -10,7 +10,7 @@ Strip solutions are typically:
 All operations are fully differentiable using JAX.
 """
 
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, replace, fields, asdict as dc_asdict
 from typing import Literal
 
 import jax.numpy as jnp
@@ -60,6 +60,18 @@ class StripperParams:
             return getattr(self, key)
         except AttributeError:
             raise KeyError(key)
+
+    def __contains__(self, key: str) -> bool:
+        """Check if a field exists in the params."""
+        return key in {f.name for f in fields(self)}
+
+    def keys(self):
+        """Return field names for dict-like iteration."""
+        return (f.name for f in fields(self))
+
+    def asdict(self) -> dict:
+        """Convert params to a dictionary."""
+        return dc_asdict(self)
 
 
 class REEStripper:

--- a/src/difflow_ree/units/stripping.py
+++ b/src/difflow_ree/units/stripping.py
@@ -69,6 +69,30 @@ class StripperParams:
         """Return field names for dict-like iteration."""
         return (f.name for f in fields(self))
 
+    def values(self):
+        """Return field values for dict-like iteration.
+
+        Returns:
+            Iterator over field values
+        """
+        return (getattr(self, f.name) for f in fields(self))
+
+    def items(self):
+        """Return (name, value) pairs for dict-like iteration.
+
+        Returns:
+            Iterator over (field_name, value) tuples
+        """
+        return ((f.name, getattr(self, f.name)) for f in fields(self))
+
+    def __iter__(self):
+        """Iterate over field names (like dict)."""
+        return (f.name for f in fields(self))
+
+    def __len__(self) -> int:
+        """Return number of fields."""
+        return len(fields(self))
+
     def asdict(self) -> dict:
         """Convert params to a dictionary."""
         return dc_asdict(self)

--- a/tests/test_cstr.py
+++ b/tests/test_cstr.py
@@ -115,3 +115,118 @@ class TestCSTR:
 
         # Gradient should be positive (more volume = more conversion = more B)
         assert float(grad_V) > 0
+
+
+class TestCSTRParamsUpdate:
+    """Test CSTRParams update() and __getitem__ methods."""
+
+    def test_update_returns_new_instance(self, simple_rate_fn):
+        """Test that update() returns a new instance."""
+        stoich = jnp.array([[-1.0], [+1.0]])
+        original = CSTRParams(
+            V=jnp.array(1.0),
+            rate_fn=simple_rate_fn,
+            stoich=stoich,
+            rate_params={"A": jnp.array(1e6), "Ea": jnp.array(50000.0)},
+            species_order=["A", "B"],
+        )
+
+        updated = original.update(V=jnp.array(2.0))
+
+        # Should be different instances
+        assert updated is not original
+        # Updated value should change
+        assert float(updated.V) == 2.0
+        # Original should be unchanged
+        assert float(original.V) == 1.0
+
+    def test_update_preserves_other_fields(self, simple_rate_fn):
+        """Test that update() preserves fields not being updated."""
+        stoich = jnp.array([[-1.0], [+1.0]])
+        original = CSTRParams(
+            V=jnp.array(1.0),
+            rate_fn=simple_rate_fn,
+            stoich=stoich,
+            rate_params={"A": jnp.array(1e6), "Ea": jnp.array(50000.0)},
+            species_order=["A", "B"],
+        )
+
+        updated = original.update(V=jnp.array(5.0))
+
+        # Other fields should be preserved
+        assert updated.rate_fn is original.rate_fn
+        assert jnp.allclose(updated.stoich, original.stoich)
+        assert updated.species_order == original.species_order
+
+    def test_update_multiple_fields(self, simple_rate_fn):
+        """Test that update() can update multiple fields at once."""
+        stoich = jnp.array([[-1.0], [+1.0]])
+        original = CSTRParams(
+            V=jnp.array(1.0),
+            rate_fn=simple_rate_fn,
+            stoich=stoich,
+            rate_params={"A": jnp.array(1e6), "Ea": jnp.array(50000.0)},
+            species_order=["A", "B"],
+        )
+
+        new_stoich = jnp.array([[-2.0], [+2.0]])
+        updated = original.update(V=jnp.array(3.0), stoich=new_stoich)
+
+        assert float(updated.V) == 3.0
+        assert jnp.allclose(updated.stoich, new_stoich)
+
+    def test_getitem_access(self, simple_rate_fn):
+        """Test that __getitem__ provides dict-like read access."""
+        stoich = jnp.array([[-1.0], [+1.0]])
+        params = CSTRParams(
+            V=jnp.array(1.0),
+            rate_fn=simple_rate_fn,
+            stoich=stoich,
+            rate_params={"A": jnp.array(1e6), "Ea": jnp.array(50000.0)},
+            species_order=["A", "B"],
+        )
+
+        # Dict-like access should work
+        assert float(params["V"]) == 1.0
+        assert params["species_order"] == ["A", "B"]
+        assert jnp.allclose(params["stoich"], stoich)
+
+    def test_getitem_invalid_key(self, simple_rate_fn):
+        """Test that __getitem__ raises KeyError for invalid keys."""
+        stoich = jnp.array([[-1.0], [+1.0]])
+        params = CSTRParams(
+            V=jnp.array(1.0),
+            rate_fn=simple_rate_fn,
+            stoich=stoich,
+            rate_params={"A": jnp.array(1e6), "Ea": jnp.array(50000.0)},
+            species_order=["A", "B"],
+        )
+
+        with pytest.raises(KeyError):
+            _ = params["nonexistent_field"]
+
+    def test_update_with_jax_grad(self, simple_thermo, simple_rate_fn):
+        """Test that update() works with JAX automatic differentiation."""
+        stoich = jnp.array([[-1.0], [+1.0]])
+        base_params = CSTRParams(
+            V=jnp.array(1.0),
+            rate_fn=simple_rate_fn,
+            stoich=stoich,
+            rate_params={"A": jnp.array(1e6), "Ea": jnp.array(50000.0)},
+            species_order=["A", "B"],
+        )
+
+        def outlet_B_with_update(V):
+            # Use update() to create new params - should be JAX compatible
+            params = base_params.update(V=V)
+            cstr = CSTR(params, thermo=simple_thermo, mode="isothermal")
+            inlet = make_stream({"A": 10.0, "B": 0.0}, T=300.0, P=101325.0)
+            outlet, _ = cstr(inlet, T_spec=350.0)
+            return outlet["F_B"]
+
+        # Compute gradient - should work without errors
+        grad_V = jax.grad(outlet_B_with_update)(jnp.array(1.0))
+
+        # Gradient should be positive and finite
+        assert jnp.isfinite(grad_V)
+        assert float(grad_V) > 0

--- a/tests/test_cstr.py
+++ b/tests/test_cstr.py
@@ -230,3 +230,70 @@ class TestCSTRParamsUpdate:
         # Gradient should be positive and finite
         assert jnp.isfinite(grad_V)
         assert float(grad_V) > 0
+
+    def test_keys_returns_field_names(self, simple_rate_fn):
+        """Test that keys() returns all field names."""
+        stoich = jnp.array([[-1.0], [+1.0]])
+        params = CSTRParams(
+            V=jnp.array(1.0),
+            rate_fn=simple_rate_fn,
+            stoich=stoich,
+            rate_params={"A": jnp.array(1e6), "Ea": jnp.array(50000.0)},
+            species_order=["A", "B"],
+        )
+
+        keys = list(params.keys())
+
+        # Should contain all dataclass fields
+        assert "V" in keys
+        assert "rate_fn" in keys
+        assert "stoich" in keys
+        assert "rate_params" in keys
+        assert "species_order" in keys
+
+    def test_contains_existing_field(self, simple_rate_fn):
+        """Test that 'field in params' works for existing fields."""
+        stoich = jnp.array([[-1.0], [+1.0]])
+        params = CSTRParams(
+            V=jnp.array(1.0),
+            rate_fn=simple_rate_fn,
+            stoich=stoich,
+            rate_params={"A": jnp.array(1e6), "Ea": jnp.array(50000.0)},
+            species_order=["A", "B"],
+        )
+
+        assert "V" in params
+        assert "rate_fn" in params
+        assert "stoich" in params
+
+    def test_contains_nonexistent_field(self, simple_rate_fn):
+        """Test that 'field in params' returns False for nonexistent fields."""
+        stoich = jnp.array([[-1.0], [+1.0]])
+        params = CSTRParams(
+            V=jnp.array(1.0),
+            rate_fn=simple_rate_fn,
+            stoich=stoich,
+            rate_params={"A": jnp.array(1e6), "Ea": jnp.array(50000.0)},
+            species_order=["A", "B"],
+        )
+
+        assert "nonexistent" not in params
+        assert "volume" not in params  # V, not volume
+
+    def test_asdict_returns_dict(self, simple_rate_fn):
+        """Test that asdict() returns a dictionary with all fields."""
+        stoich = jnp.array([[-1.0], [+1.0]])
+        params = CSTRParams(
+            V=jnp.array(1.0),
+            rate_fn=simple_rate_fn,
+            stoich=stoich,
+            rate_params={"A": jnp.array(1e6), "Ea": jnp.array(50000.0)},
+            species_order=["A", "B"],
+        )
+
+        d = params.asdict()
+
+        assert isinstance(d, dict)
+        assert float(d["V"]) == 1.0
+        assert d["species_order"] == ["A", "B"]
+        assert jnp.allclose(d["stoich"], stoich)

--- a/tests/test_cstr.py
+++ b/tests/test_cstr.py
@@ -297,3 +297,91 @@ class TestCSTRParamsUpdate:
         assert float(d["V"]) == 1.0
         assert d["species_order"] == ["A", "B"]
         assert jnp.allclose(d["stoich"], stoich)
+
+    def test_values_returns_field_values(self, simple_rate_fn):
+        """Test that values() returns all field values."""
+        stoich = jnp.array([[-1.0], [+1.0]])
+        params = CSTRParams(
+            V=jnp.array(1.0),
+            rate_fn=simple_rate_fn,
+            stoich=stoich,
+            rate_params={"A": jnp.array(1e6), "Ea": jnp.array(50000.0)},
+            species_order=["A", "B"],
+        )
+
+        values = list(params.values())
+
+        # Should have same number of values as fields
+        assert len(values) == len(list(params.keys()))
+        # First value should be V
+        assert float(values[0]) == 1.0
+
+    def test_items_returns_key_value_pairs(self, simple_rate_fn):
+        """Test that items() returns (key, value) pairs."""
+        stoich = jnp.array([[-1.0], [+1.0]])
+        params = CSTRParams(
+            V=jnp.array(1.0),
+            rate_fn=simple_rate_fn,
+            stoich=stoich,
+            rate_params={"A": jnp.array(1e6), "Ea": jnp.array(50000.0)},
+            species_order=["A", "B"],
+        )
+
+        items = list(params.items())
+
+        # Should have same count as fields
+        assert len(items) == len(list(params.keys()))
+        # Each item should be a (key, value) tuple
+        for key, value in items:
+            assert isinstance(key, str)
+        # Check specific values
+        items_dict = dict(items)
+        assert float(items_dict["V"]) == 1.0
+        assert items_dict["species_order"] == ["A", "B"]
+
+    def test_iter_over_keys(self, simple_rate_fn):
+        """Test that iterating over params yields keys."""
+        stoich = jnp.array([[-1.0], [+1.0]])
+        params = CSTRParams(
+            V=jnp.array(1.0),
+            rate_fn=simple_rate_fn,
+            stoich=stoich,
+            rate_params={"A": jnp.array(1e6), "Ea": jnp.array(50000.0)},
+            species_order=["A", "B"],
+        )
+
+        # list(params) should give field names
+        field_names = list(params)
+        assert "V" in field_names
+        assert "rate_fn" in field_names
+        assert "stoich" in field_names
+
+    def test_len_returns_field_count(self, simple_rate_fn):
+        """Test that len() returns number of fields."""
+        stoich = jnp.array([[-1.0], [+1.0]])
+        params = CSTRParams(
+            V=jnp.array(1.0),
+            rate_fn=simple_rate_fn,
+            stoich=stoich,
+            rate_params={"A": jnp.array(1e6), "Ea": jnp.array(50000.0)},
+            species_order=["A", "B"],
+        )
+
+        # CSTRParams has 7 fields
+        assert len(params) == 7
+
+    def test_dict_conversion_roundtrip(self, simple_rate_fn):
+        """Test that dict(params) works like asdict()."""
+        stoich = jnp.array([[-1.0], [+1.0]])
+        params = CSTRParams(
+            V=jnp.array(1.0),
+            rate_fn=simple_rate_fn,
+            stoich=stoich,
+            rate_params={"A": jnp.array(1e6), "Ea": jnp.array(50000.0)},
+            species_order=["A", "B"],
+        )
+
+        # dict(params) should work due to __iter__ and __getitem__
+        d = dict(params.items())
+        assert float(d["V"]) == 1.0
+        assert d["species_order"] == ["A", "B"]


### PR DESCRIPTION
This adds the `update(**kwargs)` method to all parameter dataclasses across
difflow, difflow_bio, and difflow_ree plugins. The method uses
`dataclasses.replace()` to return a new instance with specified fields
updated while leaving the original unchanged.

This pattern enables JAX-compatible parameter updates for gradient-based
optimization and sensitivity analysis:

    def experiment(volume):
        params = base_params.update(V=volume)
        reactor = CSTR(params)
        outlet, info = reactor(inlet)
        return info["conversion"]["A"]

    dX_dV = jax.grad(experiment)(2.0)  # Works!

Classes updated:
- Core: PFRParams, GasPFRParams, FlashParams, HeaterParams, CoolerParams,
  HeatExchangerParams, ShortcutColumnParams, DistillationColumnParams,
  CascadeParams, ContactorParams, EOSParams
- Bio: BioreactorParams, FedBatchParams, UltrafiltrationParams,
  DiafiltrationParams, CentrifugeParams, DiscStackParams, ProteinAParams,
  IEXParams, SECParams
- REE: REEExtractorParams, MixerSettlerParams, StripperParams,
  ScrubberParams, PrecipitatorParams, CeriumOxidizerParams,
  ExtractStripParams, ExtractScrubStripParams, SeparationTrainParams
- Economics: FinancialParams, InstallationFactors