### PR TITLE
Complete self-documenting flowsheet reports (#162)

### DIFF
--- a/src/difflow/__init__.py
+++ b/src/difflow/__init__.py
@@ -52,6 +52,8 @@ from difflow.database import (
     get_alkanes,
     get_btex,
     get_common_solvents,
+    track_database_access,
+    DatabaseAccessTracker,
 )
 from difflow.base_database import BaseDatabase
 from difflow.uncertainty import (
@@ -153,10 +155,13 @@ from difflow.units.heat_exchanger import (
 )
 from difflow.flowsheet import Flowsheet, Unit, create_objective
 from difflow.report import (
+    ConvergenceInfo,
     OptimizationReport,
     Report,
+    ReportDiff,
     build_optimization_report,
     build_report,
+    diff_reports,
     report,
     to_html,
     to_json,
@@ -288,6 +293,8 @@ __all__ = [
     "get_alkanes",
     "get_btex",
     "get_common_solvents",
+    "track_database_access",
+    "DatabaseAccessTracker",
     "BaseDatabase",
     # Uncertainty Propagation
     "linear_propagation",
@@ -370,8 +377,11 @@ __all__ = [
     # Reporting
     "Report",
     "OptimizationReport",
+    "ConvergenceInfo",
+    "ReportDiff",
     "build_report",
     "build_optimization_report",
+    "diff_reports",
     "report",
     "to_markdown",
     "to_json",

--- a/src/difflow/__init__.py
+++ b/src/difflow/__init__.py
@@ -153,7 +153,9 @@ from difflow.units.heat_exchanger import (
 )
 from difflow.flowsheet import Flowsheet, Unit, create_objective
 from difflow.report import (
+    OptimizationReport,
     Report,
+    build_optimization_report,
     build_report,
     report,
     to_html,
@@ -367,7 +369,9 @@ __all__ = [
     "create_objective",
     # Reporting
     "Report",
+    "OptimizationReport",
     "build_report",
+    "build_optimization_report",
     "report",
     "to_markdown",
     "to_json",

--- a/src/difflow/database.py
+++ b/src/difflow/database.py
@@ -488,6 +488,7 @@ def get_species_info(name: str) -> dict:
     Returns:
         Dictionary with all available properties
     """
+    _record_access(name, "info")
     key = name.lower().replace(" ", "_").replace("-", "_")
     info = {"name": key}
 
@@ -600,6 +601,87 @@ def resolve_alias(name: str) -> str:
     return _ALIASES.get(key, key)
 
 
+# =============================================================================
+# Instrumented database-access tracking (report provenance)
+# =============================================================================
+
+import contextlib as _contextlib
+
+#: stack of active access recorders; each is a list of (species, kind) tuples.
+#: Using a stack rather than a single log makes ``track_database_access``
+#: re-entrant (nested contexts each get their own record).
+_active_recorders: list[list[tuple[str, str]]] = []
+
+
+def _record_access(name: str, kind: str) -> None:
+    """Note a database lookup for any active :func:`track_database_access`."""
+    if not _active_recorders:
+        return
+    canonical = resolve_alias(name)
+    for recorder in _active_recorders:
+        recorder.append((canonical, kind))
+
+
+class DatabaseAccessTracker:
+    """Records which species/properties the database served during a solve.
+
+    Obtain one from :func:`track_database_access`.  After the ``with`` block
+    it exposes the set of species whose entries were read, which lets a
+    :class:`~difflow.report.ir.Report` distinguish species the calculation
+    actually depended on from species merely present in a stream.
+    """
+
+    def __init__(self, records: list[tuple[str, str]]):
+        self._records = records
+
+    @property
+    def records(self) -> list[tuple[str, str]]:
+        """All ``(species, kind)`` lookups in call order (with duplicates)."""
+        return list(self._records)
+
+    @property
+    def species(self) -> list[str]:
+        """Canonical species names accessed, in first-seen order."""
+        seen: dict[str, None] = {}
+        for name, _ in self._records:
+            seen.setdefault(name, None)
+        return list(seen)
+
+    def was_accessed(self, name: str) -> bool:
+        """True if ``name`` (any alias) was looked up during tracking."""
+        return resolve_alias(name) in set(n for n, _ in self._records)
+
+    def kinds(self, name: str) -> set[str]:
+        """The kinds of lookup ("critical", "ideal", "info") for ``name``."""
+        canonical = resolve_alias(name)
+        return {k for n, k in self._records if n == canonical}
+
+
+@_contextlib.contextmanager
+def track_database_access():
+    """Context manager that records database lookups made inside it.
+
+    Wrap a solve to capture precise data provenance for a report::
+
+        from difflow.database import track_database_access
+
+        with track_database_access() as tracker:
+            streams = fs.solve()
+
+        rep = fs.report(streams, db_access=tracker)
+
+    Yields:
+        A :class:`DatabaseAccessTracker`; the records are complete once the
+        ``with`` block exits (and remain readable afterward).
+    """
+    records: list[tuple[str, str]] = []
+    _active_recorders.append(records)
+    try:
+        yield DatabaseAccessTracker(records)
+    finally:
+        _active_recorders.remove(records)
+
+
 # Make alias resolution automatic in get_* functions
 _original_get_critical_props = get_critical_props
 _original_get_species_data = get_species_data
@@ -607,9 +689,11 @@ _original_get_species_data = get_species_data
 
 def get_critical_props(name: str) -> CriticalProperties:
     """Get critical properties for a species by name (with alias support)."""
+    _record_access(name, "critical")
     return _original_get_critical_props(resolve_alias(name))
 
 
 def get_species_data(name: str) -> SpeciesData:
     """Get SpeciesData for ideal thermodynamics by name (with alias support)."""
+    _record_access(name, "ideal")
     return _original_get_species_data(resolve_alias(name))

--- a/src/difflow/flowsheet.py
+++ b/src/difflow/flowsheet.py
@@ -662,6 +662,7 @@ class Flowsheet:
         self,
         streams: dict[str, Stream] | None = None,
         include_git: bool = True,
+        optimization=None,
         notes: list[str] | None = None,
     ):
         """Build a self-documenting :class:`~difflow.report.ir.Report` for this flowsheet.
@@ -673,6 +674,10 @@ class Flowsheet:
                 ``balance_checks`` fields are ``None``.
             include_git: Whether to capture git commit + dirty flag in the
                 provenance section.
+            optimization: Optional
+                :class:`~difflow.report.ir.OptimizationReport` (build one with
+                :func:`difflow.report.build_optimization_report`) to include the
+                optimization / sensitivity section.
             notes: Optional free-form notes to attach to the report.
 
         Returns:
@@ -681,7 +686,13 @@ class Flowsheet:
         """
         from difflow.report.builder import build_report
 
-        return build_report(self, streams=streams, include_git=include_git, notes=notes)
+        return build_report(
+            self,
+            streams=streams,
+            include_git=include_git,
+            optimization=optimization,
+            notes=notes,
+        )
 
     def solve_eo(
         self,

--- a/src/difflow/flowsheet.py
+++ b/src/difflow/flowsheet.py
@@ -100,6 +100,17 @@ class Flowsheet:
         #: tear iterations used by the last accelerated solve (Wegstein
         #: or Anderson); equals max_iter if it did not converge
         self.last_solve_iterations: int | None = None
+        #: final tear residual (max abs change) of the last recycle solve
+        self.last_solve_residual: float | None = None
+        #: whether the last recycle solve met its tolerance
+        self.last_solve_converged: bool | None = None
+        #: acceleration method of the last solve ("anderson", "wegstein",
+        #: "damped", or "direct" for a recycle-free sequential solve)
+        self.last_solve_method: str | None = None
+        #: tolerance requested of the last recycle solve
+        self.last_solve_tol: float | None = None
+        #: tear-stream (recycle destination) names of the last recycle solve
+        self.last_solve_tear_streams: list[str] = []
 
     def add_feed(self, name: str, stream: Stream) -> None:
         """Add a feed stream to the flowsheet.
@@ -186,7 +197,17 @@ class Flowsheet:
         """
         if not self.recycles:
             # No recycles - simple sequential solution
+            self.last_solve_method = "direct"
+            self.last_solve_iterations = 0
+            self.last_solve_residual = 0.0
+            self.last_solve_converged = True
+            self.last_solve_tol = tol
+            self.last_solve_tear_streams = []
             return self._solve_sequential()
+
+        self.last_solve_method = acceleration
+        self.last_solve_tol = tol
+        self.last_solve_tear_streams = [dest for dest in self.recycles.values()]
 
         # Initialize tear streams
         tear_streams = {}
@@ -376,6 +397,17 @@ class Flowsheet:
         )
         tear_converged = sol.value
 
+        # Record convergence diagnostics for the report layer.
+        final_residual = float(
+            jnp.max(jnp.abs(flowsheet_iteration(tear_converged, args) - tear_converged))
+        )
+        self.last_solve_residual = final_residual
+        self.last_solve_converged = bool(final_residual < tol)
+        try:
+            self.last_solve_iterations = int(sol.stats.get("num_steps", max_iter))
+        except Exception:
+            self.last_solve_iterations = max_iter
+
         # Final solve with converged tear streams
         final_tear = self._array_to_streams(tear_converged, list(tear_initial.keys()))
         streams = dict(self.feeds)
@@ -448,9 +480,12 @@ class Flowsheet:
         for iteration in range(max_iter):
             # Check convergence
             residual = jnp.max(jnp.abs(g_curr - x_prev))
+            self.last_solve_residual = float(residual)
             if float(residual) < tol:
                 self.last_solve_iterations = iteration
+                self.last_solve_converged = True
                 break
+            self.last_solve_converged = False
 
             if g_prev is None:
                 # Second iteration: can't use Wegstein yet
@@ -525,9 +560,12 @@ class Flowsheet:
 
             # Check convergence
             residual = jnp.max(jnp.abs(g_curr - x_curr))
+            self.last_solve_residual = float(residual)
             if float(residual) < tol:
                 self.last_solve_iterations = iteration
+                self.last_solve_converged = True
                 break
+            self.last_solve_converged = False
 
             # Apply Anderson acceleration
             x_next = accelerator.step(x_curr, g_curr)
@@ -663,6 +701,7 @@ class Flowsheet:
         streams: dict[str, Stream] | None = None,
         include_git: bool = True,
         optimization=None,
+        db_access=None,
         notes: list[str] | None = None,
     ):
         """Build a self-documenting :class:`~difflow.report.ir.Report` for this flowsheet.
@@ -691,6 +730,7 @@ class Flowsheet:
             streams=streams,
             include_git=include_git,
             optimization=optimization,
+            db_access=db_access,
             notes=notes,
         )
 

--- a/src/difflow/report/__init__.py
+++ b/src/difflow/report/__init__.py
@@ -23,19 +23,22 @@ from typing import Any
 
 from difflow.report.ir import (
     BalanceCheck,
+    DecisionVariable,
     Edge,
     FeedSummary,
+    OptimizationReport,
     ParamRow,
     Provenance,
     RecycleInfo,
     Report,
     ResultSummary,
     SpeciesRow,
+    TornadoRow,
     Topology,
     UnitReport,
 )
 from difflow.report.metadata import UnitMetadata, get_metadata, has_structured_metadata
-from difflow.report.builder import build_report
+from difflow.report.builder import build_optimization_report, build_report
 from difflow.report.renderers.markdown import to_markdown
 from difflow.report.renderers.json_renderer import to_json
 from difflow.report.renderers.latex import to_latex
@@ -70,10 +73,14 @@ __all__ = [
     "RecycleInfo",
     "Edge",
     "BalanceCheck",
+    "DecisionVariable",
+    "TornadoRow",
+    "OptimizationReport",
     "UnitMetadata",
     "get_metadata",
     "has_structured_metadata",
     "build_report",
+    "build_optimization_report",
     "report",
     "to_markdown",
     "to_json",

--- a/src/difflow/report/__init__.py
+++ b/src/difflow/report/__init__.py
@@ -23,6 +23,7 @@ from typing import Any
 
 from difflow.report.ir import (
     BalanceCheck,
+    ConvergenceInfo,
     DecisionVariable,
     Edge,
     FeedSummary,
@@ -39,6 +40,8 @@ from difflow.report.ir import (
 )
 from difflow.report.metadata import UnitMetadata, get_metadata, has_structured_metadata
 from difflow.report.builder import build_optimization_report, build_report
+from difflow.report.diff import ReportDiff, diff_reports
+from difflow.report.diagram import flowsheet_svg
 from difflow.report.renderers.markdown import to_markdown
 from difflow.report.renderers.json_renderer import to_json
 from difflow.report.renderers.latex import to_latex
@@ -73,9 +76,13 @@ __all__ = [
     "RecycleInfo",
     "Edge",
     "BalanceCheck",
+    "ConvergenceInfo",
     "DecisionVariable",
     "TornadoRow",
     "OptimizationReport",
+    "ReportDiff",
+    "diff_reports",
+    "flowsheet_svg",
     "UnitMetadata",
     "get_metadata",
     "has_structured_metadata",

--- a/src/difflow/report/builder.py
+++ b/src/difflow/report/builder.py
@@ -14,6 +14,7 @@ from typing import Any, Iterable
 
 from difflow.report.ir import (
     BalanceCheck,
+    ConvergenceInfo,
     DecisionVariable,
     Edge,
     FeedSummary,
@@ -119,9 +120,15 @@ def _feed_summary(name: str, stream: dict[str, Any]) -> FeedSummary:
 
 
 def _collect_species(
-    flowsheet, streams: dict[str, Any] | None
+    flowsheet, streams: dict[str, Any] | None, db_access: Any | None = None
 ) -> list[SpeciesRow]:
-    """Gather thermo + critical properties for every species in any stream."""
+    """Gather thermo + critical properties for every species in any stream.
+
+    When ``db_access`` is a tracker from
+    :func:`difflow.database.track_database_access`, each row's ``accessed``
+    flag reports whether the solve actually touched that species' database
+    entry (precise provenance); otherwise ``accessed`` stays ``None``.
+    """
     from difflow import database as _db
 
     names: list[str] = list(getattr(flowsheet, "species_order", []) or [])
@@ -165,6 +172,11 @@ def _collect_species(
             row.Hf = float(getattr(sp, "Hf", 0.0))
         except Exception:
             pass
+        if db_access is not None:
+            try:
+                row.accessed = db_access.was_accessed(name)
+            except Exception:
+                row.accessed = None
         rows.append(row)
     return rows
 
@@ -235,6 +247,28 @@ def _balance_checks(
         )
         for s in flowsheet.species_order
     ]
+
+
+def _convergence_info(flowsheet, streams: dict[str, Any] | None) -> ConvergenceInfo | None:
+    """Capture recycle-loop convergence diagnostics from the last solve.
+
+    Reads the ``last_solve_*`` attributes the flowsheet records during
+    :meth:`~difflow.flowsheet.Flowsheet.solve`.  Returns ``None`` when no
+    streams are supplied or the flowsheet has not been solved.
+    """
+    if streams is None:
+        return None
+    method = getattr(flowsheet, "last_solve_method", None)
+    if method is None:
+        return None
+    return ConvergenceInfo(
+        method=method,
+        iterations=getattr(flowsheet, "last_solve_iterations", None),
+        residual=getattr(flowsheet, "last_solve_residual", None),
+        tolerance=getattr(flowsheet, "last_solve_tol", None),
+        converged=getattr(flowsheet, "last_solve_converged", None),
+        tear_streams=list(getattr(flowsheet, "last_solve_tear_streams", []) or []),
+    )
 
 
 def _objective_source(objective: Any, explicit: str | None) -> str:
@@ -377,6 +411,7 @@ def build_report(
     streams: dict[str, Any] | None = None,
     include_git: bool = True,
     optimization: OptimizationReport | None = None,
+    db_access: Any | None = None,
     notes: Iterable[str] | None = None,
 ) -> Report:
     """Build a :class:`Report` from a flowsheet and (optionally) solved streams.
@@ -391,6 +426,10 @@ def build_report(
         optimization: Optional :class:`~difflow.report.ir.OptimizationReport`
             (build one with :func:`build_optimization_report`) to include the
             optimization / sensitivity section (report section G).
+        db_access: Optional tracker from
+            :func:`difflow.database.track_database_access` used around the
+            solve.  When given, each species row is annotated with whether
+            its database entry was actually accessed (precise provenance).
         notes: Optional free-form notes to attach to the report.
 
     Returns:
@@ -441,8 +480,9 @@ def build_report(
             if summary is not None:
                 results.append(summary)
 
-    species = _collect_species(flowsheet, streams)
+    species = _collect_species(flowsheet, streams, db_access=db_access)
     balance_checks = _balance_checks(flowsheet, streams)
+    convergence = _convergence_info(flowsheet, streams)
 
     return Report(
         provenance=collect_provenance(include_git=include_git),
@@ -452,6 +492,7 @@ def build_report(
         feeds=feeds,
         results=results,
         balance_checks=balance_checks,
+        convergence=convergence,
         optimization=optimization,
         notes=list(notes) if notes else [],
     )

--- a/src/difflow/report/builder.py
+++ b/src/difflow/report/builder.py
@@ -14,13 +14,16 @@ from typing import Any, Iterable
 
 from difflow.report.ir import (
     BalanceCheck,
+    DecisionVariable,
     Edge,
     FeedSummary,
+    OptimizationReport,
     ParamRow,
     RecycleInfo,
     Report,
     ResultSummary,
     SpeciesRow,
+    TornadoRow,
     Topology,
     UnitReport,
 )
@@ -234,10 +237,146 @@ def _balance_checks(
     ]
 
 
+def _objective_source(objective: Any, explicit: str | None) -> str:
+    """Best-effort description of where an objective function is defined."""
+    if explicit:
+        return explicit
+    name = getattr(objective, "__name__", None)
+    module = getattr(objective, "__module__", None)
+    if name and module:
+        return f"{module}.{name}"
+    if name:
+        return name
+    return ""
+
+
+def build_optimization_report(
+    objective: Any,
+    design_point: dict[str, float],
+    bounds: dict[str, tuple[float, float]] | None = None,
+    objective_name: str = "Objective",
+    objective_units: str = "",
+    objective_source: str | None = None,
+    sense: str = "minimize",
+    notes: Iterable[str] | None = None,
+) -> OptimizationReport:
+    """Build the optimization / sensitivity section (report section G).
+
+    Given the objective function and the design point (usually the optimum),
+    this captures the objective value, the per-variable gradient
+    ``dJ/dx`` (via JAX automatic differentiation), and — when bounds are
+    supplied — a one-at-a-time tornado table of the objective's swing over
+    each variable's range.  It performs no optimization itself; the caller
+    passes the design point that a solver (or hand analysis) produced.
+
+    Args:
+        objective: callable mapping a decision-variable dict to a scalar.
+            Must be JAX-differentiable for gradients to be captured; if it
+            is not, gradients are reported as ``None`` and the rest of the
+            section is still produced.
+        design_point: decision variables at the reported point, e.g. the
+            optimum ``{"V": 2.3, "reflux": 1.4}``.
+        bounds: optional ``{name: (low, high)}`` used both to annotate each
+            variable and to build the tornado table.
+        objective_name: human-readable objective name.
+        objective_units: units of the objective, if any.
+        objective_source: where the objective is defined; defaults to the
+            callable's ``module.__name__``.
+        sense: "minimize" or "maximize" (informational).
+        notes: optional free-form notes.
+
+    Returns:
+        A populated :class:`~difflow.report.ir.OptimizationReport`.
+    """
+    import jax
+    import jax.numpy as jnp
+
+    names = list(design_point.keys())
+    point = {k: float(design_point[k]) for k in names}
+
+    def _scalar(d: dict[str, Any]) -> Any:
+        return jnp.asarray(objective(d)).reshape(())
+
+    obj_value = float(_scalar(point))
+
+    # Per-variable gradient via autodiff over the decision-variable pytree.
+    grads: dict[str, float | None] = {k: None for k in names}
+    try:
+        jpoint = {k: jnp.asarray(point[k], dtype=float) for k in names}
+        graddict = jax.grad(lambda d: _scalar(d))(jpoint)
+        for k in names:
+            g = graddict.get(k)
+            if g is not None and jnp.all(jnp.isfinite(g)):
+                grads[k] = float(g)
+    except Exception:
+        pass
+
+    variables: list[DecisionVariable] = []
+    for k in names:
+        lo = hi = None
+        if bounds and k in bounds:
+            lo, hi = float(bounds[k][0]), float(bounds[k][1])
+        g = grads[k]
+        elasticity = None
+        if g is not None and obj_value != 0.0:
+            elasticity = g * point[k] / obj_value
+        variables.append(
+            DecisionVariable(
+                name=k,
+                value=point[k],
+                lower=lo,
+                upper=hi,
+                gradient=g,
+                elasticity=elasticity,
+            )
+        )
+
+    tornado: list[TornadoRow] | None = None
+    if bounds:
+        rows: list[TornadoRow] = []
+        for k in names:
+            if k not in bounds:
+                continue
+            lo, hi = float(bounds[k][0]), float(bounds[k][1])
+            low_pt = dict(point)
+            low_pt[k] = lo
+            high_pt = dict(point)
+            high_pt[k] = hi
+            try:
+                y_lo = float(_scalar(low_pt))
+                y_hi = float(_scalar(high_pt))
+            except Exception:
+                continue
+            rows.append(
+                TornadoRow(
+                    variable=k,
+                    low_value=lo,
+                    high_value=hi,
+                    low_output=y_lo,
+                    high_output=y_hi,
+                    swing=abs(y_hi - y_lo),
+                )
+            )
+        rows.sort(key=lambda r: r.swing, reverse=True)
+        tornado = rows or None
+
+    return OptimizationReport(
+        objective_name=objective_name,
+        objective_value=obj_value,
+        objective_units=objective_units,
+        objective_source=_objective_source(objective, objective_source),
+        sense=sense,
+        variables=variables,
+        tornado=tornado,
+        notes=list(notes) if notes else [],
+    )
+
+
 def build_report(
     flowsheet,
     streams: dict[str, Any] | None = None,
     include_git: bool = True,
+    optimization: OptimizationReport | None = None,
     notes: Iterable[str] | None = None,
 ) -> Report:
     """Build a :class:`Report` from a flowsheet and (optionally) solved streams.
@@ -249,6 +388,9 @@ def build_report(
             (topology, units, species, feeds) and the ``results`` /
             ``balance_checks`` fields are ``None``.
         include_git: Whether to capture git commit / dirty-flag in provenance.
+        optimization: Optional :class:`~difflow.report.ir.OptimizationReport`
+            (build one with :func:`build_optimization_report`) to include the
+            optimization / sensitivity section (report section G).
         notes: Optional free-form notes to attach to the report.
 
     Returns:
@@ -310,5 +452,6 @@ def build_report(
         feeds=feeds,
         results=results,
         balance_checks=balance_checks,
+        optimization=optimization,
         notes=list(notes) if notes else [],
     )

--- a/src/difflow/report/diagram.py
+++ b/src/difflow/report/diagram.py
@@ -1,0 +1,224 @@
+"""Self-contained inline-SVG flowsheet diagram for HTML reports.
+
+The diagram is generated purely from the :class:`~difflow.report.ir.Report`
+intermediate representation (unit inlet/outlet names + topology), so it needs
+no ``ipycytoscape``, no external JavaScript, and no network access — it embeds
+directly in the standalone HTML report.  The layout is a simple left-to-right
+layered (Sugiyama-style) placement: feeds on the left, products on the right,
+units in longest-path columns between them; recycle arcs are drawn dashed.
+"""
+
+from __future__ import annotations
+
+from html import escape
+
+from difflow.report.ir import Report
+
+# Geometry (px).
+_COL_W = 190
+_ROW_H = 78
+_NODE_W = 130
+_NODE_H = 46
+_MARGIN = 24
+
+
+def _unit_columns(unit_names, up_edges) -> dict[str, int]:
+    """Longest-path column index per unit, ignoring back (recycle) edges.
+
+    ``up_edges`` maps a unit to the list of upstream units feeding it.  A
+    Bellman-Ford-style relaxation capped at ``len(units)`` passes assigns each
+    unit one past its deepest predecessor; the cap makes it safe on cyclic
+    graphs (recycle edges simply stop lengthening the path).
+    """
+    col = {u: 0 for u in unit_names}
+    for _ in range(len(unit_names)):
+        changed = False
+        for u in unit_names:
+            for p in up_edges.get(u, ()):  # predecessors
+                if col[p] + 1 > col[u]:
+                    col[u] = col[p] + 1
+                    changed = True
+        if not changed:
+            break
+    return col
+
+
+def _node_svg(x: int, y: int, label: str, sub: str, kind: str) -> str:
+    """One rounded-rectangle node with a title line and a subtitle."""
+    fill = {"feed": "#eef6ff", "product": "#f0fff0", "unit": "#ffffff"}.get(kind, "#fff")
+    stroke = {"feed": "#5b8def", "product": "#3caa5a", "unit": "#888"}.get(kind, "#888")
+    parts = [
+        f'<rect x="{x}" y="{y}" width="{_NODE_W}" height="{_NODE_H}" rx="6" '
+        f'fill="{fill}" stroke="{stroke}" stroke-width="1.5"/>',
+        f'<text x="{x + _NODE_W // 2}" y="{y + 19}" text-anchor="middle" '
+        f'font-size="13" font-weight="bold">{escape(label)}</text>',
+    ]
+    if sub:
+        parts.append(
+            f'<text x="{x + _NODE_W // 2}" y="{y + 35}" text-anchor="middle" '
+            f'font-size="10" fill="#555">{escape(sub)}</text>'
+        )
+    return "".join(parts)
+
+
+def _edge_svg(x1: int, y1: int, x2: int, y2: int, label: str, recycle: bool) -> str:
+    """A straight arrow between two node anchor points with a small label."""
+    color = "#e74c3c" if recycle else "#666"
+    dash = ' stroke-dasharray="6 4"' if recycle else ""
+    mid_x = (x1 + x2) // 2
+    mid_y = (y1 + y2) // 2 - 4
+    line = (
+        f'<line x1="{x1}" y1="{y1}" x2="{x2}" y2="{y2}" stroke="{color}" '
+        f'stroke-width="1.5"{dash} marker-end="url(#arrow)"/>'
+    )
+    text = ""
+    if label:
+        text = (
+            f'<text x="{mid_x}" y="{mid_y}" text-anchor="middle" font-size="9" '
+            f'fill="{color}">{escape(label)}</text>'
+        )
+    return line + text
+
+
+def flowsheet_svg(report: Report) -> str:
+    """Render an inline ``<svg>`` flowsheet diagram from a :class:`Report`.
+
+    Returns an empty string when the flowsheet has no units.
+    """
+    units = report.units
+    if not units:
+        return ""
+
+    unit_names = [u.name for u in units]
+    producer: dict[str, str] = {}
+    for u in units:
+        for out in u.outlet_names:
+            producer[out] = u.name
+    all_inlets: set[str] = set()
+    for u in units:
+        all_inlets.update(u.inlet_names)
+
+    # Unit -> upstream units (only where an inlet is produced by another unit).
+    up_edges: dict[str, list[str]] = {u.name: [] for u in units}
+    unit_arcs: list[tuple[str, str, str]] = []  # (src_unit, dst_unit, stream)
+    recycle_sources = {r.source_stream for r in report.topology.recycles}
+    for u in units:
+        for inlet in u.inlet_names:
+            src = producer.get(inlet)
+            if src is not None and inlet not in recycle_sources:
+                up_edges[u.name].append(src)
+                unit_arcs.append((src, u.name, inlet))
+
+    col = _unit_columns(unit_names, up_edges)
+    max_unit_col = max(col.values()) if col else 0
+
+    # Feed streams: inlets not produced by any unit.  Product streams: outlets
+    # not consumed anywhere and not a recycle source.
+    feed_streams: list[str] = []
+    seen_f: set[str] = set()
+    for u in units:
+        for inlet in u.inlet_names:
+            if producer.get(inlet) is None and inlet not in seen_f:
+                seen_f.add(inlet)
+                feed_streams.append(inlet)
+    product_streams: list[str] = []
+    for u in units:
+        for out in u.outlet_names:
+            if out not in all_inlets and out not in recycle_sources:
+                product_streams.append(out)
+
+    feed_col = 0
+    unit_col_offset = 1 if feed_streams else 0
+    product_col = max_unit_col + unit_col_offset + (1 if product_streams else 0)
+
+    # Assign a (col, row) grid slot to every node.
+    def _place(items):
+        return {name: row for row, name in enumerate(items)}
+
+    node_pos: dict[str, tuple[int, int]] = {}
+    feed_rows = _place(feed_streams)
+    for name, row in feed_rows.items():
+        node_pos[f"feed:{name}"] = (feed_col, row)
+    # Units grouped by column.
+    by_col: dict[int, list[str]] = {}
+    for name in unit_names:
+        by_col.setdefault(col[name] + unit_col_offset, []).append(name)
+    for c, names in by_col.items():
+        for row, name in enumerate(names):
+            node_pos[f"unit:{name}"] = (c, row)
+    prod_rows = _place(product_streams)
+    for name, row in prod_rows.items():
+        node_pos[f"product:{name}"] = (product_col, row)
+
+    max_col = max((c for c, _ in node_pos.values()), default=0)
+    max_row = max((r for _, r in node_pos.values()), default=0)
+    width = 2 * _MARGIN + max_col * _COL_W + _NODE_W
+    height = 2 * _MARGIN + max_row * _ROW_H + _NODE_H
+
+    def _xy(key):
+        c, r = node_pos[key]
+        return _MARGIN + c * _COL_W, _MARGIN + r * _ROW_H
+
+    def _right(key):
+        x, y = _xy(key)
+        return x + _NODE_W, y + _NODE_H // 2
+
+    def _left(key):
+        x, y = _xy(key)
+        return x, y + _NODE_H // 2
+
+    out = [
+        f'<svg viewBox="0 0 {width} {height}" width="100%" '
+        f'style="max-width:{width}px" xmlns="http://www.w3.org/2000/svg" '
+        'font-family="system-ui, sans-serif">',
+        '<defs><marker id="arrow" markerWidth="9" markerHeight="9" refX="7" '
+        'refY="3" orient="auto" markerUnits="strokeWidth">'
+        '<path d="M0,0 L7,3 L0,6 Z" fill="#666"/></marker></defs>',
+    ]
+
+    # Edges first, so nodes render on top.
+    for src, dst, stream in unit_arcs:
+        x1, y1 = _right(f"unit:{src}")
+        x2, y2 = _left(f"unit:{dst}")
+        out.append(_edge_svg(x1, y1, x2, y2, stream, recycle=False))
+    for name in feed_streams:
+        # feed -> first consuming unit
+        target = next((u.name for u in units if name in u.inlet_names), None)
+        if target is None:
+            continue
+        x1, y1 = _right(f"feed:{name}")
+        x2, y2 = _left(f"unit:{target}")
+        out.append(_edge_svg(x1, y1, x2, y2, "", recycle=False))
+    for name in product_streams:
+        source = producer.get(name)
+        if source is None:
+            continue
+        x1, y1 = _right(f"unit:{source}")
+        x2, y2 = _left(f"product:{name}")
+        out.append(_edge_svg(x1, y1, x2, y2, "", recycle=False))
+    for rec in report.topology.recycles:
+        src = producer.get(rec.source_stream)
+        dst = next(
+            (u.name for u in units if rec.dest_stream in u.inlet_names), None
+        )
+        if src is None or dst is None:
+            continue
+        x1, y1 = _right(f"unit:{src}")
+        x2, y2 = _left(f"unit:{dst}")
+        out.append(
+            _edge_svg(x1, y1, x2, y2, f"{rec.source_stream}→{rec.dest_stream}", True)
+        )
+
+    # Nodes.
+    for name in feed_streams:
+        x, y = _xy(f"feed:{name}")
+        out.append(_node_svg(x, y, name, "feed", "feed"))
+    for u in units:
+        x, y = _xy(f"unit:{u.name}")
+        out.append(_node_svg(x, y, u.name, u.type, "unit"))
+    for name in product_streams:
+        x, y = _xy(f"product:{name}")
+        out.append(_node_svg(x, y, name, "product", "product"))
+
+    out.append("</svg>")
+    return "\n".join(out)

--- a/src/difflow/report/diff.py
+++ b/src/difflow/report/diff.py
@@ -1,0 +1,185 @@
+"""Structured diff between two :class:`~difflow.report.ir.Report` objects.
+
+Comparing two reports is how a reader sees what changed between two runs:
+a design tweak, a parameter sweep step, a difflow-version bump.  The diff is
+computed at unit / parameter / stream granularity and renders to Markdown.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from difflow.report.ir import Report
+
+
+def _num_changed(a: Any, b: Any, rtol: float = 1e-9, atol: float = 1e-12) -> bool:
+    """True if two values differ (numeric compare with tolerance, else !=)."""
+    try:
+        fa, fb = float(a), float(b)
+        return abs(fa - fb) > atol + rtol * abs(fb)
+    except (TypeError, ValueError):
+        return a != b
+
+
+@dataclass
+class ParamChange:
+    """A single changed parameter of a unit (or objective/provenance field)."""
+
+    name: str
+    before: str
+    after: str
+
+
+@dataclass
+class UnitParamChanges:
+    """Parameter changes for one unit present in both reports."""
+
+    unit: str
+    changes: list[ParamChange] = field(default_factory=list)
+
+
+@dataclass
+class StreamChange:
+    """Changed quantities (T, P, flows) of a feed or result stream."""
+
+    stream: str
+    changes: list[ParamChange] = field(default_factory=list)
+
+
+@dataclass
+class ReportDiff:
+    """Structured difference between a "before" and an "after" report."""
+
+    provenance: list[ParamChange] = field(default_factory=list)
+    units_added: list[str] = field(default_factory=list)
+    units_removed: list[str] = field(default_factory=list)
+    unit_param_changes: list[UnitParamChanges] = field(default_factory=list)
+    feed_changes: list[StreamChange] = field(default_factory=list)
+    result_changes: list[StreamChange] = field(default_factory=list)
+    objective_changes: list[ParamChange] = field(default_factory=list)
+
+    @property
+    def is_empty(self) -> bool:
+        """True when the two reports are equivalent in every compared section."""
+        return not any([
+            self.provenance,
+            self.units_added,
+            self.units_removed,
+            self.unit_param_changes,
+            self.feed_changes,
+            self.result_changes,
+            self.objective_changes,
+        ])
+
+    def to_markdown(self) -> str:
+        from difflow.report.renderers.diff_markdown import diff_to_markdown
+
+        return diff_to_markdown(self)
+
+
+def _stream_changes(a_list, b_list) -> list[StreamChange]:
+    """Diff two lists of Feed/Result summaries by name (T, P, per-species flow)."""
+    a_by = {s.name: s for s in (a_list or [])}
+    b_by = {s.name: s for s in (b_list or [])}
+    out: list[StreamChange] = []
+    for name in sorted(set(a_by) & set(b_by)):
+        sa, sb = a_by[name], b_by[name]
+        changes: list[ParamChange] = []
+        if _num_changed(sa.T, sb.T):
+            changes.append(ParamChange("T", f"{sa.T:.6g}", f"{sb.T:.6g}"))
+        if _num_changed(sa.P, sb.P):
+            changes.append(ParamChange("P", f"{sa.P:.6g}", f"{sb.P:.6g}"))
+        for sp in sorted(set(sa.flows) | set(sb.flows)):
+            va = sa.flows.get(sp, 0.0)
+            vb = sb.flows.get(sp, 0.0)
+            if _num_changed(va, vb):
+                changes.append(ParamChange(f"F_{sp}", f"{va:.6g}", f"{vb:.6g}"))
+        if changes:
+            out.append(StreamChange(stream=name, changes=changes))
+    return out
+
+
+def diff_reports(before: Report, after: Report) -> ReportDiff:
+    """Compute a :class:`ReportDiff` between two reports.
+
+    Args:
+        before: the baseline report.
+        after: the report to compare against the baseline.
+
+    Returns:
+        A :class:`ReportDiff`; use ``.is_empty`` to test for equivalence and
+        ``.to_markdown()`` to render.
+    """
+    diff = ReportDiff()
+
+    # Provenance (scalar fields).
+    pa, pb = before.provenance, after.provenance
+    for fname in (
+        "difflow_version", "jax_version", "jax_backend", "jax_x64",
+        "python_version", "platform", "git_commit", "git_dirty",
+    ):
+        va, vb = getattr(pa, fname, None), getattr(pb, fname, None)
+        if va != vb:
+            diff.provenance.append(ParamChange(fname, str(va), str(vb)))
+    for name in sorted(set(pa.plugin_versions) | set(pb.plugin_versions)):
+        va = pa.plugin_versions.get(name)
+        vb = pb.plugin_versions.get(name)
+        if va != vb:
+            diff.provenance.append(ParamChange(f"plugin:{name}", str(va), str(vb)))
+
+    # Units added / removed / param-changed.
+    a_units = {u.name: u for u in before.units}
+    b_units = {u.name: u for u in after.units}
+    diff.units_added = sorted(set(b_units) - set(a_units))
+    diff.units_removed = sorted(set(a_units) - set(b_units))
+    for name in sorted(set(a_units) & set(b_units)):
+        ua, ub = a_units[name], b_units[name]
+        a_params = {p.name: p.value_repr for p in ua.parameters}
+        b_params = {p.name: p.value_repr for p in ub.parameters}
+        changes: list[ParamChange] = []
+        for pname in sorted(set(a_params) | set(b_params)):
+            va = a_params.get(pname, "(absent)")
+            vb = b_params.get(pname, "(absent)")
+            if va != vb:
+                changes.append(ParamChange(pname, va, vb))
+        if changes:
+            diff.unit_param_changes.append(UnitParamChanges(unit=name, changes=changes))
+
+    # Feed and result streams.
+    diff.feed_changes = _stream_changes(before.feeds, after.feeds)
+    diff.result_changes = _stream_changes(before.results, after.results)
+
+    # Objective (section G).
+    oa, ob = before.optimization, after.optimization
+    if oa is not None and ob is not None:
+        if oa.objective_name != ob.objective_name:
+            diff.objective_changes.append(
+                ParamChange("name", oa.objective_name, ob.objective_name)
+            )
+        if _num_changed(oa.objective_value, ob.objective_value):
+            diff.objective_changes.append(
+                ParamChange(
+                    "value",
+                    f"{oa.objective_value:.6g}",
+                    f"{ob.objective_value:.6g}",
+                )
+            )
+        a_vars = {v.name: v for v in oa.variables}
+        b_vars = {v.name: v for v in ob.variables}
+        for vname in sorted(set(a_vars) & set(b_vars)):
+            va, vb = a_vars[vname].value, b_vars[vname].value
+            if _num_changed(va, vb):
+                diff.objective_changes.append(
+                    ParamChange(f"var:{vname}", f"{va:.6g}", f"{vb:.6g}")
+                )
+    elif (oa is None) != (ob is None):
+        diff.objective_changes.append(
+            ParamChange(
+                "optimization",
+                "absent" if oa is None else oa.objective_name,
+                "absent" if ob is None else ob.objective_name,
+            )
+        )
+
+    return diff

--- a/src/difflow/report/ir.py
+++ b/src/difflow/report/ir.py
@@ -129,6 +129,79 @@ class BalanceCheck:
 
 
 @dataclass
+class DecisionVariable:
+    """A decision variable of an optimization study (report section G).
+
+    Attributes:
+        name: variable name (matches a key of the design point dict).
+        value: value at the reported design point (typically the optimum).
+        lower: lower bound, if one was supplied.
+        upper: upper bound, if one was supplied.
+        gradient: objective gradient ``dJ/dx`` at the design point, if it
+            could be computed by automatic differentiation.
+        elasticity: normalized sensitivity ``(dJ/dx)(x/J)`` at the design
+            point, if both the gradient and a non-zero objective are known.
+    """
+
+    name: str
+    value: float
+    lower: float | None = None
+    upper: float | None = None
+    gradient: float | None = None
+    elasticity: float | None = None
+
+
+@dataclass
+class TornadoRow:
+    """One-at-a-time swing of the objective over a variable's bounds.
+
+    Attributes:
+        variable: decision-variable name.
+        low_value: variable value at the low end (its lower bound).
+        high_value: variable value at the high end (its upper bound).
+        low_output: objective with the variable at ``low_value`` and all
+            others held at the design point.
+        high_output: objective with the variable at ``high_value``.
+        swing: ``abs(high_output - low_output)`` — the tornado bar length.
+    """
+
+    variable: str
+    low_value: float
+    high_value: float
+    low_output: float
+    high_output: float
+    swing: float
+
+
+@dataclass
+class OptimizationReport:
+    """Optimization / sensitivity summary for a flowsheet (report section G).
+
+    Attributes:
+        objective_name: human-readable name of the objective (e.g.
+            "Levelized cost of capture").
+        objective_value: objective value at the design point.
+        objective_units: units of the objective, if any.
+        objective_source: where the objective is defined (function name,
+            module path, or a free-text description).
+        sense: "minimize" or "maximize".
+        variables: per-decision-variable rows (value, bounds, gradient).
+        tornado: one-at-a-time swings sorted by decreasing magnitude, or
+            ``None`` when no bounds were supplied.
+        notes: free-form notes attached to the study.
+    """
+
+    objective_name: str
+    objective_value: float
+    objective_units: str = ""
+    objective_source: str = ""
+    sense: str = "minimize"
+    variables: list[DecisionVariable] = field(default_factory=list)
+    tornado: list[TornadoRow] | None = None
+    notes: list[str] = field(default_factory=list)
+
+
+@dataclass
 class Report:
     """Full self-documenting report for a flowsheet."""
 
@@ -139,6 +212,7 @@ class Report:
     feeds: list[FeedSummary]
     results: list[ResultSummary] | None = None
     balance_checks: list[BalanceCheck] | None = None
+    optimization: OptimizationReport | None = None
     notes: list[str] = field(default_factory=list)
 
     def to_markdown(self) -> str:

--- a/src/difflow/report/ir.py
+++ b/src/difflow/report/ir.py
@@ -96,6 +96,10 @@ class SpeciesRow:
     antoine_coeffs: tuple | None = None
     Hf: float | None = None
     source: str = ""
+    #: True/False when database access was instrumented during the solve
+    #: (see :func:`difflow.database.track_database_access`); ``None`` when
+    #: access was not tracked.
+    accessed: bool | None = None
 
 
 @dataclass
@@ -126,6 +130,29 @@ class BalanceCheck:
     feed_total: float
     outlet_total: float
     residual: float
+
+
+@dataclass
+class ConvergenceInfo:
+    """Recycle-loop convergence diagnostics for a solved flowsheet.
+
+    Attributes:
+        method: the acceleration method of the solve ("anderson",
+            "wegstein", "damped", or "direct" for a recycle-free
+            sequential solve).
+        iterations: tear iterations taken (0 for a direct solve).
+        residual: final tear residual (max abs change between iterates).
+        tolerance: convergence tolerance requested of the solve.
+        converged: whether the solve met its tolerance.
+        tear_streams: recycle-destination (tear) stream names.
+    """
+
+    method: str
+    iterations: int | None = None
+    residual: float | None = None
+    tolerance: float | None = None
+    converged: bool | None = None
+    tear_streams: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -212,8 +239,19 @@ class Report:
     feeds: list[FeedSummary]
     results: list[ResultSummary] | None = None
     balance_checks: list[BalanceCheck] | None = None
+    convergence: ConvergenceInfo | None = None
     optimization: OptimizationReport | None = None
     notes: list[str] = field(default_factory=list)
+
+    def diff(self, other: "Report") -> "ReportDiff":
+        """Return a structured diff of this report against ``other``.
+
+        Thin wrapper around :func:`difflow.report.diff.diff_reports`; the
+        receiver is the "before" report and ``other`` the "after".
+        """
+        from difflow.report.diff import diff_reports
+
+        return diff_reports(self, other)
 
     def to_markdown(self) -> str:
         from difflow.report.renderers.markdown import to_markdown

--- a/src/difflow/report/renderers/diff_markdown.py
+++ b/src/difflow/report/renderers/diff_markdown.py
@@ -1,0 +1,70 @@
+"""Markdown renderer for :class:`~difflow.report.diff.ReportDiff`."""
+
+from __future__ import annotations
+
+from io import StringIO
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from difflow.report.diff import ReportDiff
+
+
+def _table(header: list[str], rows: list[list[str]]) -> str:
+    lines = ["| " + " | ".join(header) + " |"]
+    lines.append("| " + " | ".join(["---"] * len(header)) + " |")
+    for row in rows:
+        lines.append("| " + " | ".join(row) + " |")
+    return "\n".join(lines)
+
+
+def diff_to_markdown(diff: "ReportDiff") -> str:
+    """Render a :class:`ReportDiff` as Markdown."""
+    out = StringIO()
+    w = out.write
+    w("# Report Diff\n\n")
+
+    if diff.is_empty:
+        w("No differences in the compared sections.\n")
+        return out.getvalue()
+
+    if diff.provenance:
+        w("## Provenance\n\n")
+        w(_table(["field", "before", "after"],
+                 [[c.name, c.before, c.after] for c in diff.provenance]))
+        w("\n\n")
+
+    if diff.units_added or diff.units_removed:
+        w("## Units\n\n")
+        if diff.units_added:
+            w(f"- Added: {', '.join(diff.units_added)}\n")
+        if diff.units_removed:
+            w(f"- Removed: {', '.join(diff.units_removed)}\n")
+        w("\n")
+
+    if diff.unit_param_changes:
+        w("## Parameter Changes\n\n")
+        for uc in diff.unit_param_changes:
+            w(f"### {uc.unit}\n\n")
+            w(_table(["parameter", "before", "after"],
+                     [[c.name, c.before, c.after] for c in uc.changes]))
+            w("\n\n")
+
+    for title, changes in (
+        ("Feed Changes", diff.feed_changes),
+        ("Result Changes", diff.result_changes),
+    ):
+        if changes:
+            w(f"## {title}\n\n")
+            for sc in changes:
+                w(f"### {sc.stream}\n\n")
+                w(_table(["quantity", "before", "after"],
+                         [[c.name, c.before, c.after] for c in sc.changes]))
+                w("\n\n")
+
+    if diff.objective_changes:
+        w("## Optimization\n\n")
+        w(_table(["field", "before", "after"],
+                 [[c.name, c.before, c.after] for c in diff.objective_changes]))
+        w("\n\n")
+
+    return out.getvalue()

--- a/src/difflow/report/renderers/html.py
+++ b/src/difflow/report/renderers/html.py
@@ -178,5 +178,50 @@ def to_html(report: Report, embed_diagram: bool = True) -> str:
         ]
         w(_table(["species", "feed total", "outlet total", "residual"], rows))
 
+    if report.optimization is not None:
+        o = report.optimization
+        w("<h2>Optimization and Sensitivity</h2>\n")
+        units = f" {o.objective_units}" if o.objective_units else ""
+        w(
+            f"<p><b>Objective:</b> {escape(o.objective_name)} ({escape(o.sense)}); "
+            f"value = {o.objective_value:.6g}{escape(units)}</p>\n"
+        )
+        if o.objective_source:
+            w(f"<p><b>Source:</b> <code>{escape(o.objective_source)}</code></p>\n")
+
+        rows = []
+        for v in o.variables:
+            bounds = (
+                f"[{v.lower:.4g}, {v.upper:.4g}]"
+                if v.lower is not None and v.upper is not None
+                else "-"
+            )
+            rows.append([
+                v.name,
+                f"{v.value:.6g}",
+                bounds,
+                "-" if v.gradient is None else f"{v.gradient:.4g}",
+                "-" if v.elasticity is None else f"{v.elasticity:.4g}",
+            ])
+        w("<h3>Decision variables</h3>\n")
+        w(_table(["variable", "value", "bounds", "dJ/dx", "elasticity"], rows))
+
+        if o.tornado:
+            trows = [
+                [
+                    t.variable,
+                    f"{t.low_value:.4g}",
+                    f"{t.high_value:.4g}",
+                    f"{t.low_output:.6g}",
+                    f"{t.high_output:.6g}",
+                    f"{t.swing:.4g}",
+                ]
+                for t in o.tornado
+            ]
+            w("<h3>Sensitivity tornado</h3>\n")
+            w(_table(
+                ["variable", "low", "high", "J(low)", "J(high)", "swing"], trows
+            ))
+
     w("</body></html>\n")
     return out.getvalue()

--- a/src/difflow/report/renderers/html.py
+++ b/src/difflow/report/renderers/html.py
@@ -42,6 +42,7 @@ table { border-collapse: collapse; margin: 1em 0; }
 th, td { border: 1px solid #ddd; padding: 4px 10px; text-align: left; }
 th { background: #f5f5f5; }
 .eq { margin: 0.25em 0; }
+.diagram { overflow-x: auto; margin: 1em 0; }
 """
 
 
@@ -103,6 +104,15 @@ def to_html(report: Report, embed_diagram: bool = True) -> str:
         rows = [[r.source_stream, r.dest_stream] for r in report.topology.recycles]
         w(_table(["source", "dest"], rows))
 
+    # Diagram (self-contained inline SVG built from the IR).
+    if embed_diagram:
+        from difflow.report.diagram import flowsheet_svg
+
+        svg = flowsheet_svg(report)
+        if svg:
+            w("<h3>Diagram</h3>\n")
+            w(f"<div class='diagram'>{svg}</div>\n")
+
     # Units
     w("<h2>Unit Operations</h2>\n")
     for u in report.units:
@@ -138,9 +148,13 @@ def to_html(report: Report, embed_diagram: bool = True) -> str:
 
     if report.species:
         w("<h2>Species and Thermophysical Data</h2>\n")
+        tracked = any(s.accessed is not None for s in report.species)
+        header = ["species", "MW (g/mol)", "Tc (K)", "Pc (Pa)", "omega", "Hf (J/mol)", "source"]
+        if tracked:
+            header.append("accessed")
         rows = []
         for s in report.species:
-            rows.append([
+            row = [
                 s.name,
                 "-" if s.MW is None else f"{s.MW:.4g}",
                 "-" if s.Tc is None else f"{s.Tc:.4g}",
@@ -148,11 +162,11 @@ def to_html(report: Report, embed_diagram: bool = True) -> str:
                 "-" if s.omega is None else f"{s.omega:.4g}",
                 "-" if s.Hf is None else f"{s.Hf:.4g}",
                 s.source or "-",
-            ])
-        w(_table(
-            ["species", "MW (g/mol)", "Tc (K)", "Pc (Pa)", "omega", "Hf (J/mol)", "source"],
-            rows,
-        ))
+            ]
+            if tracked:
+                row.append("yes" if s.accessed else "no")
+            rows.append(row)
+        w(_table(header, rows))
 
     if report.feeds:
         w("<h2>Feed Streams</h2>\n")
@@ -177,6 +191,19 @@ def to_html(report: Report, embed_diagram: bool = True) -> str:
             for b in report.balance_checks
         ]
         w(_table(["species", "feed total", "outlet total", "residual"], rows))
+
+    if report.convergence is not None:
+        c = report.convergence
+        w("<h2>Recycle Convergence</h2>\n")
+        conv_rows = [
+            ["method", c.method],
+            ["tear streams", ", ".join(c.tear_streams) or "(none)"],
+            ["iterations", "-" if c.iterations is None else str(c.iterations)],
+            ["residual", "-" if c.residual is None else f"{c.residual:.3g}"],
+            ["tolerance", "-" if c.tolerance is None else f"{c.tolerance:.3g}"],
+            ["converged", {True: "yes", False: "no", None: "-"}[c.converged]],
+        ]
+        w(_table(["field", "value"], conv_rows))
 
     if report.optimization is not None:
         o = report.optimization

--- a/src/difflow/report/renderers/latex.py
+++ b/src/difflow/report/renderers/latex.py
@@ -142,4 +142,53 @@ def to_latex(report: Report) -> str:
         w(_tabular(["species", "feed total", "outlet total", "residual"], rows))
         w("\n\n")
 
+    if report.optimization is not None:
+        o = report.optimization
+        w(r"\subsection*{Optimization and Sensitivity}" + "\n")
+        units = f" {o.objective_units}" if o.objective_units else ""
+        w(
+            _esc(f"Objective: {o.objective_name} ({o.sense}); ")
+            + f"value $= {o.objective_value:.6g}$"
+            + _esc(units)
+            + ".\n\n"
+        )
+        if o.objective_source:
+            w(r"\textbf{Source.} \texttt{" + _esc(o.objective_source) + "}\n\n")
+
+        w(r"\textbf{Decision variables.}" + "\n\n")
+        rows = []
+        for v in o.variables:
+            bounds = (
+                f"[{v.lower:.4g}, {v.upper:.4g}]"
+                if v.lower is not None and v.upper is not None
+                else "-"
+            )
+            rows.append([
+                v.name,
+                f"{v.value:.6g}",
+                bounds,
+                "-" if v.gradient is None else f"{v.gradient:.4g}",
+                "-" if v.elasticity is None else f"{v.elasticity:.4g}",
+            ])
+        w(_tabular(["variable", "value", "bounds", "dJ/dx", "elasticity"], rows))
+        w("\n\n")
+
+        if o.tornado:
+            w(r"\textbf{Sensitivity tornado.}" + "\n\n")
+            trows = [
+                [
+                    t.variable,
+                    f"{t.low_value:.4g}",
+                    f"{t.high_value:.4g}",
+                    f"{t.low_output:.6g}",
+                    f"{t.high_output:.6g}",
+                    f"{t.swing:.4g}",
+                ]
+                for t in o.tornado
+            ]
+            w(_tabular(
+                ["variable", "low", "high", "J(low)", "J(high)", "swing"], trows
+            ))
+            w("\n\n")
+
     return out.getvalue()

--- a/src/difflow/report/renderers/latex.py
+++ b/src/difflow/report/renderers/latex.py
@@ -98,9 +98,13 @@ def to_latex(report: Report) -> str:
 
     if report.species:
         w(r"\subsection*{Species and Thermophysical Data}" + "\n")
+        tracked = any(s.accessed is not None for s in report.species)
+        header = ["species", "MW (g/mol)", "Tc (K)", "Pc (Pa)", "omega", "Hf (J/mol)", "source"]
+        if tracked:
+            header.append("accessed")
         rows = []
         for s in report.species:
-            rows.append([
+            row = [
                 s.name,
                 "-" if s.MW is None else f"{s.MW:.4g}",
                 "-" if s.Tc is None else f"{s.Tc:.4g}",
@@ -108,11 +112,11 @@ def to_latex(report: Report) -> str:
                 "-" if s.omega is None else f"{s.omega:.4g}",
                 "-" if s.Hf is None else f"{s.Hf:.4g}",
                 s.source or "-",
-            ])
-        w(_tabular(
-            ["species", "MW (g/mol)", "Tc (K)", "Pc (Pa)", "omega", "Hf (J/mol)", "source"],
-            rows,
-        ))
+            ]
+            if tracked:
+                row.append("yes" if s.accessed else "no")
+            rows.append(row)
+        w(_tabular(header, rows))
         w("\n\n")
 
     if report.feeds:
@@ -140,6 +144,20 @@ def to_latex(report: Report) -> str:
             for b in report.balance_checks
         ]
         w(_tabular(["species", "feed total", "outlet total", "residual"], rows))
+        w("\n\n")
+
+    if report.convergence is not None:
+        c = report.convergence
+        w(r"\subsection*{Recycle Convergence}" + "\n")
+        conv_rows = [
+            ["method", c.method],
+            ["tear streams", ", ".join(c.tear_streams) or "(none)"],
+            ["iterations", "-" if c.iterations is None else str(c.iterations)],
+            ["residual", "-" if c.residual is None else f"{c.residual:.3g}"],
+            ["tolerance", "-" if c.tolerance is None else f"{c.tolerance:.3g}"],
+            ["converged", {True: "yes", False: "no", None: "-"}[c.converged]],
+        ]
+        w(_tabular(["field", "value"], conv_rows))
         w("\n\n")
 
     if report.optimization is not None:

--- a/src/difflow/report/renderers/markdown.py
+++ b/src/difflow/report/renderers/markdown.py
@@ -160,6 +160,61 @@ def to_markdown(report: Report) -> str:
         w(_table(["species", "feed total", "outlet total", "residual"], rows))
         w("\n\n")
 
+    # --- Optimization / sensitivity (section G)
+    if report.optimization is not None:
+        o = report.optimization
+        w("## Optimization and Sensitivity\n\n")
+        units = f" {o.objective_units}" if o.objective_units else ""
+        w(f"- Objective: {o.objective_name} ({o.sense})\n")
+        w(f"- Value at design point: {o.objective_value:.6g}{units}\n")
+        if o.objective_source:
+            w(f"- Source: `{o.objective_source}`\n")
+        w("\n")
+
+        w("**Decision variables**\n\n")
+        rows = []
+        for v in o.variables:
+            bounds = (
+                f"[{v.lower:.4g}, {v.upper:.4g}]"
+                if v.lower is not None and v.upper is not None
+                else "-"
+            )
+            rows.append([
+                v.name,
+                f"{v.value:.6g}",
+                bounds,
+                "-" if v.gradient is None else f"{v.gradient:.4g}",
+                "-" if v.elasticity is None else f"{v.elasticity:.4g}",
+            ])
+        w(_table(
+            ["variable", "value", "bounds", "dJ/dx", "elasticity"], rows
+        ))
+        w("\n\n")
+
+        if o.tornado:
+            w("**Sensitivity tornado** (objective swing over each bound)\n\n")
+            trows = [
+                [
+                    t.variable,
+                    f"{t.low_value:.4g}",
+                    f"{t.high_value:.4g}",
+                    f"{t.low_output:.6g}",
+                    f"{t.high_output:.6g}",
+                    f"{t.swing:.4g}",
+                ]
+                for t in o.tornado
+            ]
+            w(_table(
+                ["variable", "low", "high", "J(low)", "J(high)", "swing"],
+                trows,
+            ))
+            w("\n\n")
+
+        if o.notes:
+            for n in o.notes:
+                w(f"- {n}\n")
+            w("\n")
+
     if report.notes:
         w("## Notes\n\n")
         for n in report.notes:

--- a/src/difflow/report/renderers/markdown.py
+++ b/src/difflow/report/renderers/markdown.py
@@ -109,9 +109,13 @@ def to_markdown(report: Report) -> str:
     # --- Species table
     if report.species:
         w("## Species and Thermophysical Data\n\n")
+        tracked = any(s.accessed is not None for s in report.species)
+        header = ["species", "MW (g/mol)", "Tc (K)", "Pc (Pa)", "ω", "Hf (J/mol)", "source"]
+        if tracked:
+            header.append("accessed")
         rows = []
         for s in report.species:
-            rows.append([
+            row = [
                 s.name,
                 "-" if s.MW is None else f"{s.MW:.4g}",
                 "-" if s.Tc is None else f"{s.Tc:.4g}",
@@ -119,11 +123,11 @@ def to_markdown(report: Report) -> str:
                 "-" if s.omega is None else f"{s.omega:.4g}",
                 "-" if s.Hf is None else f"{s.Hf:.4g}",
                 s.source or "-",
-            ])
-        w(_table(
-            ["species", "MW (g/mol)", "Tc (K)", "Pc (Pa)", "ω", "Hf (J/mol)", "source"],
-            rows,
-        ))
+            ]
+            if tracked:
+                row.append("yes" if s.accessed else "no")
+            rows.append(row)
+        w(_table(header, rows))
         w("\n\n")
 
     # --- Feeds
@@ -159,6 +163,22 @@ def to_markdown(report: Report) -> str:
         ]
         w(_table(["species", "feed total", "outlet total", "residual"], rows))
         w("\n\n")
+
+    # --- Recycle convergence (section F)
+    if report.convergence is not None:
+        c = report.convergence
+        w("## Recycle Convergence\n\n")
+        w(f"- Method: {c.method}\n")
+        w(f"- Tear streams: {', '.join(c.tear_streams) or '(none)'}\n")
+        if c.iterations is not None:
+            w(f"- Iterations: {c.iterations}\n")
+        if c.residual is not None:
+            w(f"- Final residual: {c.residual:.3g}\n")
+        if c.tolerance is not None:
+            w(f"- Tolerance: {c.tolerance:.3g}\n")
+        if c.converged is not None:
+            w(f"- Converged: {'yes' if c.converged else 'no'}\n")
+        w("\n")
 
     # --- Optimization / sensitivity (section G)
     if report.optimization is not None:

--- a/tests/snapshots/report_canonical.md
+++ b/tests/snapshots/report_canonical.md
@@ -1,0 +1,92 @@
+# Flowsheet Report
+
+## Topology
+
+- Units: split
+- Species order: methane, ethane
+
+**Connections**
+
+| stream | source | target |
+| --- | --- | --- |
+| feed | (feed) | split |
+
+## Unit Operations
+
+### split — Splitter (core)
+
+Simple stream splitter (no phase equilibrium).
+
+**Inlets:** feed  
+**Outlets:** top, bot
+
+**Governing equations**
+
+- $$F_{i,k}^{\mathrm{out}} = \phi_k\, F_{i}^{\mathrm{in}}\qquad \sum_k \phi_k = 1$$
+- $$T^{\mathrm{out}} = T^{\mathrm{in}},\quad P^{\mathrm{out}} = P^{\mathrm{in}}$$
+
+**Assumptions**
+
+- No phase change; each outlet has the same composition as the inlet.
+- Isothermal, isobaric split.
+
+**References**
+
+- Seider, Seader, Lewin, Widagdo. Product & Process Design Principles, 4e.
+
+## Species and Thermophysical Data
+
+| species | MW (g/mol) | Tc (K) | Pc (Pa) | ω | Hf (J/mol) | source |
+| --- | --- | --- | --- | --- | --- | --- |
+| methane | 16.04 | 190.6 | 4.599e+06 | 0.011 | -7.487e+04 | NIST Chemistry WebBook; Perry's 9e; Yaws; DIPPR 801 |
+| ethane | 30.07 | 305.3 | 4.872e+06 | 0.099 | -8.4e+04 | NIST Chemistry WebBook; Perry's 9e; Yaws; DIPPR 801 |
+
+## Feed Streams
+
+### feed
+
+- T = 300 K
+- P = 1.013e+05 Pa
+
+| species | F (mol/s) |
+| --- | --- |
+| methane | 1 |
+| ethane | 0.5 |
+
+## Solved Streams
+
+### top
+
+- T = 300 K
+- P = 1.013e+05 Pa
+
+| species | F (mol/s) |
+| --- | --- |
+| methane | 0.6 |
+| ethane | 0.3 |
+
+### bot
+
+- T = 300 K
+- P = 1.013e+05 Pa
+
+| species | F (mol/s) |
+| --- | --- |
+| methane | 0.4 |
+| ethane | 0.2 |
+
+## Mass Balance Closure
+
+| species | feed total | outlet total | residual |
+| --- | --- | --- | --- |
+| methane | 1 | 1 | +0 |
+| ethane | 0.5 | 0.5 | +0 |
+
+## Recycle Convergence
+
+- Method: direct
+- Tear streams: (none)
+- Iterations: 0
+- Final residual: 0
+- Tolerance: 1e-08
+- Converged: yes

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -8,7 +8,14 @@ import jax.numpy as jnp
 import pytest
 
 import difflow
-from difflow import Flowsheet, Splitter, Unit, __version__, build_report
+from difflow import (
+    Flowsheet,
+    Splitter,
+    Unit,
+    __version__,
+    build_optimization_report,
+    build_report,
+)
 from difflow.plugins import load_plugins, registry
 from difflow.report import get_metadata
 from difflow.streams import make_stream
@@ -137,6 +144,95 @@ def test_report_round_trip_through_json():
         if s["name"] in {"methane", "ethane"}:
             assert s["source"]
             assert s["Tc"] is not None
+
+
+def _quadratic_objective(d):
+    # Minimum at V=2.0, reflux=1.5; J* = 0. dJ/dV = 2(V-2), dJ/dreflux = 4(r-1.5).
+    return (d["V"] - 2.0) ** 2 + 2.0 * (d["reflux"] - 1.5) ** 2
+
+
+def test_build_optimization_report_gradient_and_tornado():
+    opt = build_optimization_report(
+        _quadratic_objective,
+        design_point={"V": 2.0, "reflux": 1.5},
+        bounds={"V": (1.0, 3.0), "reflux": (0.5, 2.5)},
+        objective_name="Test cost",
+        objective_units="USD",
+        sense="minimize",
+    )
+
+    assert opt.objective_name == "Test cost"
+    assert opt.objective_units == "USD"
+    assert opt.objective_value == pytest.approx(0.0, abs=1e-9)
+    # Source auto-derived from the callable.
+    assert "_quadratic_objective" in opt.objective_source
+
+    by_name = {v.name: v for v in opt.variables}
+    assert set(by_name) == {"V", "reflux"}
+    # At the optimum the gradient is ~0 for both variables.
+    assert by_name["V"].gradient == pytest.approx(0.0, abs=1e-6)
+    assert by_name["reflux"].gradient == pytest.approx(0.0, abs=1e-6)
+    assert by_name["V"].lower == 1.0 and by_name["V"].upper == 3.0
+
+    # Tornado present, sorted by decreasing swing.
+    assert opt.tornado is not None
+    swings = [t.swing for t in opt.tornado]
+    assert swings == sorted(swings, reverse=True)
+    # reflux (coeff 2, half-width 1.0 -> swing 0) vs V (coeff 1, half-width 1.0
+    # -> swing 0): both symmetric about optimum so J(low)==J(high) here.
+    for t in opt.tornado:
+        assert t.swing == pytest.approx(0.0, abs=1e-9)
+
+
+def test_build_optimization_report_gradient_off_optimum():
+    opt = build_optimization_report(
+        _quadratic_objective,
+        design_point={"V": 3.0, "reflux": 1.5},
+        objective_name="Test cost",
+    )
+    by_name = {v.name: v for v in opt.variables}
+    # dJ/dV = 2(V-2) = 2 at V=3.
+    assert by_name["V"].gradient == pytest.approx(2.0, rel=1e-5)
+    # Elasticity = (dJ/dx)(x/J) = 2 * 3 / 1 = 6.
+    assert by_name["V"].elasticity == pytest.approx(6.0, rel=1e-5)
+    # No bounds -> no tornado.
+    assert opt.tornado is None
+
+
+def test_report_includes_optimization_section_all_renderers():
+    fs = _make_simple_flowsheet()
+    opt = build_optimization_report(
+        _quadratic_objective,
+        design_point={"V": 3.0, "reflux": 1.5},
+        bounds={"V": (1.0, 3.0)},
+        objective_name="Test cost",
+    )
+    rep = fs.report(include_git=False, optimization=opt)
+
+    assert rep.optimization is opt
+
+    md = rep.to_markdown()
+    assert "Optimization and Sensitivity" in md
+    assert "Test cost" in md
+
+    data = json.loads(rep.to_json())
+    assert data["optimization"]["objective_name"] == "Test cost"
+    assert {v["name"] for v in data["optimization"]["variables"]} == {"V", "reflux"}
+
+    html = rep.to_html()
+    assert "Optimization and Sensitivity" in html
+
+    tex = rep.to_latex()
+    assert "Optimization and Sensitivity" in tex
+
+
+def test_report_without_optimization_omits_section():
+    fs = _make_simple_flowsheet()
+    rep = fs.report(include_git=False)
+    assert rep.optimization is None
+    assert "Optimization and Sensitivity" not in rep.to_markdown()
+    data = json.loads(rep.to_json())
+    assert data["optimization"] is None
 
 
 def test_cli_markdown_roundtrip(tmp_path, capsys):

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -15,9 +15,12 @@ from difflow import (
     __version__,
     build_optimization_report,
     build_report,
+    diff_reports,
+    track_database_access,
 )
+from difflow.database import get_critical_props
 from difflow.plugins import load_plugins, registry
-from difflow.report import get_metadata
+from difflow.report import flowsheet_svg, get_metadata
 from difflow.streams import make_stream
 
 
@@ -233,6 +236,223 @@ def test_report_without_optimization_omits_section():
     assert "Optimization and Sensitivity" not in rep.to_markdown()
     data = json.loads(rep.to_json())
     assert data["optimization"] is None
+
+
+class _AffineRecycle:
+    """out = offset + slope * in (single species 'A'); contractive for |slope|<1."""
+
+    def __init__(self, offset: float, slope: float):
+        self.offset = offset
+        self.slope = slope
+
+    def __call__(self, inlet):
+        return make_stream(
+            {"A": self.offset + self.slope * inlet["F_A"]}, inlet["T"], inlet["P"]
+        )
+
+
+def _make_recycle_flowsheet() -> Flowsheet:
+    fs = Flowsheet(species_order=["A"], default_flow=1.0)
+    fs.add_feed("feed", make_stream({"A": 1.0}, 300.0, 1e5))
+    fs.add_unit(Unit("loop", _AffineRecycle(0.5, 0.5), ["tear"], ["loop_out"]))
+    fs.add_recycle("loop_out", "tear")
+    return fs
+
+
+# --- Section F: recycle convergence -----------------------------------------
+
+def test_convergence_direct_solve():
+    fs = _make_simple_flowsheet()
+    streams = fs.solve()
+    rep = fs.report(streams=streams, include_git=False)
+
+    assert rep.convergence is not None
+    assert rep.convergence.method == "direct"
+    assert rep.convergence.iterations == 0
+    assert rep.convergence.converged is True
+    assert rep.convergence.tear_streams == []
+    assert "Recycle Convergence" in rep.to_markdown()
+
+
+def test_convergence_recycle_solve():
+    fs = _make_recycle_flowsheet()
+    streams = fs.solve(acceleration="anderson", tol=1e-10)
+    rep = fs.report(streams=streams, include_git=False)
+
+    c = rep.convergence
+    assert c is not None
+    assert c.method == "anderson"
+    assert c.tear_streams == ["tear"]
+    assert c.converged is True
+    assert c.iterations is not None and c.iterations >= 0
+    assert c.residual is not None and c.residual < 1e-9
+    data = json.loads(rep.to_json())
+    assert data["convergence"]["method"] == "anderson"
+
+
+def test_convergence_absent_without_streams():
+    fs = _make_simple_flowsheet()
+    rep = fs.report(include_git=False)
+    assert rep.convergence is None
+    assert "Recycle Convergence" not in rep.to_markdown()
+
+
+# --- Section D upgrade: instrumented database access -------------------------
+
+def test_track_database_access_records_lookups():
+    with track_database_access() as tracker:
+        get_critical_props("methane")
+        get_critical_props("co2")  # alias -> carbon_dioxide
+    assert tracker.was_accessed("methane")
+    assert tracker.was_accessed("carbon_dioxide")
+    assert tracker.was_accessed("co2")  # alias resolves
+    assert not tracker.was_accessed("ethane")
+    assert "critical" in tracker.kinds("methane")
+
+
+def test_report_annotates_accessed_species():
+    fs = _make_simple_flowsheet()
+    with track_database_access() as tracker:
+        streams = fs.solve()
+        # Simulate a unit that consults the database for methane only.
+        get_critical_props("methane")
+    rep = fs.report(streams=streams, include_git=False, db_access=tracker)
+
+    by_name = {s.name: s for s in rep.species}
+    assert by_name["methane"].accessed is True
+    assert by_name["ethane"].accessed is False
+    md = rep.to_markdown()
+    assert "accessed" in md  # column shown only when tracked
+
+
+def test_report_species_accessed_none_when_untracked():
+    fs = _make_simple_flowsheet()
+    rep = fs.report(include_git=False)
+    assert all(s.accessed is None for s in rep.species)
+    # No 'accessed' column header when tracking was not used.
+    assert "accessed" not in rep.to_markdown()
+
+
+# --- v2: embedded diagram ----------------------------------------------------
+
+def test_flowsheet_svg_contains_units():
+    fs = _make_simple_flowsheet()
+    rep = fs.report(include_git=False)
+    svg = flowsheet_svg(rep)
+    assert svg.startswith("<svg")
+    assert "split" in svg
+    assert "feed" in svg
+    # Embedded in HTML by default.
+    assert "<svg" in rep.to_html()
+    # Suppressible.
+    assert "<svg" not in rep.to_html(embed_diagram=False)
+
+
+def test_flowsheet_svg_empty_for_no_units():
+    fs = Flowsheet(["methane"])
+    rep = fs.report(include_git=False)
+    assert flowsheet_svg(rep) == ""
+
+
+# --- v2: report diff ---------------------------------------------------------
+
+def _make_gain_flowsheet(gain: float) -> Flowsheet:
+    from dataclasses import dataclass
+
+    from difflow.params_mixin import ParamsMixin
+
+    @dataclass
+    class _GainParams(ParamsMixin):
+        gain: float = 1.0
+
+    class _GainUnit:
+        symbol = "Gain"
+        equations = [r"F^\mathrm{out} = g\, F^\mathrm{in}"]
+        references = ["test"]
+
+        def __init__(self, g: float):
+            self.params = _GainParams(gain=g)
+
+        def __call__(self, inlet):
+            return make_stream(
+                {"A": self.params.gain * inlet["F_A"]}, inlet["T"], inlet["P"]
+            )
+
+    fs = Flowsheet(species_order=["A"], default_flow=1.0)
+    fs.add_feed("feed", make_stream({"A": 1.0}, 300.0, 1e5))
+    fs.add_unit(Unit("gain", _GainUnit(gain), ["feed"], ["out"]))
+    return fs
+
+
+def test_report_diff_detects_param_and_result_changes():
+    fs1 = _make_gain_flowsheet(1.0)
+    rep1 = fs1.report(streams=fs1.solve(), include_git=False)
+
+    fs2 = _make_gain_flowsheet(2.0)
+    rep2 = fs2.report(streams=fs2.solve(), include_git=False)
+
+    d = rep1.diff(rep2)
+    assert not d.is_empty
+    # gain param change captured on the "gain" unit.
+    changes = {uc.unit: uc for uc in d.unit_param_changes}
+    assert "gain" in changes
+    names = {c.name for c in changes["gain"].changes}
+    assert "gain" in names
+    # Result stream "out" changed (1.0 -> 2.0).
+    assert {sc.stream for sc in d.result_changes} == {"out"}
+    md = d.to_markdown()
+    assert "# Report Diff" in md and "gain" in md
+
+
+def test_report_diff_empty_for_identical():
+    fs = _make_simple_flowsheet()
+    s = fs.solve()
+    rep = fs.report(streams=s, include_git=False)
+    d = diff_reports(rep, rep)
+    assert d.is_empty
+    assert "No differences" in d.to_markdown()
+
+
+# --- v2: markdown snapshot regression ---------------------------------------
+
+def _redact_provenance(md: str) -> str:
+    """Drop the volatile Provenance section (timestamp, versions, platform)."""
+    out, skip = [], False
+    for line in md.splitlines():
+        if line.startswith("## Provenance"):
+            skip = True
+            continue
+        if skip and line.startswith("## "):
+            skip = False
+        if not skip:
+            out.append(line)
+    return "\n".join(out).rstrip() + "\n"
+
+
+def test_markdown_snapshot_regression():
+    """The canonical flowsheet's Markdown must not drift unexpectedly.
+
+    Regenerate the snapshot with::
+
+        DIFFLOW_UPDATE_SNAPSHOTS=1 pytest tests/test_report.py -k snapshot
+    """
+    import os
+    from pathlib import Path
+
+    fs = _make_simple_flowsheet()
+    streams = fs.solve()
+    current = _redact_provenance(
+        fs.report(streams=streams, include_git=False).to_markdown()
+    )
+
+    snap = Path(__file__).parent / "snapshots" / "report_canonical.md"
+    if os.environ.get("DIFFLOW_UPDATE_SNAPSHOTS"):
+        snap.write_text(current)
+    expected = snap.read_text()
+    assert current == expected, (
+        "Canonical report Markdown drifted. If intentional, regenerate with "
+        "DIFFLOW_UPDATE_SNAPSHOTS=1 pytest -k snapshot."
+    )
 
 
 def test_cli_markdown_roundtrip(tmp_path, capsys):


### PR DESCRIPTION
Closes #162.

Completes the remaining scope of the self-documenting flowsheet report feature — the optimization/sensitivity section (G) and the full v2 tail — so every section A–G in the issue is now implemented across all four renderers, with the issue's verification tests in place.

## What's added

### Section G — optimization / sensitivity
`build_optimization_report(objective, design_point, bounds=...)` captures, for a design point a solver produced:
- objective value, name, units, and auto-derived source;
- per-decision-variable **gradients via `jax.grad`** (over the decision-variable pytree) plus elasticities — guarded, so a non-differentiable objective still renders with `None` gradients;
- a **sensitivity tornado** (objective swing over each variable's bounds, sorted by magnitude).

Threaded through `build_report`, `report()`, and `fs.report(optimization=...)`.

### Recycle convergence (section F)
`Flowsheet.solve` records `last_solve_{method,iterations,residual,tolerance,converged,tear_streams}` across the Anderson, Wegstein, damped, and direct paths. The report gains a `ConvergenceInfo` section.

### Instrumented database-access tracking (section D upgrade)
`track_database_access()` context manager records exactly which species/property lookups a solve makes (re-entrant, alias-aware). `build_report(db_access=tracker)` annotates each species row with an `accessed` flag; renderers show the "accessed" column only when tracking was used — the precise-provenance upgrade over the static species dump.

### Embedded HTML diagram
New `report/diagram.py` renders a **self-contained inline SVG** (layered left-to-right layout; feeds, units, products; dashed recycle arcs) built purely from the IR — no ipycytoscape, no CDN, no network. Wired into `to_html(embed_diagram=...)`, previously a no-op.

### `report.diff()`
New `report/diff.py` with `ReportDiff` / `diff_reports()` / `Report.diff(other)`, comparing provenance, units added/removed, per-unit parameter changes, feed/result stream changes, and objective changes, with a Markdown renderer.

### Verification tests
- Markdown **snapshot regression** test on a canonical flowsheet (provenance redacted; regenerate with `DIFFLOW_UPDATE_SNAPSHOTS=1`).
- JSON round-trip test (already present) plus new tests for every item above.

All four renderers (JSON/Markdown/HTML/LaTeX) updated for the new sections; JSON is automatic via `asdict`. New sections are omitted when their inputs are absent, so existing reports are unchanged.

## Files
- `src/difflow/report/ir.py` — `ConvergenceInfo`, `DecisionVariable`, `TornadoRow`, `OptimizationReport`; `Report.convergence`/`optimization` fields; `SpeciesRow.accessed`; `Report.diff()`.
- `src/difflow/report/builder.py` — `build_optimization_report`, `_convergence_info`, `db_access` wiring.
- `src/difflow/report/diagram.py`, `report/diff.py`, `report/renderers/diff_markdown.py` — new.
- `src/difflow/report/renderers/{markdown,latex,html}.py` — render sections F/G, accessed column, embedded SVG.
- `src/difflow/flowsheet.py` — convergence attributes + `report(optimization=, db_access=)`.
- `src/difflow/database.py` — `track_database_access` / `DatabaseAccessTracker`.
- `src/difflow/__init__.py`, `report/__init__.py` — exports.
- `tests/test_report.py`, `tests/snapshots/report_canonical.md` — tests + snapshot.

## Testing
Full suite: **1210 passed, 2 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012dn72Pt9yXjdLWeKhU1JD7

---
_Generated by [Claude Code](https://claude.ai/code/session_012dn72Pt9yXjdLWeKhU1JD7)_