### PR TITLE
feat: add data reconciliation, demonstrated on gas networks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,7 @@ difflow/
 │   │   ├── database.py    # Species property database
 │   │   ├── flowsheet.py   # Flowsheet with recycle solving
 │   │   ├── uncertainty.py # Sensitivity & UQ
+│   ├── reconciliation/ # Data reconciliation, gross error detection, observability
 │   │   ├── params_mixin.py # ParamsMixin base class for Params dataclasses
 │   │   ├── units/         # Steady-state unit operations
 │   │   ├── dynamic/       # Dynamic modeling (DAE)
@@ -255,6 +256,7 @@ class MyUnit:
 - Flowsheets: `GasNetworkFlowsheet` (signed-flow Anderson + damped differentiable tear solve), `build_network_flowsheet`
 - Physics: `weymouth_beta`, `resistor_xi`, `compressor_power`, `smoothed_power_w`, GasLib unit conversions
 - Verification: full equation-oriented residual checks (`difflow_gas.verify`)
+- Reconciliation: JAX-traceable residuals (`difflow_gas.residuals`) + `reconcile_network`
 - Gotchas encoded in docs: solve with `clip_negative_flows=False` (signed flows), damp the tear map (alpha ~ 0.3), pose optimization pressure constraints in squared pressure
 
 ### Debugging Gradients

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,7 +256,8 @@ class MyUnit:
 - Flowsheets: `GasNetworkFlowsheet` (signed-flow Anderson + damped differentiable tear solve), `build_network_flowsheet`
 - Physics: `weymouth_beta`, `resistor_xi`, `compressor_power`, `smoothed_power_w`, GasLib unit conversions
 - Verification: full equation-oriented residual checks (`difflow_gas.verify`)
-- Reconciliation: JAX-traceable residuals (`difflow_gas.residuals`) + `reconcile_network`
+- Equations: `difflow_gas.residuals.network_residuals` is the single JAX-traceable definition of the equation set; `verify` is the reporting layer over it
+- Reconciliation: `reconcile_network` (see `difflow.reconciliation`)
 - Gotchas encoded in docs: solve with `clip_negative_flows=False` (signed flows), damp the tear map (alpha ~ 0.3), pose optimization pressure constraints in squared pressure
 
 ### Debugging Gradients

--- a/README.md
+++ b/README.md
@@ -405,6 +405,30 @@ dW_dr = jax.grad(obj)({"cs_cs1.ratio": 1.3})
 Pipes, resistors, compressor stations, open valves, control valves and
 short pipes are supported; see `docs/unit-operations-gas.md`.
 
+## Data Reconciliation
+
+Plant measurements are noisy and, taken at face value, contradict the
+model. `difflow.reconciliation` finds the smallest statistically
+weighted adjustment that satisfies the model equations, and returns
+estimates sharper than the raw measurements:
+
+```python
+from difflow.reconciliation import reconcile, global_test, measurement_test
+
+res = reconcile(residual_fn, y, sigma, names=names)
+print(res.summary())           # measured vs reconciled, with standard errors
+global_test(res)               # is the data set consistent with the model?
+measurement_test(res)          # which sensor is lying?
+```
+
+An entry of `sigma` set to `inf` marks a variable to be *estimated*
+rather than reconciled, so joint parameter estimation and reconciliation
+are the same solve. Whether an unknown can be recovered at all is decided
+before solving, so an ill-posed problem raises a named error instead of
+returning `NaN`. Works with any differentiable residual function; see
+`docs/data-reconciliation.md` and
+`examples/28_data_reconciliation.ipynb` for the gas-network case.
+
 ## Thermodynamics
 
 ### Ideal Thermodynamics (for VLE)

--- a/_toc.yml
+++ b/_toc.yml
@@ -16,6 +16,7 @@ parts:
       - file: docs/thermodynamics
       - file: docs/technoeconomics
       - file: docs/parameter-estimation
+      - file: docs/data-reconciliation
       - file: docs/streams-and-flowsheets
       - file: docs/dynamic-modeling
       - file: docs/solvers-and-utilities

--- a/docs/data-reconciliation.md
+++ b/docs/data-reconciliation.md
@@ -1,0 +1,181 @@
+# Data Reconciliation
+
+## Overview
+
+Plant measurements are noisy, and taken at face value they contradict the model: nominations do not close, balances do not balance, pressure drops do not match flows. **Data reconciliation** finds the smallest statistically weighted adjustment to the measurements that makes them satisfy the model equations. Because the model carries information the sensors do not, the reconciled estimates are *more* precise than the raw measurements — often by a factor of two or three.
+
+`difflow.reconciliation` provides:
+
+- **Constrained weighted least squares** against any differentiable residual function $F(x, \theta) = 0$ — a flowsheet, a gas network, or an equation set you write yourself.
+- **Joint parameter estimation**: mark a variable unmeasured and it is *estimated* rather than reconciled, with a standard error, in the same solve.
+- **Covariance of the estimates**, from the inverse KKT matrix, and the sensitivity $\partial \hat x/\partial y$ by automatic differentiation.
+- **Gross error detection**: the global $\chi^2$ test, the measurement test, and serial elimination.
+- **Observability and redundancy classification**, run *before* the solve so an ill-posed problem raises a named error instead of returning `NaN`.
+- **Sensor placement**: what a proposed meter would buy, before anyone buys it.
+
+Everything that makes this work — the constraint Jacobian, the covariance, the sensitivities — is derivative information. A conventional flowsheet package hand-derives it per unit operation; a differentiable one gets it from `jax.jacobian`.
+
+The module is domain-agnostic. `difflow_gas.residuals` shows how a plugin supplies its equation set; see [`examples/28_data_reconciliation.ipynb`](../examples/28_data_reconciliation.ipynb) for the worked gas-network case.
+
+---
+
+## Mathematical Formulation
+
+### The problem
+
+$$\min_x \; (x - y)^T W (x - y) \quad \text{subject to} \quad F(x, \theta) = 0$$
+
+where $y$ are the measurements, $W = \operatorname{diag}(1/\sigma_i^2)$, and $F$ are the model equations. Entries with $\sigma_i = \infty$ get $W_{ii} = 0$: they are **estimated**, not reconciled. A *finite* $\sigma$ on an unmetered variable acts as a Bayesian prior, which is the graceful way to handle a weakly identified parameter.
+
+### The KKT system
+
+The first-order conditions are
+
+$$\begin{bmatrix} W & A^T \\ A & 0 \end{bmatrix} \begin{bmatrix} \Delta x \\ \lambda \end{bmatrix} = \begin{bmatrix} -W(x - y) \\ -F(x) \end{bmatrix}, \qquad A = \frac{\partial F}{\partial x},$$
+
+iterated to convergence. This is Gauss–Newton: it drops the $\sum_k \lambda_k \nabla^2 F_k$ term of the exact Newton Jacobian, which is where a pipe law's non-smooth $q|q|$ second derivative would enter. Exact gradients are recovered afterwards from one implicit-function-theorem correction that *does* use the full Jacobian, so `jax.grad` through `reconcile` is exact with respect to $y$, $\sigma$ and $\theta$.
+
+### Solvability is observability
+
+For $W \succeq 0$, the KKT matrix is nonsingular **iff** $A$ has full row rank and $Z^T W Z \succ 0$ on a basis $Z$ of $\ker A$. With $W$ diagonal and zero exactly on the unmeasured entries, the second condition collapses to
+
+> the unmeasured columns $A_U$ must have full column rank
+
+which is precisely the classical observability condition. `classify` runs this test first and raises `ReconciliationStructureError` naming the culprits.
+
+Two consequences worth knowing:
+
+- **Boundary flows must be state variables, not fixed parameters.** With them fixed, the node-balance block of $A$ is the incidence matrix, whose rank is only $n_{\text{nodes}} - 1$, and the KKT matrix is singular for purely structural reasons.
+- **Ranks come from `svd(A)`, never from the eigenvalues of $A^T A$.** Squaring the matrix squares its condition number, and a structurally zero singular value reappears near $\sqrt{\varepsilon}\,\sigma_{\max}$ — an unobservable system reported as full rank.
+
+### Covariance
+
+$$\Sigma_{\hat x} = [K^{-1}]_{11}$$
+
+For a fully measured problem this equals the textbook projection $\Sigma - \Sigma A^T (A\Sigma A^T)^{-1} A \Sigma$, but unlike it, it stays well defined when a variable is unmeasured — so the standard error of an estimated parameter comes from the same expression as the reconciled variance of a metered flow. The adjustment covariance is $\Sigma_{\text{adj}} = \Sigma - \Sigma_{\hat x}$.
+
+`measurement_sensitivity` computes $S = \partial \hat x/\partial y$ by differentiating the solver. For **linear** constraints $S \Sigma S^T = \Sigma_{\hat x}$ exactly. For nonlinear ones the two differ by the curvature term the covariance formula drops: they agree to machine precision when the data are consistent (the multipliers vanish) and diverge in proportion to how inconsistent the data are. The classical formula is itself a linearization; the discrepancy is a useful diagnostic of how nonlinear the model is over the range the adjustments span.
+
+### Scaling
+
+The KKT matrix mixes $W$ (units of 1/variable²) with $A$ (units of residual/variable), so its conditioning depends on the unit system — the same gas network posed in Pa and Pa² rather than bar and bar² is many orders worse conditioned, past what float64 resolves. Variables are scaled by $d_i = \sigma_i$, which makes the scaled weight matrix a 0/1 mask (so $1/\sigma^2$ is never evaluated and an infinite $\sigma$ cannot produce a `NaN`), and residual rows are equilibrated to unit 2-norm. This is on by default; pass `scaling=False` only to observe what it prevents.
+
+### Gross error detection
+
+The **global test** statistic is the optimal objective itself, distributed $\chi^2$ on the degrees of redundancy $m - \operatorname{rank}(A_U)$. The often-quoted form $F(y)^T (A\Sigma A^T)^{-1} F(y)$ is a special case that cannot be evaluated at all when a variable is unmeasured, and carries the wrong degrees of freedom.
+
+The **measurement test** standardizes each adjustment, $z_i = (\hat x_i - y_i)/\sqrt{\Sigma_{\text{adj},ii}}$, which is standard normal under the null hypothesis. A measurement nothing checks has $\Sigma_{\text{adj},ii} = 0$ and is reported as untestable rather than given a spurious $z$. Because that and the redundancy classification are read from the same $\Sigma_{\hat x}$, they cannot disagree.
+
+Least squares smears a gross error across neighbouring measurements, so identification is reliable only where redundancy is high; `serial_elimination` discards the prime suspect and re-tests until the data are clean.
+
+---
+
+## API Reference
+
+### `reconcile`
+
+```python
+def reconcile(
+    residual_fn,                    # F(x, params) -> (m,) Array
+    y: Array,
+    sigma: Array,                   # inf entry => unmeasured
+    *,
+    params=None, names=None, x0=None,
+    unmeasured_init=None, unmeasured_scale=None,
+    scaling: Scaling | bool = True,
+    max_steps: int = 20, tol: float = 1e-9,
+    method: str = "gauss_newton",
+    check_structure: bool = True, rank_tol=None,
+) -> ReconcileResult
+```
+
+**Parameters:**
+- `residual_fn` — the model equations, JAX-traceable.
+- `y` — measurements. Entries with infinite `sigma` are ignored and may be `nan`.
+- `sigma` — standard deviations; `inf` marks a variable to estimate.
+- `params` — extra argument threaded to `residual_fn`; `jax.grad` with respect to it answers *how would the reconciled state move if this fixed parameter changed* — a different question from estimating it.
+- `check_structure` — run the observability test first. Disable only inside a `jit`/`vmap` sweep whose structure you have already validated.
+
+**Returns** a `ReconcileResult` with `x`, `x_named`, `adjustment`, `objective`, `covariance`, `std`, `converged`, `structure` and `scaling`, plus a `summary()` table.
+
+### Other entry points
+
+```python
+classify(residual_fn, x, sigma, *, scaling, names=None) -> StructureReport
+reconciled_covariance(residual_fn, x, sigma, *, scaling) -> Array
+measurement_sensitivity(residual_fn, y, sigma, *, x0, scaling) -> Array
+
+global_test(result, alpha=0.05) -> GlobalTestResult
+measurement_test(result, alpha=0.05, bonferroni=True) -> MeasurementTestResult
+serial_elimination(residual_fn, y, sigma, *, alpha=0.05, max_removed=3) -> list
+
+sensor_value(residual_fn, x, sigma, *, target, candidate, candidate_sigma) -> dict
+sensor_ranking(residual_fn, x, sigma, *, target, candidates, candidate_sigma) -> list
+```
+
+`StructureReport.classes` assigns every variable one of `measured-redundant`, `measured-just-determined`, `unmeasured-observable` or `unmeasured-unobservable`, and `summary()` prints the table.
+
+---
+
+## Worked Example
+
+A three-stream splitter whose meters do not close:
+
+```python
+import jax.numpy as jnp
+from difflow.reconciliation import reconcile, global_test, measurement_test
+
+def balance(x, params=None):
+    return jnp.array([x[0] - x[1] - x[2]])       # feed = top + bottom
+
+y     = jnp.array([100.0, 62.0, 40.0])           # out by 2 units
+sigma = jnp.array([2.0, 1.0, 1.0])               # the feed meter is worst
+
+res = reconcile(balance, y, sigma, names=["feed", "top", "bottom"])
+print(res.summary())
+print(global_test(res))
+```
+
+The feed meter, being the least trusted, absorbs most of the adjustment; the reconciled standard deviations are all below the raw `sigma`. With one equation and three measurements the degree of redundancy is 1.
+
+To *estimate* a quantity instead of reconciling it, give it an infinite sigma:
+
+```python
+sigma = jnp.array([2.0, 1.0, jnp.inf])           # the bottoms meter failed
+res = reconcile(balance, y, sigma, names=["feed", "top", "bottom"])
+res.x_named["bottom"]                            # inferred from the balance
+res.std["bottom"]                                # and its standard error
+```
+
+Ask for one unknown too many and the problem is diagnosed rather than silently failing:
+
+```python
+sigma = jnp.array([2.0, jnp.inf, jnp.inf])
+reconcile(balance, y, sigma, names=["feed", "top", "bottom"])
+# ReconciliationStructureError: reconciliation problem is not solvable:
+# 1 unmeasured variable(s) cannot be determined from the constraints.
+# Unobservable: top, bottom. ...
+```
+
+---
+
+## Gas Networks
+
+`difflow_gas` supplies the equation set for transmission networks. `difflow_gas.residuals.network_residuals` is a JAX-traceable twin of [`difflow_gas.verify`](unit-operations-gas.md): the same nodal balances, resistance laws and valve relations, **plus** the compressor relation $p_{\text{to}} = r\, p_{\text{from}}$ that `verify` omits because a sequential solve satisfies it by construction. A reconciliation cannot omit it — and on the example network it is exactly what makes the loop observable.
+
+```python
+import jax
+import difflow_gas as dg
+
+layout = dg.gas_state_layout(net, efficiency_arcs=["p3"])   # estimate fouling
+sigma  = dg.measurement_sigma(layout)                       # meter accuracies
+y      = dg.perturb(x_true, sigma, jax.random.PRNGKey(0))   # simulated data
+
+res = dg.reconcile_network(net, y, sigma, layout, ratios={"cs1": 1.2})
+p_bar, q_kg_s, supply = dg.reconciled_values(res, layout)
+dg.verify.residuals_from_values(p_bar, q_kg_s, net).ok      # True
+```
+
+Measured nominations are deliberately kept out of `GasNetwork`, which rejects supplies that do not sum to zero — real nominations do not, and making them close is what the reconciliation is for.
+
+See [`examples/28_data_reconciliation.ipynb`](../examples/28_data_reconciliation.ipynb) for the full treatment: variance reduction, a biased flow meter found and eliminated, an unmeasured pipe-fouling factor estimated with its standard error, the observability boundary, and sensor placement.

--- a/docs/data-reconciliation.md
+++ b/docs/data-reconciliation.md
@@ -161,7 +161,9 @@ reconcile(balance, y, sigma, names=["feed", "top", "bottom"])
 
 ## Gas Networks
 
-`difflow_gas` supplies the equation set for transmission networks. `difflow_gas.residuals.network_residuals` is a JAX-traceable twin of [`difflow_gas.verify`](unit-operations-gas.md): the same nodal balances, resistance laws and valve relations, **plus** the compressor relation $p_{\text{to}} = r\, p_{\text{from}}$ that `verify` omits because a sequential solve satisfies it by construction. A reconciliation cannot omit it — and on the example network it is exactly what makes the loop observable.
+`difflow_gas` supplies the equation set for transmission networks. `difflow_gas.residuals.network_residuals` is the single definition of that set — nodal balances, resistance laws, valve relations, **and** the compressor relation $p_{\text{to}} = r\, p_{\text{from}}$. [`difflow_gas.verify`](unit-operations-gas.md) is the reporting layer over it, unflattening the same residual vector into labelled dicts of floats.
+
+`verify` reports every block except the compressor relation, which a sequential solve satisfies by construction — there is nothing to check. A reconciliation cannot drop it, and on the example network it turns out to be exactly what makes the loop observable.
 
 ```python
 import jax

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,6 +26,7 @@
 | [Streams and Flowsheets](streams-and-flowsheets.md) | Stream handling, flowsheet solver, recycle calculations |
 | [Dynamic Modeling](dynamic-modeling.md) | Transient simulation, ODE/DAE integration, diffrax backend |
 | [Solvers and Utilities](solvers-and-utilities.md) | Numerical methods, uncertainty propagation |
+| [Data Reconciliation](data-reconciliation.md) | Constrained least squares on noisy plant data, gross error detection, observability |
 
 ## Architecture Overview
 
@@ -37,6 +38,7 @@ difflow/
 ├── database.py         # Species property database
 ├── solvers.py          # Numerical solvers
 ├── flowsheet.py        # Flowsheet management
+├── reconciliation/     # Data reconciliation and gross error detection
 ├── uncertainty.py      # Uncertainty propagation
 ├── cantera_import.py   # Cantera data import
 ├── pyglenn_import.py   # NASA Glenn (pyglenn) thermo import

--- a/examples/28_data_reconciliation.ipynb
+++ b/examples/28_data_reconciliation.ipynb
@@ -1,0 +1,1255 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "781406f4",
+   "metadata": {},
+   "source": [
+    "# Data Reconciliation of a Gas Transmission Network\n",
+    "\n",
+    "Plant measurements disagree with the model. Meters drift, nominations do not close, and\n",
+    "a pressure drop rarely matches the flow that supposedly caused it. **Data reconciliation**\n",
+    "finds the smallest statistically weighted adjustment that makes the measurements satisfy\n",
+    "the model equations:\n",
+    "\n",
+    "$$\\min_x \\; (x - y)^T W (x - y) \\quad \\text{subject to} \\quad F(x, \\theta) = 0$$\n",
+    "\n",
+    "The payoff is not just consistency. Because the model equations carry information the\n",
+    "sensors do not, the reconciled estimates are **more precise than the measurements** --- on\n",
+    "the network below, by 58% to 93% in variance.\n",
+    "\n",
+    "Everything reconciliation needs is derivative information: the constraint Jacobian $A =\n",
+    "\\partial F/\\partial x$, the covariance of the estimates, the sensitivity of each estimate\n",
+    "to each measurement. A conventional flowsheet package hand-derives it unit by unit. Here\n",
+    "`jax.jacobian` supplies it, which is what makes the same code work for a gas network, a\n",
+    "reactor train, or an equation set you write on the spot.\n",
+    "\n",
+    "**What this notebook covers**\n",
+    "\n",
+    "1. The network and its true state\n",
+    "2. Corrupting it, and seeing the model reject the data\n",
+    "3. Reconciliation, and the precision it buys\n",
+    "4. Covariance two ways: the textbook formula and autodiff\n",
+    "5. Finding a biased flow meter\n",
+    "6. Estimating an unmeasured pipe fouling factor\n",
+    "7. The observability boundary --- and what the compressor has to do with it\n",
+    "8. Sensor placement"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "97e1dfe2",
+   "metadata": {},
+   "source": [
+    "## 1. Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "f613b549",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-27T11:55:45.317821Z",
+     "iopub.status.busy": "2026-08-27T11:55:45.317554Z",
+     "iopub.status.idle": "2026-08-27T11:55:47.693406Z",
+     "shell.execute_reply": "2026-08-27T11:55:47.691182Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "JAX version: 0.10.2\n"
+     ]
+    }
+   ],
+   "source": [
+    "import jax\n",
+    "import jax.numpy as jnp\n",
+    "\n",
+    "jax.config.update(\"jax_enable_x64\", True)\n",
+    "\n",
+    "import numpy as np\n",
+    "import difflow_gas as dg\n",
+    "from difflow_gas import verify\n",
+    "from difflow.reconciliation import (\n",
+    "    global_test,\n",
+    "    measurement_test,\n",
+    "    measurement_sensitivity,\n",
+    "    reconciled_covariance,\n",
+    "    sensor_ranking,\n",
+    "    serial_elimination,\n",
+    "    solve_reconciliation,\n",
+    "    ReconciliationStructureError,\n",
+    ")\n",
+    "\n",
+    "print(\"JAX version:\", jax.__version__)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d0b503ff",
+   "metadata": {},
+   "source": [
+    "## 2. The network\n",
+    "\n",
+    "Five nodes, one compressor station, and a loop. Gas enters at `src` at 120 kg/s, is boosted\n",
+    "by station `cs1`, and leaves at `c` (50 kg/s) and `d` (70 kg/s). Arcs `p2`, `p3` and `p4`\n",
+    "form the loop `b-c-d-b`, which is what creates redundancy: the flow split around a loop is\n",
+    "determined by the pipe resistances, so measuring it over-determines the state.\n",
+    "\n",
+    "This is the network of `20_gas_network_flowsheets.ipynb`, with realistic Weymouth\n",
+    "coefficients for 0.6 m pipes at transmission scale."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "c17cbc58",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-27T11:55:47.697770Z",
+     "iopub.status.busy": "2026-08-27T11:55:47.697193Z",
+     "iopub.status.idle": "2026-08-27T11:55:47.708314Z",
+     "shell.execute_reply": "2026-08-27T11:55:47.706726Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "5 nodes, 5 arcs, cycle rank 1\n"
+     ]
+    }
+   ],
+   "source": [
+    "RATIOS = {\"cs1\": 1.2}          # compressor pressure ratio\n",
+    "P_SLACK_PA = 60.0e5           # slack pressure at src (60 bar)\n",
+    "\n",
+    "net = dg.GasNetwork(\n",
+    "    arcs={\n",
+    "        \"p1\":  (\"src\", \"a\", \"pipe\"),\n",
+    "        \"cs1\": (\"a\",   \"b\", \"compressor\"),\n",
+    "        \"p2\":  (\"b\",   \"c\", \"pipe\"),\n",
+    "        \"p3\":  (\"b\",   \"d\", \"pipe\"),\n",
+    "        \"p4\":  (\"c\",   \"d\", \"pipe\"),        # closes the loop b-c-d-b\n",
+    "    },\n",
+    "    beta={\n",
+    "        aid: dg.weymouth_beta(length_m=L, diameter_m=0.6, roughness_m=1e-4)\n",
+    "        for aid, L in [(\"p1\", 20e3), (\"p2\", 40e3), (\"p3\", 60e3), (\"p4\", 80e3)]\n",
+    "    },\n",
+    "    supply_kg_s={\"src\": 120.0, \"c\": -50.0, \"d\": -70.0},\n",
+    "    pressure_bounds_bar={n: (30.0, 80.0) for n in [\"src\", \"a\", \"b\", \"c\", \"d\"]},\n",
+    ")\n",
+    "\n",
+    "print(f\"{len(net.nodes)} nodes, {len(net.arcs)} arcs, cycle rank {net.cycle_rank}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7f5e1de6",
+   "metadata": {},
+   "source": [
+    "Solve it sequentially to get the true state that the measurements will be sampled around."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "d262ca8e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-27T11:55:47.711107Z",
+     "iopub.status.busy": "2026-08-27T11:55:47.710733Z",
+     "iopub.status.idle": "2026-08-27T11:55:50.555627Z",
+     "shell.execute_reply": "2026-08-27T11:55:50.554090Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "pressures (bar): {'src': 60.0, 'a': 51.624, 'b': 61.948, 'c': 57.406, 'd': 56.921}\n",
+      "flows (kg/s)   : {'p1': 120.0, 'cs1': 120.0, 'p2': 64.612, 'p3': 55.388, 'p4': 14.612}\n",
+      "all equations satisfied: True\n"
+     ]
+    }
+   ],
+   "source": [
+    "fs, dec = dg.build_network_flowsheet(\n",
+    "    net, root=\"src\", p_slack_pa=P_SLACK_PA, ratios=RATIOS\n",
+    ")\n",
+    "streams = fs.solve(tol=1e-12, max_iter=500)\n",
+    "\n",
+    "p_true = verify.node_pressures_bar(streams, dec)\n",
+    "q_true = verify.arc_flows_kg_s(streams, dec)\n",
+    "\n",
+    "print(\"pressures (bar):\", {k: round(v, 3) for k, v in p_true.items()})\n",
+    "print(\"flows (kg/s)   :\", {k: round(v, 3) for k, v in q_true.items()})\n",
+    "print(\"all equations satisfied:\", verify.residual_report(streams, net, dec).ok)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aec7bafe",
+   "metadata": {},
+   "source": [
+    "### The state vector\n",
+    "\n",
+    "`gas_state_layout` packs pressures (bar), signed arc flows (kg/s) and **boundary flows**\n",
+    "into one vector. The boundary flows being *variables* rather than fixed parameters matters\n",
+    "more than it looks: with them held fixed, the node-balance block of the Jacobian is the\n",
+    "network's incidence matrix, whose rank is only $n_{\\text{nodes}} - 1$, and the KKT system\n",
+    "below would be singular for purely structural reasons. Carrying them as unknowns gives every\n",
+    "balance row a $+1$ in its own column.\n",
+    "\n",
+    "It also reflects reality. Real nominations do not sum to zero --- and `GasNetwork` refuses\n",
+    "to store supplies that do not. So the measured nominations live in the measurement vector,\n",
+    "and making them close is precisely the reconciliation's job."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "40739c3b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-27T11:55:50.558723Z",
+     "iopub.status.busy": "2026-08-27T11:55:50.558416Z",
+     "iopub.status.idle": "2026-08-27T11:55:50.777499Z",
+     "shell.execute_reply": "2026-08-27T11:55:50.775867Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "13 variables: ['p_a', 'p_b', 'p_c', 'p_d', 'p_src', 'q_cs1', 'q_p1', 'q_p2', 'q_p3', 'q_p4', 's_c', 's_d', 's_src']\n",
+      "\n",
+      "10 equations: ['balance_a', 'balance_b', 'balance_c', 'balance_d', 'balance_src', 'resistance_p1', 'resistance_p2', 'resistance_p3', 'resistance_p4', 'compressor_cs1']\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "F(x_true) max residual: 1.2986518527213775e-09\n"
+     ]
+    }
+   ],
+   "source": [
+    "layout = dg.gas_state_layout(net)\n",
+    "residual_fn = dg.network_residual_fn(net, layout, ratios=RATIOS)\n",
+    "\n",
+    "x_true = layout.pack(p_true, q_true, net.supply_kg_s)\n",
+    "\n",
+    "print(f\"{layout.size} variables:\", layout.names)\n",
+    "print(f\"\\n{len(dg.residual_names(net, layout))} equations:\", dg.residual_names(net, layout))\n",
+    "print(\"\\nF(x_true) max residual:\", float(jnp.max(jnp.abs(residual_fn(x_true)))))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8132f0e3",
+   "metadata": {},
+   "source": [
+    "Note the last equation. `difflow_gas.verify` deliberately omits the compressor relation\n",
+    "$p_{\\text{to}} = r\\,p_{\\text{from}}$, because a sequential solve satisfies it by\n",
+    "construction --- there is nothing to check. A reconciliation formulation *cannot* omit it:\n",
+    "without that row the pressures downstream of the station are untied from the ones upstream.\n",
+    "Section 7 shows it is exactly what makes the loop observable."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "facb9800",
+   "metadata": {},
+   "source": [
+    "## 3. Corrupting the data\n",
+    "\n",
+    "Real transmission practice: pressure transmitters are good, flow meters less so, and\n",
+    "nominated boundary flows are the least reliable numbers in the system."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "cfcb2c2b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-27T11:55:50.780634Z",
+     "iopub.status.busy": "2026-08-27T11:55:50.780264Z",
+     "iopub.status.idle": "2026-08-27T11:55:51.214362Z",
+     "shell.execute_reply": "2026-08-27T11:55:51.212361Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "worst node imbalance   :   1.5623 kg/s\n",
+      "worst resistance error :  97.6610 bar^2\n",
+      "\n",
+      "nominations sum to     :  -0.2062 kg/s  (should be 0)\n"
+     ]
+    }
+   ],
+   "source": [
+    "sigma = dg.measurement_sigma(\n",
+    "    layout,\n",
+    "    sigma_p_bar=0.3,          # pressure transmitters\n",
+    "    sigma_q_kg_s=1.0,         # flow meters\n",
+    "    sigma_supply_kg_s=1.5,    # nominations\n",
+    ")\n",
+    "y = dg.perturb(x_true, sigma, jax.random.PRNGKey(0))\n",
+    "\n",
+    "measured_p = {n: float(y[layout.index(f\"p_{n}\")]) for n in layout.nodes}\n",
+    "measured_q = {a: float(y[layout.index(f\"q_{a}\")]) for a in layout.arcs}\n",
+    "before = verify.residuals_from_values(measured_p, measured_q, net)\n",
+    "\n",
+    "print(f\"worst node imbalance   : {before.max_node_imbalance_kg_s:8.4f} kg/s\")\n",
+    "print(f\"worst resistance error : {before.max_resistance_residual_bar2:8.4f} bar^2\")\n",
+    "nomination_sum = sum(float(y[layout.index(f\"s_{n}\")]) for n in layout.supply_nodes)\n",
+    "print(f\"\\nnominations sum to     : {nomination_sum:8.4f} kg/s  (should be 0)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c5de2db3",
+   "metadata": {},
+   "source": [
+    "The raw measurements are physically impossible: gas appears and disappears at nodes, and\n",
+    "the pipe laws are off by tens of bar². Every number is individually plausible; collectively\n",
+    "they are not."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3105afda",
+   "metadata": {},
+   "source": [
+    "## 4. Reconciliation\n",
+    "\n",
+    "One call. `sigma` sets the weights, and the returned object carries the reconciled state,\n",
+    "its covariance, and the observability structure."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "ff061e08",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-27T11:55:51.217421Z",
+     "iopub.status.busy": "2026-08-27T11:55:51.217108Z",
+     "iopub.status.idle": "2026-08-27T11:56:00.253374Z",
+     "shell.execute_reply": "2026-08-27T11:56:00.251566Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "objective 8.753 on 10 degrees of redundancy, |F| = 4.55e-13, converged = True\n",
+      "\n",
+      "variable                 measured   reconciled     adjust     sigma    sd_hat\n",
+      "----------------------------------------------------------------------------\n",
+      "p_a                       51.5620      51.6985     0.1365    0.3000    0.1174\n",
+      "p_b                       61.7130      62.0382     0.3252    0.3000    0.1409\n",
+      "p_c                       57.9511      57.4973    -0.4538    0.3000    0.1565\n",
+      "p_d                       56.9776      56.9743    -0.0033    0.3000    0.1585\n",
+      "p_src                     60.0243      60.1001     0.0758    0.3000    0.1266\n",
+      "q_cs1                    119.6279     120.2752     0.6473    1.0000    0.5348\n",
+      "q_p1                     121.1902     120.2752    -0.9150    1.0000    0.5348\n",
+      "q_p2                      64.9507      64.6521    -0.2986    1.0000    0.3254\n",
+      "q_p3                      55.4728      55.6231     0.1503    1.0000    0.2718\n",
+      "q_p4                      13.7402      15.1823     1.4421    1.0000    0.6456\n",
+      "s_c                      -48.4182     -49.4697    -1.0515    1.5000    0.8258\n",
+      "s_d                      -72.3392     -70.8054     1.5338    1.5000    0.8190\n",
+      "s_src                    120.5513     120.2752    -0.2761    1.5000    0.5348\n"
+     ]
+    }
+   ],
+   "source": [
+    "res = dg.reconcile_network(net, y, sigma, layout, ratios=RATIOS)\n",
+    "print(res.summary())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "0bb9e0d9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-27T11:56:00.257081Z",
+     "iopub.status.busy": "2026-08-27T11:56:00.256778Z",
+     "iopub.status.idle": "2026-08-27T11:56:00.268199Z",
+     "shell.execute_reply": "2026-08-27T11:56:00.266439Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "worst resistance error : 1.298e-09 bar^2   (was 97.6610)\n",
+      "nominations sum to     : 1.421e-14 kg/s\n",
+      "\n",
+      "reconciled by the plugin's own verifier: consistent\n"
+     ]
+    }
+   ],
+   "source": [
+    "p_rec, q_rec, s_rec = dg.reconciled_values(res, layout)\n",
+    "after = verify.residuals_from_values(p_rec, q_rec, net)\n",
+    "\n",
+    "print(f\"worst resistance error : {after.max_resistance_residual_bar2:.3e} bar^2\"\n",
+    "      f\"   (was {before.max_resistance_residual_bar2:.4f})\")\n",
+    "print(f\"nominations sum to     : {sum(s_rec.values()):.3e} kg/s\")\n",
+    "print(f\"\\nreconciled by the plugin's own verifier: consistent\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "785044bd",
+   "metadata": {},
+   "source": [
+    "### What the constraints bought\n",
+    "\n",
+    "The reconciled standard deviations come from $\\Sigma_{\\hat x} = [K^{-1}]_{11}$, the leading\n",
+    "block of the inverse KKT matrix. Every estimate is sharper than its measurement, and nothing\n",
+    "was measured twice --- the improvement comes entirely from the model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "b9546106",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-27T11:56:00.271252Z",
+     "iopub.status.busy": "2026-08-27T11:56:00.270937Z",
+     "iopub.status.idle": "2026-08-27T11:56:00.281365Z",
+     "shell.execute_reply": "2026-08-27T11:56:00.280326Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "variable      sigma   sd_hat   variance reduction\n",
+      "--------------------------------------------------\n",
+      "p_a           0.300   0.1174              84.7 %\n",
+      "p_b           0.300   0.1409              77.9 %\n",
+      "p_c           0.300   0.1565              72.8 %\n",
+      "p_d           0.300   0.1585              72.1 %\n",
+      "p_src         0.300   0.1266              82.2 %\n",
+      "q_cs1         1.000   0.5348              71.4 %\n",
+      "q_p1          1.000   0.5348              71.4 %\n",
+      "q_p2          1.000   0.3254              89.4 %\n",
+      "q_p3          1.000   0.2718              92.6 %\n",
+      "q_p4          1.000   0.6456              58.3 %\n",
+      "s_c           1.500   0.8258              69.7 %\n",
+      "s_d           1.500   0.8190              70.2 %\n",
+      "s_src         1.500   0.5348              87.3 %\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"{'variable':<10} {'sigma':>8} {'sd_hat':>8} {'variance reduction':>20}\")\n",
+    "print(\"-\" * 50)\n",
+    "for i, name in enumerate(layout.names):\n",
+    "    s0, s1 = float(sigma[i]), res.std[name]\n",
+    "    print(f\"{name:<10} {s0:8.3f} {s1:8.4f} {100 * (1 - (s1 / s0) ** 2):17.1f} %\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b55a1f7f",
+   "metadata": {},
+   "source": [
+    "`q_p4` gains the least. It is the loop's long, thin leg carrying only ~15 kg/s, so the\n",
+    "balances constrain it least --- which makes it the natural place to consider adding a meter\n",
+    "(section 8), and the hardest place to catch a bad one (section 6).\n",
+    "\n",
+    "The **degrees of redundancy** are the number of independent checks the data must pass:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "9165c690",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-27T11:56:00.283734Z",
+     "iopub.status.busy": "2026-08-27T11:56:00.283471Z",
+     "iopub.status.idle": "2026-08-27T11:56:00.291280Z",
+     "shell.execute_reply": "2026-08-27T11:56:00.290080Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "equations                : 10\n",
+      "measured / unmeasured    : 13 / 0\n",
+      "degrees of redundancy    : 10\n",
+      "solvable                 : True\n",
+      "\n",
+      "global test: chi2 = 8.753 on 10 dof, critical = 18.307, p = 0.556 -> no gross error\n"
+     ]
+    }
+   ],
+   "source": [
+    "st = res.structure\n",
+    "print(f\"equations                : {st.n_equations}\")\n",
+    "print(f\"measured / unmeasured    : {st.n_measured} / {st.n_unmeasured}\")\n",
+    "print(f\"degrees of redundancy    : {st.degree_of_redundancy}\")\n",
+    "print(f\"solvable                 : {st.solvable}\")\n",
+    "print()\n",
+    "print(global_test(res))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6f9c5a73",
+   "metadata": {},
+   "source": [
+    "## 5. Covariance, two ways\n",
+    "\n",
+    "The classical result says the reconciled covariance is a projection,\n",
+    "$\\Sigma_{\\hat x} = \\Sigma - \\Sigma A^T (A\\Sigma A^T)^{-1} A \\Sigma$.\n",
+    "\n",
+    "But reconciliation is also just a function $\\hat x(y)$, so its covariance ought to follow\n",
+    "from propagating $\\Sigma$ through the sensitivity $S = \\partial \\hat x / \\partial y$ ---\n",
+    "which `jax.jacfwd` can take straight through the solver. Do the two agree?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "c0bdcef2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-27T11:56:00.294701Z",
+     "iopub.status.busy": "2026-08-27T11:56:00.294425Z",
+     "iopub.status.idle": "2026-08-27T11:56:04.471199Z",
+     "shell.execute_reply": "2026-08-27T11:56:04.469514Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "max |S Sigma S^T  -  Sigma_xhat| : 0.009617096676138526\n",
+      "largest covariance entry         : 0.681879383820637\n",
+      "max |lambda| (constraint forces) : 1.8680644638109307\n"
+     ]
+    }
+   ],
+   "source": [
+    "S = measurement_sensitivity(\n",
+    "    residual_fn, y, sigma, x0=x_true, scaling=res.scaling\n",
+    ")\n",
+    "Sigma = np.diag(np.asarray(sigma) ** 2)\n",
+    "\n",
+    "autodiff_cov = np.asarray(S) @ Sigma @ np.asarray(S).T\n",
+    "formula_cov = np.asarray(res.covariance)\n",
+    "\n",
+    "print(\"max |S Sigma S^T  -  Sigma_xhat| :\", np.max(np.abs(autodiff_cov - formula_cov)))\n",
+    "print(\"largest covariance entry         :\", np.max(np.abs(formula_cov)))\n",
+    "print(\"max |lambda| (constraint forces) :\", float(jnp.max(jnp.abs(res.multipliers))))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "03c5114d",
+   "metadata": {},
+   "source": [
+    "Close, but not equal --- and the reason is worth understanding.\n",
+    "\n",
+    "For **linear** constraints the two are the same matrix identically: $S = \\Sigma_{\\hat x} W$\n",
+    "and $W \\Sigma W = W$, so $S \\Sigma S^T = \\Sigma_{\\hat x}$ exactly. For **nonlinear**\n",
+    "constraints they differ by the curvature term $\\sum_k \\lambda_k \\nabla^2 F_k$, which the\n",
+    "covariance formula drops and differentiating the solver does not.\n",
+    "\n",
+    "The gap is therefore proportional to the Lagrange multipliers --- to how hard the\n",
+    "constraints had to pull. On consistent data it vanishes:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "e5e37bf9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-27T11:56:04.474212Z",
+     "iopub.status.busy": "2026-08-27T11:56:04.473927Z",
+     "iopub.status.idle": "2026-08-27T11:56:21.011531Z",
+     "shell.execute_reply": "2026-08-27T11:56:21.010003Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " noise level   max |lambda|   max |difference|\n",
+      "----------------------------------------------\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        0.00          6e-11          4.948e-13\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        0.05         0.0934          0.0004855\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        0.20         0.3736           0.001939\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        1.00          1.868           0.009617\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        3.00          5.605             0.0282\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"{'noise level':>12} {'max |lambda|':>14} {'max |difference|':>18}\")\n",
+    "print(\"-\" * 46)\n",
+    "for scale in [0.0, 0.05, 0.2, 1.0, 3.0]:\n",
+    "    y_s = x_true + scale * (y - x_true)\n",
+    "    r_s = dg.reconcile_network(net, y_s, sigma, layout, ratios=RATIOS)\n",
+    "    S_s = measurement_sensitivity(\n",
+    "        residual_fn, y_s, sigma, x0=x_true, scaling=r_s.scaling\n",
+    "    )\n",
+    "    gap = np.max(np.abs(np.asarray(S_s) @ Sigma @ np.asarray(S_s).T\n",
+    "                        - np.asarray(r_s.covariance)))\n",
+    "    print(f\"{scale:12.2f} {float(jnp.max(jnp.abs(r_s.multipliers))):14.4g} {gap:18.4g}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fc991f3b",
+   "metadata": {},
+   "source": [
+    "At zero noise the multipliers vanish and the two agree to machine precision; the gap then\n",
+    "grows linearly with them. So the textbook covariance is itself a linearization, and the\n",
+    "autodiff route is the more faithful of the two. The discrepancy is a free diagnostic: a\n",
+    "large one says the model is strongly nonlinear over the range the adjustments span."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c88bc42d",
+   "metadata": {},
+   "source": [
+    "## 6. Finding a bad meter\n",
+    "\n",
+    "Reconciliation assumes zero-mean noise. A biased sensor breaks that, and because least\n",
+    "squares spreads the error over *all* the adjustments, one bad meter corrupts every\n",
+    "reconciled value. Bias the `p3` flow meter by $8\\sigma$ and see whether the tests notice."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "30a42413",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-27T11:56:21.014868Z",
+     "iopub.status.busy": "2026-08-27T11:56:21.014615Z",
+     "iopub.status.idle": "2026-08-27T11:56:22.601621Z",
+     "shell.execute_reply": "2026-08-27T11:56:22.599918Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "global test: chi2 = 65.583 on 10 dof, critical = 18.307, p = 3.13e-10 -> GROSS ERROR DETECTED\n",
+      "\n",
+      "measurement test (|z| > 2.891): suspect q_p3\n",
+      "  q_p3                 z = -7.540\n",
+      "  q_p4                 z = +2.855\n",
+      "  q_cs1                z = +1.963\n",
+      "  p_c                  z = -1.922\n",
+      "  p_b                  z = +1.308\n"
+     ]
+    }
+   ],
+   "source": [
+    "y_bad = dg.perturb(\n",
+    "    x_true, sigma, jax.random.PRNGKey(0),\n",
+    "    layout=layout, gross_errors={\"q_p3\": 8.0},     # in multiples of sigma\n",
+    ")\n",
+    "res_bad = dg.reconcile_network(net, y_bad, sigma, layout, ratios=RATIOS)\n",
+    "\n",
+    "print(global_test(res_bad))\n",
+    "print()\n",
+    "print(measurement_test(res_bad))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "27d967d5",
+   "metadata": {},
+   "source": [
+    "The **global test** compares the reconciliation objective against $\\chi^2$ on the degrees of\n",
+    "redundancy: it says *something* is wrong. The **measurement test** standardizes each\n",
+    "adjustment by its own standard deviation, $z_i = (\\hat x_i - y_i)/\\sqrt{\\Sigma_{adj,ii}}$,\n",
+    "and points at the culprit --- here `q_p3` stands well clear of everything else.\n",
+    "\n",
+    "Note that the second-largest $|z|$ belongs to an innocent sensor. That is smearing: the\n",
+    "adjustment had to go somewhere. **Serial elimination** discards the prime suspect and\n",
+    "re-tests."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "ffb433a6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-27T11:56:22.605255Z",
+     "iopub.status.busy": "2026-08-27T11:56:22.604946Z",
+     "iopub.status.idle": "2026-08-27T11:56:25.505613Z",
+     "shell.execute_reply": "2026-08-27T11:56:25.504057Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "removed (none)   chi2 =  65.583 on 10 dof -> REJECT   next suspect: q_p3\n",
+      "removed q_p3     chi2 =   8.729 on  9 dof -> accept   next suspect: None\n"
+     ]
+    }
+   ],
+   "source": [
+    "for step in serial_elimination(\n",
+    "    residual_fn, y_bad, sigma,\n",
+    "    names=layout.names, unmeasured_scale=layout.default_scale,\n",
+    "):\n",
+    "    removed = step.removed or \"(none)\"\n",
+    "    verdict = \"REJECT\" if step.detected else \"accept\"\n",
+    "    print(f\"removed {removed:<8} chi2 = {step.statistic:7.3f} on {step.dof:2d} dof \"\n",
+    "          f\"-> {verdict}   next suspect: {step.suspect}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "54d9bdf2",
+   "metadata": {},
+   "source": [
+    "Discarding `q_p3` drops the statistic from rejection to a routine value, at the cost of one\n",
+    "degree of redundancy. The data are clean --- and the flow through `p3` is still estimated,\n",
+    "now from the balances alone rather than from a meter that was lying."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1c426206",
+   "metadata": {},
+   "source": [
+    "## 7. Estimating an unmeasured fouling factor\n",
+    "\n",
+    "Pipes foul. Their effective resistance drifts above the design value, and nobody measures\n",
+    "it directly. In this framework an unknown parameter is simply a variable with **no\n",
+    "measurement**: give it $\\sigma = \\infty$ and it is estimated rather than reconciled, in the\n",
+    "same solve, with a standard error from the same covariance matrix.\n",
+    "\n",
+    "Add an efficiency multiplier $\\eta$ on `p3`, where $\\eta > 1$ means *more* resistance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "62696856",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-27T11:56:25.509165Z",
+     "iopub.status.busy": "2026-08-27T11:56:25.508736Z",
+     "iopub.status.idle": "2026-08-27T11:56:34.559716Z",
+     "shell.execute_reply": "2026-08-27T11:56:34.558345Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "estimated eta_p3 = 1.1337 +- 0.0487   (true value 1.15)\n",
+      "that is 0.34 standard errors from the truth\n",
+      "\n",
+      "degrees of redundancy: 9 (estimating a parameter costs one)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# a network whose p3 really is 15% more resistive than the model believes\n",
+    "fouled = dg.GasNetwork(\n",
+    "    arcs=net.arcs,\n",
+    "    beta={**net.beta, \"p3\": net.beta[\"p3\"] * 1.15},\n",
+    "    supply_kg_s=net.supply_kg_s,\n",
+    ")\n",
+    "fs_f, dec_f = dg.build_network_flowsheet(\n",
+    "    fouled, root=\"src\", p_slack_pa=P_SLACK_PA, ratios=RATIOS\n",
+    ")\n",
+    "st_f = fs_f.solve(tol=1e-12, max_iter=500)\n",
+    "\n",
+    "layout_eta = dg.gas_state_layout(net, efficiency_arcs=[\"p3\"])\n",
+    "sigma_eta = dg.measurement_sigma(layout_eta)        # eta defaults to unmeasured\n",
+    "\n",
+    "x_fouled = layout_eta.pack(\n",
+    "    verify.node_pressures_bar(st_f, dec_f),\n",
+    "    verify.arc_flows_kg_s(st_f, dec_f),\n",
+    "    fouled.supply_kg_s,\n",
+    "    {\"eta_p3\": 1.0},\n",
+    ")\n",
+    "y_fouled = dg.perturb(x_fouled, sigma_eta, jax.random.PRNGKey(3))\n",
+    "\n",
+    "# the residual model still uses the CLEAN beta, so eta must absorb the fouling\n",
+    "res_eta = dg.reconcile_network(net, y_fouled, sigma_eta, layout_eta, ratios=RATIOS)\n",
+    "\n",
+    "eta, sd = res_eta.x_named[\"eta_p3\"], res_eta.std[\"eta_p3\"]\n",
+    "print(f\"estimated eta_p3 = {eta:.4f} +- {sd:.4f}   (true value 1.15)\")\n",
+    "print(f\"that is {abs(eta - 1.15) / sd:.2f} standard errors from the truth\")\n",
+    "print(f\"\\ndegrees of redundancy: {res_eta.structure.degree_of_redundancy} \"\n",
+    "      f\"(estimating a parameter costs one)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cce02a18",
+   "metadata": {},
+   "source": [
+    "The fouling is recovered from pressures and flows that never mention it, with an honest\n",
+    "uncertainty attached. Nothing about this was a separate \"parameter estimation\" step ---\n",
+    "it is the same least-squares problem with one fewer weight.\n",
+    "\n",
+    "The complementary question is what happens to the reconciled state if a *fixed* parameter\n",
+    "changes. That is a derivative, not an estimate, and `params` supplies it:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "b729daa2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-27T11:56:34.562269Z",
+     "iopub.status.busy": "2026-08-27T11:56:34.562013Z",
+     "iopub.status.idle": "2026-08-27T11:56:39.730175Z",
+     "shell.execute_reply": "2026-08-27T11:56:39.728230Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "q_p3 at eta = 1.0      : 55.6231 kg/s\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "d q_p3 / d eta         : -14.3876 kg/s per unit eta\n"
+     ]
+    }
+   ],
+   "source": [
+    "def q_p3_hat(efficiency):\n",
+    "    \"\"\"Reconciled flow through p3 as a function of its fouling factor.\"\"\"\n",
+    "    x, _ = solve_reconciliation(\n",
+    "        residual_fn, y, sigma, x0=x_true,\n",
+    "        scaling=res.scaling, params={\"p3\": efficiency}, n_steps=12,\n",
+    "    )\n",
+    "    return x[layout.index(\"q_p3\")]\n",
+    "\n",
+    "print(f\"q_p3 at eta = 1.0      : {float(q_p3_hat(1.0)):.4f} kg/s\")\n",
+    "print(f\"d q_p3 / d eta         : {float(jax.grad(q_p3_hat)(1.0)):.4f} kg/s per unit eta\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f91a2b73",
+   "metadata": {},
+   "source": [
+    "Negative, as it must be: a dirtier pipe carries less of the loop's flow. The gradient runs\n",
+    "through the entire reconciliation --- the Gauss-Newton iteration, the KKT solves, the\n",
+    "constraint Jacobian --- by the implicit function theorem."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "817b885a",
+   "metadata": {},
+   "source": [
+    "## 8. Where estimation stops working\n",
+    "\n",
+    "You cannot estimate everything. The KKT system is nonsingular if and only if the *unmeasured*\n",
+    "columns of the Jacobian have full column rank --- which is exactly the classical\n",
+    "observability condition of data reconciliation. Solvability and observability are one test,\n",
+    "and it runs before the solve, so an ill-posed problem is diagnosed rather than returning\n",
+    "`NaN`.\n",
+    "\n",
+    "Un-meter the whole loop --- three flows and three pressures --- while still asking for\n",
+    "$\\eta$:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "6da86dc0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-27T11:56:39.733019Z",
+     "iopub.status.busy": "2026-08-27T11:56:39.732752Z",
+     "iopub.status.idle": "2026-08-27T11:56:39.905579Z",
+     "shell.execute_reply": "2026-08-27T11:56:39.904239Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "reconciliation problem is not solvable: 1 unmeasured variable(s) cannot be determined from the constraints. Unobservable: eta_p3. (10 equations, 7 measured and 7 unmeasured variables; rank(A)=10, rank(A_unmeasured)=6). Measure one of the variables above, give it a finite sigma as a prior, or remove it from the state.\n"
+     ]
+    }
+   ],
+   "source": [
+    "LOOP = [\"q_p2\", \"q_p3\", \"q_p4\", \"p_b\", \"p_c\", \"p_d\"]\n",
+    "\n",
+    "sigma_blind = dg.measurement_sigma(layout_eta, unmeasured=LOOP)\n",
+    "try:\n",
+    "    dg.reconcile_network(net, y_fouled, sigma_blind, layout_eta, ratios=RATIOS)\n",
+    "except ReconciliationStructureError as err:\n",
+    "    print(err)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c5e47f3f",
+   "metadata": {},
+   "source": [
+    "Now drop $\\eta$ and un-meter *the same six loop variables*:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "85c9272a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-27T11:56:39.908680Z",
+     "iopub.status.busy": "2026-08-27T11:56:39.908399Z",
+     "iopub.status.idle": "2026-08-27T11:56:41.274286Z",
+     "shell.execute_reply": "2026-08-27T11:56:41.272298Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "solvable: True, degrees of redundancy: 4\n",
+      "  q_p2   =   64.532  +- 0.383\n",
+      "  q_p3   =   55.935  +- 0.329\n",
+      "  q_p4   =   16.259  +- 0.871\n",
+      "  p_b    =   61.884  +- 0.277\n",
+      "  p_c    =   57.349  +- 0.312\n",
+      "  p_d    =   56.747  +- 0.317\n"
+     ]
+    }
+   ],
+   "source": [
+    "sigma_loop = dg.measurement_sigma(layout, unmeasured=LOOP)\n",
+    "res_loop = dg.reconcile_network(net, y, sigma_loop, layout, ratios=RATIOS)\n",
+    "\n",
+    "print(f\"solvable: {res_loop.structure.solvable}, \"\n",
+    "      f\"degrees of redundancy: {res_loop.structure.degree_of_redundancy}\")\n",
+    "for name in LOOP:\n",
+    "    print(f\"  {name:<6} = {res_loop.x_named[name]:8.3f}  +- {res_loop.std[name]:.3f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9fd13c68",
+   "metadata": {},
+   "source": [
+    "Six unknowns are recoverable; seven are not. And the reason the six work is the compressor:\n",
+    "$p_b = 1.2\\,p_a$ ties the loop's pressures to the measured pressure upstream of the station.\n",
+    "Remove that equation --- as `verify` does, quite reasonably, for a sequential solve --- and\n",
+    "the loop floats free.\n",
+    "\n",
+    "The classification is available directly, for any variable:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "f571fcc8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-27T11:56:41.278459Z",
+     "iopub.status.busy": "2026-08-27T11:56:41.278118Z",
+     "iopub.status.idle": "2026-08-27T11:56:41.285490Z",
+     "shell.execute_reply": "2026-08-27T11:56:41.283915Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "degrees of redundancy : 4\n",
+      "equations             : 10\n",
+      "measured / unmeasured : 7 / 6\n",
+      "solvable              : True\n",
+      "\n",
+      "variable             class                        redundancy\n",
+      "------------------------------------------------------------\n",
+      "p_a                  measured-redundant                0.408\n",
+      "p_b                  unmeasured-observable                  \n",
+      "p_c                  unmeasured-observable                  \n",
+      "p_d                  unmeasured-observable                  \n",
+      "p_src                measured-redundant                0.553\n",
+      "q_cs1                measured-redundant                0.640\n",
+      "q_p1                 measured-redundant                0.640\n",
+      "q_p2                 unmeasured-observable                  \n",
+      "q_p3                 unmeasured-observable                  \n",
+      "q_p4                 unmeasured-observable                  \n",
+      "s_c                  measured-redundant                0.460\n",
+      "s_d                  measured-redundant                0.460\n",
+      "s_src                measured-redundant                0.840\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(res_loop.structure.summary())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "69e019a5",
+   "metadata": {},
+   "source": [
+    "### Estimating anyway, with a prior\n",
+    "\n",
+    "Failing is not the only option. A *finite* $\\sigma$ on an unmetered variable is a Bayesian\n",
+    "prior, and costs nothing extra --- it is simply another measured entry. Instead of raising,\n",
+    "a weakly identified parameter shrinks toward its prior.\n",
+    "\n",
+    "Be careful what you conclude from it, though."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "38a2bb5b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-27T11:56:41.288270Z",
+     "iopub.status.busy": "2026-08-27T11:56:41.287955Z",
+     "iopub.status.idle": "2026-08-27T11:56:42.793033Z",
+     "shell.execute_reply": "2026-08-27T11:56:42.791566Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "eta_p3 = 1.0000 +- 0.1000\n",
+      "prior was          1.0000 +- 0.1000\n",
+      "truth is           1.1500\n",
+      "\n",
+      "information gained from the data: 0.0% of the prior variance\n"
+     ]
+    }
+   ],
+   "source": [
+    "sigma_prior = dg.measurement_sigma(\n",
+    "    layout_eta, unmeasured=LOOP, sigma_eta=0.1     # a 10% prior on the fouling\n",
+    ")\n",
+    "res_prior = dg.reconcile_network(\n",
+    "    net, y_fouled, sigma_prior, layout_eta, ratios=RATIOS\n",
+    ")\n",
+    "print(f\"eta_p3 = {res_prior.x_named['eta_p3']:.4f} +- {res_prior.std['eta_p3']:.4f}\")\n",
+    "print(f\"prior was          1.0000 +- 0.1000\")\n",
+    "print(f\"truth is           1.1500\")\n",
+    "print(f\"\\ninformation gained from the data: \"\n",
+    "      f\"{100 * (1 - (res_prior.std['eta_p3'] / 0.1) ** 2):.1f}% of the prior variance\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bcfc471a",
+   "metadata": {},
+   "source": [
+    "The posterior is the prior, exactly --- and it is *wrong*, because the truth is 1.15.\n",
+    "\n",
+    "With the loop unmetered the data say nothing whatever about $\\eta$, so reconciliation\n",
+    "returns what you told it to believe. This is the honest failure mode of a prior: it converts\n",
+    "an error you would have noticed into an answer you might not question. The standard error is\n",
+    "the tell --- no reduction means no information --- and the fix is not a better prior but a\n",
+    "meter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c5c27371",
+   "metadata": {},
+   "source": [
+    "## 9. Which sensor should you buy?\n",
+    "\n",
+    "The value of a meter is not its own accuracy but how much it sharpens the quantity you care\n",
+    "about --- a question the covariance answers before any money is spent. Rank candidate\n",
+    "sensors by their effect on the fouling estimate, starting from the blind-loop case above."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "b02dbee3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-27T11:56:42.795737Z",
+     "iopub.status.busy": "2026-08-27T11:56:42.795466Z",
+     "iopub.status.idle": "2026-08-27T11:56:45.026586Z",
+     "shell.execute_reply": "2026-08-27T11:56:45.025279Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "add a meter on      sd(eta)   variance reduction\n",
+      "--------------------------------------------------\n",
+      "q_p3             0.1000 -> 0.0661           56.3 %\n",
+      "q_p2             0.1000 -> 0.0666           55.7 %\n",
+      "q_p4             0.1000 -> 0.0741           45.1 %\n",
+      "p_d              0.1000 -> 0.0968            6.4 %\n",
+      "p_c              0.1000 -> 0.0985            2.9 %\n",
+      "p_b              0.1000 -> 0.1000            0.0 %\n"
+     ]
+    }
+   ],
+   "source": [
+    "ranked = sensor_ranking(\n",
+    "    dg.network_residual_fn(net, layout_eta, ratios=RATIOS),\n",
+    "    x_fouled, sigma_prior,\n",
+    "    target=\"eta_p3\", candidates=LOOP, candidate_sigma=1.0,\n",
+    "    names=layout_eta.names,\n",
+    ")\n",
+    "\n",
+    "print(f\"{'add a meter on':<16} {'sd(eta)':>10} {'variance reduction':>20}\")\n",
+    "print(\"-\" * 50)\n",
+    "for d in ranked:\n",
+    "    print(f\"{d['candidate']:<16} {d['sd_before']:.4f} -> {d['sd_after']:.4f}\"\n",
+    "          f\" {100 * d['variance_reduction']:14.1f} %\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "210df9be",
+   "metadata": {},
+   "source": [
+    "The loop **flow** meters are worth far more than the pressure transmitters, and `p_b` is\n",
+    "worth nothing at all --- it is already pinned by the compressor relation, so measuring it\n",
+    "adds no information. That is the kind of conclusion that is expensive to reach empirically\n",
+    "and nearly free to compute."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aa11d203",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "| Question | Answer | Where it comes from |\n",
+    "|---|---|---|\n",
+    "| Do the measurements fit the model? | Global $\\chi^2$ test on the objective | `global_test` |\n",
+    "| What are the true values? | Constrained WLS via the KKT system | `reconcile` |\n",
+    "| How good are the estimates? | $\\Sigma_{\\hat x} = [K^{-1}]_{11}$ | `res.covariance`, `res.std` |\n",
+    "| Which sensor is lying? | Standardized adjustments | `measurement_test`, `serial_elimination` |\n",
+    "| What is the unknown parameter? | Give it $\\sigma = \\infty$ | same solve |\n",
+    "| Can it be known at all? | $\\operatorname{rank}(A_U)$, before solving | `res.structure` |\n",
+    "| Which meter should we add? | Covariance with and without | `sensor_ranking` |\n",
+    "\n",
+    "**What the differentiability bought**\n",
+    "\n",
+    "1. The constraint Jacobian is `jax.jacobian(F)` --- no hand-derived analytical model per unit.\n",
+    "2. Gradients run *through* the reconciliation, so `d(estimate)/d(parameter)` is one `jax.grad` call.\n",
+    "3. Covariance can be obtained two independent ways, and their disagreement measures the model's nonlinearity rather than a bug.\n",
+    "4. Joint parameter estimation is not a separate algorithm --- it is one weight set to zero.\n",
+    "\n",
+    "**Practical notes**\n",
+    "\n",
+    "- Solve in **bar and bar²**, not Pa. The KKT matrix mixes $W$ (1/variable²) with $A$ (residual/variable), so its conditioning depends on the unit system; automatic scaling makes the result unit-invariant and is on by default.\n",
+    "- Boundary flows belong in the **state**, not in the `GasNetwork`. Real nominations do not sum to zero, which is the whole point.\n",
+    "- Redundancy is uneven. A gross error on a weakly redundant sensor (`q_p4` here) may be misattributed to its neighbours --- check the ranked $z$ scores, not just the top one."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/difflow/__init__.py
+++ b/src/difflow/__init__.py
@@ -227,6 +227,9 @@ from difflow.plugins import (
 # Parameter estimation submodule
 from difflow import estimation
 
+# Data reconciliation submodule
+from difflow import reconciliation
+
 # Economics submodule
 from difflow import economics
 
@@ -471,6 +474,8 @@ __all__ = [
     "OperationRegistry",
     # Parameter estimation
     "estimation",
+    # Data reconciliation
+    "reconciliation",
     # Economics
     "economics",
     # Visualization (optional)

--- a/src/difflow/reconciliation/__init__.py
+++ b/src/difflow/reconciliation/__init__.py
@@ -1,0 +1,116 @@
+"""Data reconciliation for differentiable flowsheets.
+
+Plant measurements are noisy and, taken at face value, contradict the
+model: nominations do not close, balances do not balance. Data
+reconciliation finds the smallest statistically weighted adjustment
+that makes them consistent,
+
+.. math::
+
+    \\min_x (x - y)^T W (x - y) \\quad \\text{s.t.} \\quad F(x, \\theta) = 0,
+
+and in doing so produces estimates *more* precise than the raw
+measurements, because the model equations carry information the sensors
+do not.
+
+Everything that makes this work is derivative information --- the
+constraint Jacobian, the covariance of the estimates, the sensitivity
+of an estimate to each measurement --- so a differentiable flowsheet
+gets it from ``jax.jacobian`` instead of hand-derived analytical
+models. The module is deliberately domain-agnostic: give it any
+traceable ``F(x, params) -> residuals`` and it works. See
+:mod:`difflow_gas.residuals` for a flowsheet-derived example.
+
+Example:
+    >>> import jax.numpy as jnp
+    >>> from difflow.reconciliation import reconcile, global_test
+    >>> def F(x, params=None):          # one balance: in = out1 + out2
+    ...     return jnp.array([x[0] - x[1] - x[2]])
+    >>> y = jnp.array([100.0, 62.0, 40.0])       # does not close
+    >>> sigma = jnp.array([2.0, 1.0, 1.0])
+    >>> res = reconcile(F, y, sigma, names=["feed", "top", "bottom"])
+    >>> res.x_named                               # doctest: +SKIP
+    {'feed': 100.67, 'top': 61.33, 'bottom': 39.33}
+    >>> global_test(res).detected                 # doctest: +SKIP
+    False
+
+An entry of ``sigma`` set to ``inf`` marks a variable to be *estimated*
+rather than reconciled --- an unknown fouling factor, an unmetered
+offtake --- which is how joint parameter estimation and reconciliation
+become the same computation. Whether such a variable can be recovered
+at all is decided up front by
+:func:`~difflow.reconciliation.structure.classify`, so an ill-posed
+problem raises :class:`ReconciliationStructureError` naming the
+culprits instead of returning NaN.
+"""
+
+from difflow.reconciliation.core import (
+    Scaling,
+    auto_scaling,
+    identity_scaling,
+    implicit_correction,
+    jacobian_of,
+    kkt_matrix,
+    measured_mask,
+    measurement_sensitivity,
+    reconciled_covariance,
+    solve_reconciliation,
+    stationarity,
+)
+from difflow.reconciliation.design import sensor_ranking, sensor_value
+from difflow.reconciliation.gross_error import (
+    EliminationStep,
+    GlobalTestResult,
+    MeasurementTestResult,
+    global_test,
+    measurement_test,
+    serial_elimination,
+)
+from difflow.reconciliation.reconcile import ReconcileResult, reconcile
+from difflow.reconciliation.structure import (
+    MEASURED_JUST_DETERMINED,
+    MEASURED_REDUNDANT,
+    REDUNDANCY_TOL,
+    UNMEASURED_OBSERVABLE,
+    UNMEASURED_UNOBSERVABLE,
+    ReconciliationStructureError,
+    StructureReport,
+    classify,
+)
+
+__all__ = [
+    # entry point
+    "reconcile",
+    "ReconcileResult",
+    # KKT core
+    "Scaling",
+    "auto_scaling",
+    "identity_scaling",
+    "kkt_matrix",
+    "jacobian_of",
+    "measured_mask",
+    "solve_reconciliation",
+    "reconciled_covariance",
+    "measurement_sensitivity",
+    "stationarity",
+    "implicit_correction",
+    # structure
+    "classify",
+    "StructureReport",
+    "ReconciliationStructureError",
+    "MEASURED_REDUNDANT",
+    "MEASURED_JUST_DETERMINED",
+    "UNMEASURED_OBSERVABLE",
+    "UNMEASURED_UNOBSERVABLE",
+    "REDUNDANCY_TOL",
+    # gross error detection
+    "global_test",
+    "GlobalTestResult",
+    "measurement_test",
+    "MeasurementTestResult",
+    "serial_elimination",
+    "EliminationStep",
+    # sensor placement
+    "sensor_value",
+    "sensor_ranking",
+]

--- a/src/difflow/reconciliation/core.py
+++ b/src/difflow/reconciliation/core.py
@@ -1,0 +1,373 @@
+"""Scaling and the KKT core of constrained weighted least squares.
+
+Data reconciliation solves
+
+.. math::
+
+    \\min_x (x - y)^T W (x - y) \\quad \\text{s.t.} \\quad F(x, \\theta) = 0
+
+with :math:`W = \\mathrm{diag}(1/\\sigma_i^2)` on measured entries and
+:math:`W_{ii} = 0` on unmeasured ones (unknown parameters, unmetered
+streams). Everything in this module works on a *scaled* problem; see
+:class:`Scaling` for why that is not optional.
+
+The first-order conditions are the KKT system
+
+.. math::
+
+    \\begin{bmatrix} W & A^T \\\\ A & 0 \\end{bmatrix}
+    \\begin{bmatrix} \\Delta x \\\\ \\lambda \\end{bmatrix} =
+    \\begin{bmatrix} -W(x - y) \\\\ -F(x) \\end{bmatrix},
+    \\qquad A = \\partial F / \\partial x,
+
+iterated to convergence. Dropping the :math:`\\sum_k \\lambda_k
+\\nabla^2 F_k` term of the exact Newton Jacobian makes this
+Gauss-Newton, which is what :func:`solve_reconciliation` does by
+default: that term contains the second derivative of the pipe law's
+:math:`q|q|`, and the multipliers are small at a consistent solution,
+so dropping it costs almost nothing and buys robustness. Exact
+gradients are recovered afterwards from one implicit-function-theorem
+correction that *does* use the full Jacobian --- see
+:func:`implicit_correction`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+import jax
+import jax.numpy as jnp
+from jax import Array
+
+from difflow.params_mixin import ParamsMixin
+
+
+def measured_mask(sigma: Array) -> Array:
+    """Boolean mask of the entries that carry a measurement.
+
+    An entry is measured when its standard deviation is finite and
+    strictly positive. ``inf`` (or ``nan``) marks a variable to be
+    estimated rather than reconciled; a *finite* sigma on a variable
+    that is not really metered acts as a prior, which is a legitimate
+    way to regularize a weakly identified parameter.
+    """
+    sigma = jnp.asarray(sigma)
+    return jnp.isfinite(sigma) & (sigma > 0.0)
+
+
+@dataclass
+class Scaling(ParamsMixin):
+    """Diagonal variable and residual scaling of the KKT system.
+
+    The KKT matrix mixes ``W`` (units of 1/variable^2) with ``A``
+    (units of residual/variable), so its conditioning depends on the
+    unit system: the same gas network posed in Pa and Pa^2 rather than
+    bar and bar^2 is many orders worse conditioned, and can exceed what
+    float64 resolves. Scaling makes the formulation unit-invariant, so
+    it is on by default.
+
+    With ``d_i = sigma_i`` on measured entries the scaled weight matrix
+    becomes a 0/1 mask, which has a second benefit: ``1/sigma^2`` is
+    never evaluated, so an infinite sigma cannot introduce a NaN.
+
+    Attributes:
+        d: variable scales, shape ``(n,)``, strictly positive.
+        r: residual row scales, shape ``(m,)``, strictly positive.
+    """
+
+    d: Array
+    r: Array
+
+    @property
+    def n(self) -> int:
+        return int(self.d.shape[0])
+
+    @property
+    def m(self) -> int:
+        return int(self.r.shape[0])
+
+
+def identity_scaling(n: int, m: int) -> Scaling:
+    """Unit scaling, i.e. no scaling at all."""
+    return Scaling(d=jnp.ones(n), r=jnp.ones(m))
+
+
+def auto_scaling(
+    residual_fn: Callable,
+    x0: Array,
+    sigma: Array,
+    *,
+    params: Any = None,
+    unmeasured_scale: Array | float | None = None,
+) -> Scaling:
+    """Build variable and residual scales from the problem itself.
+
+    Variable scales are the measurement standard deviations, so that a
+    scaled adjustment of 1.0 means "one sigma". Unmeasured entries have
+    no sigma to borrow, so they take ``unmeasured_scale`` (by default
+    the magnitude of their initial value, floored at 1). Residual rows
+    are equilibrated to unit 2-norm in the scaled variables, which
+    adapts automatically as variables are added or removed.
+
+    Args:
+        residual_fn: ``F(x, params) -> (m,)``.
+        x0: state to linearize about, shape ``(n,)``.
+        sigma: measurement standard deviations, shape ``(n,)``.
+        params: extra argument threaded to ``residual_fn``.
+        unmeasured_scale: scale for unmeasured entries; scalar or
+            ``(n,)``.
+
+    Returns:
+        A :class:`Scaling`.
+    """
+    x0 = jnp.asarray(x0, dtype=jnp.float64)
+    sigma = jnp.asarray(sigma, dtype=jnp.float64)
+    mask = measured_mask(sigma)
+
+    if unmeasured_scale is None:
+        fallback = jnp.maximum(jnp.abs(x0), 1.0)
+    else:
+        fallback = jnp.broadcast_to(
+            jnp.asarray(unmeasured_scale, dtype=jnp.float64), x0.shape
+        )
+    d = jnp.where(mask, jnp.where(mask, sigma, 1.0), fallback)
+    d = jnp.where(d > 0, d, 1.0)
+
+    a = jacobian_of(residual_fn, x0, params)
+    row_norms = jnp.linalg.norm(a * d[None, :], axis=1)
+    r = jnp.where(row_norms > 0, 1.0 / jnp.where(row_norms > 0, row_norms, 1.0), 1.0)
+    return Scaling(d=d, r=r)
+
+
+def jacobian_of(residual_fn: Callable, x: Array, params: Any = None) -> Array:
+    """Constraint Jacobian ``A = dF/dx`` at ``x``, shape ``(m, n)``."""
+    return jax.jacobian(lambda xx: residual_fn(xx, params))(x)
+
+
+def kkt_matrix(a: Array, weights: Array) -> Array:
+    """Assemble ``[[diag(w), A^T], [A, 0]]``, shape ``(n+m, n+m)``.
+
+    Args:
+        a: constraint Jacobian, shape ``(m, n)``.
+        weights: diagonal of ``W``, shape ``(n,)``. Zeros are allowed
+            and mark unmeasured variables.
+    """
+    m, n = a.shape
+    top = jnp.concatenate([jnp.diag(weights), a.T], axis=1)
+    bottom = jnp.concatenate([a, jnp.zeros((m, m), dtype=a.dtype)], axis=1)
+    return jnp.concatenate([top, bottom], axis=0)
+
+
+def _scaled_problem(residual_fn, sigma, scaling, params):
+    """Return ``(F_tilde, w_tilde, to_u, to_x)`` for the scaled problem."""
+    d, r = scaling.d, scaling.r
+    mask = measured_mask(sigma)
+    w = jnp.where(mask, 1.0, 0.0)
+
+    def f_tilde(u):
+        return r * residual_fn(d * u, params)
+
+    return f_tilde, w, (lambda x: x / d), (lambda u: d * u)
+
+
+def _gauss_newton_step(f_tilde, w, u, v):
+    """One KKT step of the scaled problem; returns ``(du, lam)``."""
+    a = jax.jacobian(f_tilde)(u)
+    f = f_tilde(u)
+    n = u.shape[0]
+    k = kkt_matrix(a, w)
+    rhs = jnp.concatenate([-w * (u - v), -f])
+    sol = jnp.linalg.solve(k, rhs)
+    return sol[:n], sol[n:]
+
+
+def stationarity(f_tilde, w, u, lam, v) -> Array:
+    """Scaled first-order conditions ``G(u, lambda)``, shape ``(n+m,)``."""
+    f, vjp = jax.vjp(f_tilde, u)
+    (at_lam,) = vjp(lam)
+    return jnp.concatenate([w * (u - v) + at_lam, f])
+
+
+def implicit_correction(f_tilde, w, u, lam, v) -> tuple[Array, Array]:
+    """One exact Newton step on the stationarity system.
+
+    Applied after Gauss-Newton has converged, this leaves the *value*
+    essentially unchanged (``G`` is already ~0) while giving reverse-
+    and forward-mode differentiation the exact implicit-function
+    derivative, taken through the full Jacobian --- including the
+    ``sum_k lambda_k grad^2 F_k`` term that Gauss-Newton drops. Using
+    the Gauss-Newton Jacobian here instead would make gradients subtly
+    wrong.
+
+    Differentiating the unrolled Gauss-Newton loop would also work, but
+    costs one reverse pass per iteration and is only correct at full
+    convergence.
+    """
+    n = u.shape[0]
+    z = jnp.concatenate([u, lam])
+    z_star = jax.lax.stop_gradient(z)
+
+    def g(zz):
+        return stationarity(f_tilde, w, zz[:n], zz[n:], v)
+
+    jac = jax.jacobian(g)(z_star)
+    z_new = z_star - jnp.linalg.solve(jac, g(z_star))
+    return z_new[:n], z_new[n:]
+
+
+def solve_reconciliation(
+    residual_fn: Callable,
+    y: Array,
+    sigma: Array,
+    *,
+    x0: Array,
+    scaling: Scaling,
+    params: Any = None,
+    n_steps: int = 12,
+    method: str = "gauss_newton",
+    correct: bool = True,
+) -> tuple[Array, Array]:
+    """Solve the constrained WLS problem. Traceable and differentiable.
+
+    Runs a fixed number of steps so the trip count is static under
+    ``jit``/``vmap``; convergence is judged by the caller from the
+    residual at the returned point (:func:`difflow.reconciliation.
+    reconcile` does this).
+
+    Args:
+        residual_fn: ``F(x, params) -> (m,)``.
+        y: measurements, shape ``(n,)``. Entries whose sigma is
+            infinite are ignored and may be nan.
+        sigma: standard deviations, shape ``(n,)``; ``inf`` = unmeasured.
+        x0: initial state, shape ``(n,)``.
+        scaling: variable and residual scaling to solve in.
+        params: extra argument threaded to ``residual_fn``.
+        n_steps: number of iterations.
+        method: ``"gauss_newton"`` (default) or ``"newton"``, which
+            iterates the full stationarity system instead.
+        correct: apply :func:`implicit_correction` at the end, giving
+            exact derivatives w.r.t. ``y``, ``sigma`` and ``params``.
+
+    Returns:
+        ``(x_hat, multipliers)`` in unscaled units.
+    """
+    y = jnp.asarray(y, dtype=jnp.float64)
+    sigma = jnp.asarray(sigma, dtype=jnp.float64)
+    x0 = jnp.asarray(x0, dtype=jnp.float64)
+
+    f_tilde, w, to_u, to_x = _scaled_problem(
+        residual_fn, sigma, scaling, params
+    )
+    mask = measured_mask(sigma)
+    # y is meaningless where unmeasured and may be nan; zero it so it
+    # cannot poison the arithmetic even though its weight is zero.
+    y_safe = jnp.where(mask, y, 0.0)
+    v = to_u(y_safe)
+    u = to_u(jnp.where(mask, y_safe, x0))
+    lam = jnp.zeros(scaling.m, dtype=jnp.float64)
+
+    if method == "gauss_newton":
+        def body(_, state):
+            uu, _lam = state
+            du, ll = _gauss_newton_step(f_tilde, w, uu, v)
+            return uu + du, ll
+    elif method == "newton":
+        def body(_, state):
+            uu, ll = state
+            z = jnp.concatenate([uu, ll])
+            n = uu.shape[0]
+
+            def g(zz):
+                return stationarity(f_tilde, w, zz[:n], zz[n:], v)
+
+            dz = jnp.linalg.solve(jax.jacobian(g)(z), -g(z))
+            z = z + dz
+            return z[:n], z[n:]
+    else:
+        raise ValueError(
+            f"unknown method {method!r}; expected 'gauss_newton' or 'newton'"
+        )
+
+    u, lam = jax.lax.fori_loop(0, n_steps, body, (u, lam))
+    if correct:
+        u, lam = implicit_correction(f_tilde, w, u, lam, v)
+    return to_x(u), scaling.r * lam
+
+
+def reconciled_covariance(
+    residual_fn: Callable,
+    x: Array,
+    sigma: Array,
+    *,
+    scaling: Scaling,
+    params: Any = None,
+) -> Array:
+    """Covariance of the reconciled estimates, shape ``(n, n)``.
+
+    Computed as the leading block of the inverse KKT matrix,
+
+    .. math:: \\Sigma_{\\hat x} = [K^{-1}]_{11},
+
+    which for a fully measured problem equals the textbook projection
+    :math:`\\Sigma - \\Sigma A^T (A \\Sigma A^T)^{-1} A \\Sigma` but,
+    unlike it, stays well defined when some variables are unmeasured
+    --- so the standard error of an estimated parameter comes out of
+    the same expression as the reconciled variance of a metered flow.
+
+    Args:
+        residual_fn: ``F(x, params) -> (m,)``.
+        x: point to linearize about, normally the reconciled state.
+        sigma: standard deviations, ``inf`` = unmeasured.
+        scaling: the scaling the problem was solved in.
+        params: extra argument threaded to ``residual_fn``.
+    """
+    d = scaling.d
+    f_tilde, w, _, _ = _scaled_problem(residual_fn, sigma, scaling, params)
+    u = x / d
+    a = jax.jacobian(f_tilde)(u)
+    n = u.shape[0]
+    k = kkt_matrix(a, w)
+    cov_u = jnp.linalg.solve(k, jnp.eye(k.shape[0]))[:n, :n]
+    return cov_u * d[:, None] * d[None, :]
+
+
+def measurement_sensitivity(
+    residual_fn: Callable,
+    y: Array,
+    sigma: Array,
+    *,
+    x0: Array,
+    scaling: Scaling,
+    params: Any = None,
+    n_steps: int = 12,
+) -> Array:
+    """``S = d x_hat / d y``, shape ``(n, n)``, by forward-mode autodiff.
+
+    This is the matrix every reconciliation textbook writes down as a
+    projection; here it falls out of differentiating the solver.
+
+    For **linear** constraints it satisfies ``S Sigma S^T ==
+    Sigma_xhat`` exactly, since ``S = Sigma_xhat W`` and ``W Sigma W =
+    W``. For nonlinear constraints the two differ by the curvature term
+    ``sum_k lambda_k grad^2 F_k`` that :func:`reconciled_covariance`
+    drops: they agree to machine precision when the data are consistent
+    (the multipliers vanish) and diverge in proportion to how
+    inconsistent the data are --- around 1% of the largest covariance
+    entry at a typical noise level on the gas network of
+    ``examples/28_data_reconciliation.ipynb``, 4% at three times that
+    noise.
+
+    So the classical covariance formula is itself a linearization, and
+    differentiating the solver is the more faithful of the two. The
+    discrepancy is a useful diagnostic: a large one means the model is
+    strongly nonlinear over the range the adjustments span.
+    """
+    def solve_for(yy):
+        x_hat, _ = solve_reconciliation(
+            residual_fn, yy, sigma, x0=x0, scaling=scaling,
+            params=params, n_steps=n_steps,
+        )
+        return x_hat
+
+    return jax.jacfwd(solve_for)(jnp.asarray(y, dtype=jnp.float64))

--- a/src/difflow/reconciliation/design.py
+++ b/src/difflow/reconciliation/design.py
@@ -1,0 +1,147 @@
+"""Sensor placement: what a proposed measurement would actually buy.
+
+Reconciled precision comes from the constraints as much as from the
+meters, so the value of a new sensor is not its own accuracy but how
+much it shrinks the uncertainty of the quantity you care about --- and
+that is a question the covariance answers before anyone buys anything.
+
+Everything here reuses :func:`difflow.reconciliation.reconciled_
+covariance`; adding a candidate sensor just means giving its variable a
+finite sigma.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Sequence
+
+import jax.numpy as jnp
+import numpy as np
+from jax import Array
+
+from difflow.reconciliation.core import (
+    Scaling,
+    auto_scaling,
+    reconciled_covariance,
+)
+
+
+def _std_of(
+    residual_fn, x, sigma, target_index, *, params, scaling
+) -> float:
+    cov = reconciled_covariance(
+        residual_fn, x, sigma, scaling=scaling, params=params
+    )
+    return float(jnp.sqrt(jnp.clip(cov[target_index, target_index], 0.0, jnp.inf)))
+
+
+def sensor_value(
+    residual_fn: Callable,
+    x: Array,
+    sigma: Array,
+    *,
+    target: int | str,
+    candidate: int | str,
+    candidate_sigma: float,
+    names: Sequence[str] | None = None,
+    params: Any = None,
+    scaling: Scaling | None = None,
+) -> dict:
+    """Effect of adding one sensor on the precision of a target quantity.
+
+    Args:
+        residual_fn: ``F(x, params) -> (m,)``.
+        x: state to linearize about (normally the reconciled state).
+        sigma: current standard deviations; ``inf`` = unmeasured.
+        target: index or name of the quantity to be estimated well.
+        candidate: index or name of the variable a sensor would measure.
+        candidate_sigma: accuracy of the proposed sensor.
+        names: variable names, needed if ``target``/``candidate`` are
+            given by name.
+        params: extra argument threaded to ``residual_fn``.
+        scaling: scaling to use; derived automatically if omitted.
+
+    Returns:
+        ``{'sd_before', 'sd_after', 'variance_reduction', 'sd_reduction'}``,
+        where the reductions are fractions in ``[0, 1]``.
+    """
+    names = list(names) if names is not None else None
+
+    def _idx(v):
+        if isinstance(v, str):
+            if names is None:
+                raise ValueError("names are required to look up a variable")
+            return names.index(v)
+        return int(v)
+
+    t, c = _idx(target), _idx(candidate)
+    sigma = jnp.asarray(sigma, dtype=jnp.float64)
+    x = jnp.asarray(x, dtype=jnp.float64)
+
+    sc_before = scaling or auto_scaling(residual_fn, x, sigma, params=params)
+    sd_before = _std_of(
+        residual_fn, x, sigma, t, params=params, scaling=sc_before
+    )
+
+    sigma_after = sigma.at[c].set(candidate_sigma)
+    sc_after = auto_scaling(residual_fn, x, sigma_after, params=params)
+    sd_after = _std_of(
+        residual_fn, x, sigma_after, t, params=params, scaling=sc_after
+    )
+
+    var_red = (
+        1.0 - (sd_after ** 2) / (sd_before ** 2) if sd_before > 0 else 0.0
+    )
+    return {
+        "target": names[t] if names else t,
+        "candidate": names[c] if names else c,
+        "sd_before": sd_before,
+        "sd_after": sd_after,
+        "variance_reduction": float(var_red),
+        "sd_reduction": float(1.0 - sd_after / sd_before) if sd_before > 0 else 0.0,
+    }
+
+
+def sensor_ranking(
+    residual_fn: Callable,
+    x: Array,
+    sigma: Array,
+    *,
+    target: int | str,
+    candidates: Sequence[int | str],
+    candidate_sigma: float | Sequence[float],
+    names: Sequence[str] | None = None,
+    params: Any = None,
+) -> list[dict]:
+    """Rank candidate sensors by how much they sharpen a target estimate.
+
+    Args:
+        residual_fn: ``F(x, params) -> (m,)``.
+        x: state to linearize about.
+        sigma: current standard deviations.
+        target: the quantity to be estimated well.
+        candidates: variables a sensor could be added to.
+        candidate_sigma: accuracy of each candidate; a scalar applies
+            to all of them.
+        names: variable names.
+        params: extra argument threaded to ``residual_fn``.
+
+    Returns:
+        The :func:`sensor_value` dicts, best first.
+    """
+    if np.isscalar(candidate_sigma):
+        sigmas = [float(candidate_sigma)] * len(candidates)
+    else:
+        sigmas = [float(s) for s in candidate_sigma]
+        if len(sigmas) != len(candidates):
+            raise ValueError(
+                f"got {len(sigmas)} sigmas for {len(candidates)} candidates"
+            )
+
+    out = [
+        sensor_value(
+            residual_fn, x, sigma, target=target, candidate=c,
+            candidate_sigma=s, names=names, params=params,
+        )
+        for c, s in zip(candidates, sigmas)
+    ]
+    return sorted(out, key=lambda d: -d["variance_reduction"])

--- a/src/difflow/reconciliation/gross_error.py
+++ b/src/difflow/reconciliation/gross_error.py
@@ -1,0 +1,277 @@
+"""Gross error detection: the global test, the measurement test, elimination.
+
+Reconciliation assumes the measurement errors are zero-mean and normal.
+A miscalibrated, drifting or failed sensor breaks that assumption, and
+because least squares spreads a single large error across *all* the
+adjustments ("smearing"), a gross error left in the data corrupts every
+reconciled value, not just its own.
+
+Two classical tests, both read off quantities the reconciliation has
+already produced:
+
+* the **global test** asks whether the whole data set is consistent
+  with the model. The optimal objective is itself the statistic, and it
+  is distributed :math:`\\chi^2` on the degrees of redundancy. (The
+  often-quoted form :math:`F(y)^T (A \\Sigma A^T)^{-1} F(y)` is a
+  special case that cannot be evaluated at all when some variable is
+  unmeasured, and carries the wrong degrees of freedom.)
+* the **measurement test** standardizes each adjustment by its own
+  standard deviation to point at the sensor responsible.
+
+A measurement nothing checks has zero adjustment variance, so it is not
+testable. Because both that fact and the redundancy classification come
+from the same :math:`\\Sigma_{\\hat x}`, they cannot disagree.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+import jax.numpy as jnp
+import numpy as np
+from scipy import stats
+
+from difflow.params_mixin import ParamsMixin
+
+from difflow.reconciliation.core import measured_mask
+from difflow.reconciliation.reconcile import ReconcileResult, reconcile
+from difflow.reconciliation.structure import REDUNDANCY_TOL
+
+
+@dataclass
+class GlobalTestResult(ParamsMixin):
+    """Whether the data set as a whole is consistent with the model.
+
+    Attributes:
+        statistic: the reconciliation objective.
+        dof: degrees of redundancy.
+        critical: the ``1 - alpha`` quantile of ``chi2(dof)``.
+        p_value: probability of a statistic this large under H0.
+        detected: ``statistic > critical``.
+        alpha: significance level used.
+    """
+
+    statistic: float
+    dof: int
+    critical: float
+    p_value: float
+    detected: bool
+    alpha: float
+
+    def __str__(self) -> str:
+        verdict = "GROSS ERROR DETECTED" if self.detected else "no gross error"
+        return (
+            f"global test: chi2 = {self.statistic:.3f} on {self.dof} dof, "
+            f"critical = {self.critical:.3f}, p = {self.p_value:.3g} "
+            f"-> {verdict}"
+        )
+
+
+@dataclass
+class MeasurementTestResult(ParamsMixin):
+    """Per-sensor standardized adjustments.
+
+    Attributes:
+        z: variable -> standardized adjustment; ``nan`` when the
+            measurement carries no redundancy and so cannot be tested.
+        critical: two-sided normal critical value, Bonferroni-corrected
+            across the testable measurements by default.
+        suspect: the testable variable with the largest ``|z|``, or
+            ``None`` if nothing exceeds ``critical``.
+        z_max: that largest ``|z|``.
+        detected: whether any ``|z|`` exceeds ``critical``.
+        testable: variable -> whether it carries enough redundancy.
+    """
+
+    z: dict[str, float]
+    critical: float
+    suspect: str | None
+    z_max: float
+    detected: bool
+    testable: dict[str, bool]
+    alpha: float = 0.05
+
+    def ranked(self) -> list[tuple[str, float]]:
+        """Testable variables sorted by decreasing ``|z|``."""
+        items = [
+            (nm, v) for nm, v in self.z.items()
+            if self.testable.get(nm, False) and np.isfinite(v)
+        ]
+        return sorted(items, key=lambda kv: -abs(kv[1]))
+
+    def __str__(self) -> str:
+        rows = self.ranked()[:5]
+        head = (
+            f"measurement test (|z| > {self.critical:.3f}): "
+            + (f"suspect {self.suspect}" if self.suspect else "nothing flagged")
+        )
+        return "\n".join([head] + [f"  {nm:<20} z = {v:+.3f}" for nm, v in rows])
+
+
+def global_test(result: ReconcileResult, alpha: float = 0.05) -> GlobalTestResult:
+    """Chi-squared test on the whole data set.
+
+    Args:
+        result: a finished reconciliation.
+        alpha: significance level.
+
+    Returns:
+        A :class:`GlobalTestResult`.
+    """
+    dof = int(result.structure.degree_of_redundancy)
+    stat = float(result.objective)
+    if dof <= 0:
+        return GlobalTestResult(
+            statistic=stat, dof=0, critical=float("inf"), p_value=1.0,
+            detected=False, alpha=alpha,
+        )
+    critical = float(stats.chi2.ppf(1.0 - alpha, dof))
+    p_value = float(stats.chi2.sf(stat, dof))
+    return GlobalTestResult(
+        statistic=stat, dof=dof, critical=critical, p_value=p_value,
+        detected=bool(stat > critical), alpha=alpha,
+    )
+
+
+def measurement_test(
+    result: ReconcileResult,
+    alpha: float = 0.05,
+    *,
+    bonferroni: bool = True,
+    min_redundancy: float = REDUNDANCY_TOL,
+) -> MeasurementTestResult:
+    """Standardized adjustments, to identify which sensor is at fault.
+
+    The adjustment covariance is :math:`\\Sigma_{adj} = \\Sigma -
+    \\Sigma_{\\hat x}` on the measured block, so
+    :math:`z_i = (\\hat x_i - y_i)/\\sqrt{\\Sigma_{adj,ii}}` is standard
+    normal under the null hypothesis.
+
+    Args:
+        result: a finished reconciliation.
+        alpha: significance level.
+        bonferroni: correct the critical value for the number of
+            simultaneous tests (recommended; without it, one false
+            positive per twenty sensors is expected by construction).
+        min_redundancy: adjustment variance below this fraction of
+            ``sigma^2`` marks a measurement as untestable.
+
+    Returns:
+        A :class:`MeasurementTestResult`.
+    """
+    sigma = np.asarray(result.sigma, dtype=float)
+    x = np.asarray(result.x, dtype=float)
+    y = np.asarray(result.y, dtype=float)
+    var_hat = np.diag(np.asarray(result.covariance, dtype=float))
+    mask = np.asarray(measured_mask(result.sigma))
+
+    z: dict[str, float] = {}
+    testable: dict[str, bool] = {}
+    for i, nm in enumerate(result.names):
+        var_adj = sigma[i] ** 2 - var_hat[i] if mask[i] else 0.0
+        ok = bool(mask[i] and var_adj > min_redundancy * sigma[i] ** 2)
+        testable[nm] = ok
+        z[nm] = float((x[i] - y[i]) / np.sqrt(var_adj)) if ok else float("nan")
+
+    n_tests = max(sum(testable.values()), 1)
+    level = alpha / n_tests if bonferroni else alpha
+    critical = float(stats.norm.ppf(1.0 - level / 2.0))
+
+    candidates = [(nm, abs(v)) for nm, v in z.items() if testable[nm]]
+    if candidates:
+        suspect, z_max = max(candidates, key=lambda kv: kv[1])
+    else:
+        suspect, z_max = None, 0.0
+    detected = bool(z_max > critical)
+    return MeasurementTestResult(
+        z=z, critical=critical,
+        suspect=suspect if detected else None,
+        z_max=float(z_max), detected=detected, testable=testable, alpha=alpha,
+    )
+
+
+@dataclass
+class EliminationStep(ParamsMixin):
+    """One round of serial elimination.
+
+    Attributes:
+        removed: the measurement discarded to reach this round, or
+            ``None`` for the initial round.
+        statistic, dof, critical, p_value: the global test of this round.
+        detected: whether the global test still rejects.
+        suspect: the measurement the measurement test now points at.
+        z_max: its standardized adjustment.
+    """
+
+    removed: str | None
+    statistic: float
+    dof: int
+    critical: float
+    p_value: float
+    detected: bool
+    suspect: str | None
+    z_max: float
+
+
+def serial_elimination(
+    residual_fn: Callable,
+    y,
+    sigma,
+    *,
+    alpha: float = 0.05,
+    max_removed: int = 3,
+    names=None,
+    **reconcile_kw: Any,
+) -> list[EliminationStep]:
+    """Repeatedly discard the most suspect measurement until data is clean.
+
+    Each round reconciles, runs the global test, and --- if it still
+    rejects --- marks the measurement with the largest standardized
+    adjustment as unmeasured (``sigma = inf``) and repeats. Discarding a
+    measurement costs one degree of redundancy, so the procedure stops
+    once the global test passes, ``max_removed`` is reached, or the
+    remaining problem would become unobservable.
+
+    Args:
+        residual_fn: ``F(x, params) -> (m,)``.
+        y: measurements.
+        sigma: standard deviations.
+        alpha: significance level for both tests.
+        max_removed: cap on discarded measurements.
+        names: variable names.
+        **reconcile_kw: forwarded to :func:`reconcile`.
+
+    Returns:
+        One :class:`EliminationStep` per round, oldest first. The last
+        entry has ``detected=False`` if the data ended up clean.
+    """
+    from difflow.reconciliation.structure import ReconciliationStructureError
+
+    sigma = jnp.asarray(sigma, dtype=jnp.float64)
+    steps: list[EliminationStep] = []
+    removed: str | None = None
+
+    for _ in range(max_removed + 1):
+        try:
+            res = reconcile(
+                residual_fn, y, sigma, names=names, **reconcile_kw
+            )
+        except ReconciliationStructureError:
+            break
+        gt = global_test(res, alpha=alpha)
+        mt = measurement_test(res, alpha=alpha)
+        steps.append(
+            EliminationStep(
+                removed=removed, statistic=gt.statistic, dof=gt.dof,
+                critical=gt.critical, p_value=gt.p_value,
+                detected=gt.detected, suspect=mt.suspect, z_max=mt.z_max,
+            )
+        )
+        if not gt.detected or mt.suspect is None:
+            break
+        idx = res.names.index(mt.suspect)
+        sigma = sigma.at[idx].set(jnp.inf)
+        removed = mt.suspect
+
+    return steps

--- a/src/difflow/reconciliation/reconcile.py
+++ b/src/difflow/reconciliation/reconcile.py
@@ -1,0 +1,240 @@
+"""The user-facing reconciliation entry point."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Sequence
+
+import jax.numpy as jnp
+import numpy as np
+from jax import Array
+
+from difflow.params_mixin import ParamsMixin
+
+from difflow.reconciliation.core import (
+    Scaling,
+    auto_scaling,
+    identity_scaling,
+    measured_mask,
+    reconciled_covariance,
+    solve_reconciliation,
+)
+from difflow.reconciliation.structure import StructureReport, classify
+
+
+@dataclass
+class ReconcileResult(ParamsMixin):
+    """Outcome of a data reconciliation.
+
+    Attributes:
+        x: reconciled state, shape ``(n,)``.
+        x_named: the same, as ``{name: value}``.
+        adjustment: ``x - y``, ``nan`` where unmeasured.
+        multipliers: Lagrange multipliers of the constraints.
+        objective: the weighted sum of squared adjustments. This is
+            also the global-test statistic; see
+            :func:`difflow.reconciliation.global_test`.
+        residual: ``F(x)`` at the solution.
+        residual_norm: its infinity norm.
+        covariance: covariance of the reconciled estimates.
+        std: their standard deviations, as ``{name: value}``.
+        converged: whether the constraints are satisfied to ``tol``.
+        names: variable names.
+        sigma: the standard deviations used.
+        structure: the observability/redundancy report.
+        scaling: the scaling actually used.
+    """
+
+    x: Array
+    x_named: dict[str, float]
+    adjustment: Array
+    multipliers: Array
+    objective: float
+    residual: Array
+    residual_norm: float
+    covariance: Array
+    std: dict[str, float]
+    converged: bool
+    names: list[str]
+    sigma: Array
+    structure: StructureReport
+    scaling: Scaling
+    n_steps: int = 0
+    y: Array | None = None
+
+    def std_of(self, name: str) -> float:
+        """Standard deviation of one reconciled estimate."""
+        return self.std[name]
+
+    def summary(self) -> str:
+        """Table of measurements, reconciled values and adjustments."""
+        sig = np.asarray(self.sigma, dtype=float)
+        y = np.asarray(self.y, dtype=float) if self.y is not None else None
+        x = np.asarray(self.x, dtype=float)
+        lines = [
+            f"objective {self.objective:.4g} on "
+            f"{self.structure.degree_of_redundancy} degrees of redundancy, "
+            f"|F| = {self.residual_norm:.3g}, converged = {self.converged}",
+            "",
+            f"{'variable':<20} {'measured':>12} {'reconciled':>12} "
+            f"{'adjust':>10} {'sigma':>9} {'sd_hat':>9}",
+            "-" * 76,
+        ]
+        for i, nm in enumerate(self.names):
+            meas = "-" if y is None or not np.isfinite(sig[i]) else f"{y[i]:12.4f}"
+            adj = (
+                "-"
+                if y is None or not np.isfinite(sig[i])
+                else f"{x[i] - y[i]:10.4f}"
+            )
+            sg = "-" if not np.isfinite(sig[i]) else f"{sig[i]:9.4f}"
+            lines.append(
+                f"{nm:<20} {meas:>12} {x[i]:12.4f} {adj:>10} {sg:>9} "
+                f"{self.std[nm]:9.4f}"
+            )
+        return "\n".join(lines)
+
+
+def reconcile(
+    residual_fn: Callable,
+    y: Array,
+    sigma: Array,
+    *,
+    params: Any = None,
+    names: Sequence[str] | None = None,
+    x0: Array | None = None,
+    unmeasured_init: Array | float | None = None,
+    unmeasured_scale: Array | float | None = None,
+    scaling: Scaling | bool = True,
+    max_steps: int = 20,
+    tol: float = 1e-9,
+    method: str = "gauss_newton",
+    check_structure: bool = True,
+    rank_tol: float | None = None,
+) -> ReconcileResult:
+    """Reconcile measurements against a model's constraint equations.
+
+    Solves :math:`\\min (x-y)^T W (x-y)` subject to
+    :math:`F(x, \\theta) = 0`, where entries of ``sigma`` that are
+    infinite mark variables to be *estimated* rather than reconciled.
+    A finite sigma on an unmetered variable acts as a prior, which is
+    the graceful way to handle a weakly identified parameter.
+
+    Args:
+        residual_fn: ``F(x, params) -> (m,)``, JAX-traceable.
+        y: measurements, shape ``(n,)``. Entries with infinite sigma
+            are ignored and may be ``nan``.
+        sigma: standard deviations, shape ``(n,)``; ``inf`` or ``nan``
+            marks an unmeasured variable.
+        params: extra argument threaded to ``residual_fn``; gradients
+            with respect to it are exact, which answers a different
+            question from estimating a variable (how the reconciled
+            state would move if a *fixed* model parameter changed).
+        names: variable names for reporting, defaulting to ``x0...``.
+        x0: full initial state. Defaults to ``y`` on measured entries
+            and ``unmeasured_init`` elsewhere.
+        unmeasured_init: starting value for unmeasured entries
+            (default 1.0), used only when ``x0`` is not given.
+        unmeasured_scale: typical magnitude of unmeasured entries, for
+            scaling; defaults to their initial magnitude.
+        scaling: ``True`` for automatic scaling (recommended and the
+            default), a :class:`Scaling` to force one, or ``False`` to
+            solve in raw units.
+        max_steps: Gauss-Newton iterations.
+        tol: constraint tolerance deciding ``converged``.
+        method: ``"gauss_newton"`` or ``"newton"``.
+        check_structure: run the observability check first and raise
+            :class:`~difflow.reconciliation.ReconciliationStructureError`
+            rather than returning a NaN state. Turn it off only inside
+            a ``jit``/``vmap`` sweep whose structure you have already
+            validated.
+        rank_tol: override the rank threshold of the structure check.
+
+    Returns:
+        A :class:`ReconcileResult`.
+
+    Raises:
+        ReconciliationStructureError: if unmeasured variables cannot be
+            determined from the constraints.
+
+    Example:
+        >>> res = reconcile(F, y, sigma, names=layout.names)
+        >>> res.objective, res.std_of("q_p3")
+    """
+    y = jnp.asarray(y, dtype=jnp.float64)
+    sigma = jnp.asarray(sigma, dtype=jnp.float64)
+    n = y.shape[0]
+    if sigma.shape != y.shape:
+        raise ValueError(
+            f"sigma has shape {sigma.shape} but y has shape {y.shape}"
+        )
+    names = list(names) if names is not None else [f"x{i}" for i in range(n)]
+    if len(names) != n:
+        raise ValueError(f"got {len(names)} names for {n} variables")
+
+    mask = measured_mask(sigma)
+    if x0 is None:
+        init = 1.0 if unmeasured_init is None else unmeasured_init
+        init = jnp.broadcast_to(jnp.asarray(init, dtype=jnp.float64), y.shape)
+        x0 = jnp.where(mask, jnp.where(mask, y, 0.0), init)
+    x0 = jnp.asarray(x0, dtype=jnp.float64)
+
+    m = int(residual_fn(x0, params).shape[0])
+    if scaling is True:
+        sc = auto_scaling(
+            residual_fn, x0, sigma, params=params,
+            unmeasured_scale=unmeasured_scale,
+        )
+    elif scaling is False:
+        sc = identity_scaling(n, m)
+    else:
+        sc = scaling
+
+    if check_structure:
+        classify(
+            residual_fn, x0, sigma, scaling=sc, params=params,
+            names=names, rank_tol=rank_tol,
+        ).raise_if_unsolvable()
+
+    x_hat, multipliers = solve_reconciliation(
+        residual_fn, y, sigma, x0=x0, scaling=sc, params=params,
+        n_steps=max_steps, method=method,
+    )
+
+    residual = residual_fn(x_hat, params)
+    residual_norm = float(jnp.max(jnp.abs(residual)))
+    adjustment = jnp.where(mask, x_hat - jnp.where(mask, y, 0.0), jnp.nan)
+    objective = float(
+        jnp.sum(jnp.where(mask, (x_hat - jnp.where(mask, y, 0.0)) ** 2
+                          / jnp.where(mask, sigma, 1.0) ** 2, 0.0))
+    )
+
+    covariance = reconciled_covariance(
+        residual_fn, x_hat, sigma, scaling=sc, params=params
+    )
+    std_arr = jnp.sqrt(jnp.clip(jnp.diag(covariance), 0.0, jnp.inf))
+    std = {nm: float(std_arr[i]) for i, nm in enumerate(names)}
+
+    structure = classify(
+        residual_fn, x_hat, sigma, scaling=sc, params=params,
+        names=names, rank_tol=rank_tol, covariance=covariance,
+    )
+
+    return ReconcileResult(
+        x=x_hat,
+        x_named={nm: float(x_hat[i]) for i, nm in enumerate(names)},
+        adjustment=adjustment,
+        multipliers=multipliers,
+        objective=objective,
+        residual=residual,
+        residual_norm=residual_norm,
+        covariance=covariance,
+        std=std,
+        converged=bool(residual_norm < tol),
+        names=names,
+        sigma=sigma,
+        structure=structure,
+        scaling=sc,
+        n_steps=max_steps,
+        y=y,
+    )

--- a/src/difflow/reconciliation/structure.py
+++ b/src/difflow/reconciliation/structure.py
@@ -1,0 +1,298 @@
+"""Observability, redundancy and solvability of a reconciliation problem.
+
+Whether the KKT system can be solved and whether the unmeasured
+variables can be observed are *the same question*. For
+
+.. math::
+
+    K = \\begin{bmatrix} W & A^T \\\\ A & 0 \\end{bmatrix},
+    \\qquad W \\succeq 0,
+
+:math:`K` is nonsingular if and only if :math:`A` has full row rank and
+:math:`Z^T W Z \\succ 0` on a basis :math:`Z` of :math:`\\ker A`. With
+:math:`W` diagonal, positive on measured entries and zero elsewhere,
+the second condition collapses to
+
+    **the unmeasured columns** :math:`A_U` **must have full column rank**
+
+which is exactly the classical observability condition of data
+reconciliation. So this module runs *before* the solve: a problem that
+would produce a singular KKT matrix raises
+:class:`ReconciliationStructureError` naming the variables responsible,
+instead of returning NaN.
+
+Ranks and variable classes are discrete, so they are not differentiable
+and do not pretend to be: this module works in NumPy, mirroring the
+split in :mod:`difflow.estimation.confidence`, which takes derivatives
+with JAX and then does statistics with SciPy.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Sequence
+
+import numpy as np
+from jax import Array
+
+from difflow.params_mixin import ParamsMixin
+
+from difflow.reconciliation.core import (
+    Scaling,
+    jacobian_of,
+    measured_mask,
+    reconciled_covariance,
+)
+
+#: measured, and checked by at least one constraint
+MEASURED_REDUNDANT = "measured-redundant"
+#: measured, but nothing constrains it -- it passes through unchanged
+MEASURED_JUST_DETERMINED = "measured-just-determined"
+#: unmeasured, but determined by the constraints
+UNMEASURED_OBSERVABLE = "unmeasured-observable"
+#: unmeasured and not determined -- the problem is ill-posed
+UNMEASURED_UNOBSERVABLE = "unmeasured-unobservable"
+
+#: below this, a measurement is treated as carrying no redundancy
+REDUNDANCY_TOL = 1e-8
+
+
+class ReconciliationStructureError(ValueError):
+    """The reconciliation problem is structurally unsolvable.
+
+    Raised when the unmeasured variables cannot be determined from the
+    constraints, or when the constraints are linearly dependent. The
+    message names the variables involved.
+    """
+
+
+@dataclass
+class StructureReport(ParamsMixin):
+    """Observability and redundancy structure of a reconciliation problem.
+
+    Attributes:
+        classes: variable name -> one of the four class constants.
+        degree_of_redundancy: ``m - rank(A_U)``; the degrees of freedom
+            of the global chi-squared test.
+        redundancy: measured variable -> ``1 - Var(x_hat_i)/sigma_i^2``
+            in ``[0, 1]``. Zero means the measurement is unchecked.
+        rank_A, rank_A_unmeasured: numerical ranks.
+        singular_values_A, singular_values_A_unmeasured: full spectra,
+            so a marginal case can be inspected rather than guessed at.
+        rank_tol: the threshold used.
+        rank_gap: ratio of the smallest retained to the largest
+            discarded singular value of ``A_U``; small means the
+            classification is tolerance-dependent.
+        solvable: whether the KKT system is nonsingular.
+        reason: empty when solvable, else a short diagnosis.
+        unobservable: names of the unmeasured variables implicated in a
+            null-space direction.
+    """
+
+    classes: dict[str, str]
+    degree_of_redundancy: int
+    redundancy: dict[str, float]
+    rank_A: int
+    rank_A_unmeasured: int
+    n_equations: int
+    n_measured: int
+    n_unmeasured: int
+    singular_values_A: np.ndarray
+    singular_values_A_unmeasured: np.ndarray
+    rank_tol: float
+    rank_gap: float
+    solvable: bool
+    reason: str = ""
+    unobservable: list[str] = field(default_factory=list)
+    names: list[str] = field(default_factory=list)
+
+    def raise_if_unsolvable(self) -> None:
+        """Raise :class:`ReconciliationStructureError` if not solvable."""
+        if self.solvable:
+            return
+        detail = ""
+        if self.unobservable:
+            detail = f" Unobservable: {', '.join(self.unobservable)}."
+        raise ReconciliationStructureError(
+            f"reconciliation problem is not solvable: {self.reason}.{detail} "
+            f"({self.n_equations} equations, {self.n_measured} measured and "
+            f"{self.n_unmeasured} unmeasured variables; "
+            f"rank(A)={self.rank_A}, rank(A_unmeasured)="
+            f"{self.rank_A_unmeasured}). Measure one of the variables above, "
+            "give it a finite sigma as a prior, or remove it from the state."
+        )
+
+    def summary(self) -> str:
+        """Human-readable table of the classification."""
+        lines = [
+            f"degrees of redundancy : {self.degree_of_redundancy}",
+            f"equations             : {self.n_equations}",
+            f"measured / unmeasured : {self.n_measured} / {self.n_unmeasured}",
+            f"solvable              : {self.solvable}"
+            + (f"  ({self.reason})" if self.reason else ""),
+            "",
+            f"{'variable':<20} {'class':<28} {'redundancy':>10}",
+            "-" * 60,
+        ]
+        for name in self.names:
+            red = self.redundancy.get(name)
+            red_s = f"{red:10.3f}" if red is not None else " " * 10
+            lines.append(f"{name:<20} {self.classes[name]:<28} {red_s}")
+        return "\n".join(lines)
+
+
+def _rank_and_spectrum(a: np.ndarray, tol: float | None):
+    """Numerical rank of ``a`` by SVD, with the spectrum and threshold.
+
+    SVD, never the eigenvalues of ``a.T @ a``: squaring the matrix
+    squares its condition number, so a structurally zero singular value
+    reappears near ``sqrt(eps) * sigma_max`` and an unobservable system
+    is reported as full rank.
+    """
+    if a.size == 0 or a.shape[1] == 0:
+        return 0, np.zeros(0), (tol or 0.0), float("inf")
+    s = np.linalg.svd(a, compute_uv=False)
+    if tol is None:
+        # sqrt(eps), not eps: A is evaluated at an approximate solution,
+        # so structural zeros are only zero to about that.
+        tol = max(a.shape) * np.sqrt(np.finfo(float).eps) * s[0]
+    rank = int((s > tol).sum())
+    if 0 < rank < len(s):
+        gap = float(s[rank - 1] / s[rank]) if s[rank] > 0 else float("inf")
+    else:
+        gap = float("inf")
+    return rank, s, float(tol), gap
+
+
+def classify(
+    residual_fn: Callable,
+    x: Array,
+    sigma: Array,
+    *,
+    scaling: Scaling,
+    params: Any = None,
+    names: Sequence[str] | None = None,
+    rank_tol: float | None = None,
+    covariance: Array | None = None,
+) -> StructureReport:
+    """Classify every variable and decide whether the problem is solvable.
+
+    Args:
+        residual_fn: ``F(x, params) -> (m,)``.
+        x: point to linearize about.
+        sigma: standard deviations; ``inf`` = unmeasured.
+        scaling: the scaling the problem is solved in; the Jacobian is
+            equilibrated with it before any rank test, so the answer
+            does not depend on the unit system.
+        params: extra argument threaded to ``residual_fn``.
+        names: variable names, defaulting to ``x0, x1, ...``.
+        rank_tol: override the singular-value threshold.
+        covariance: precomputed reconciled covariance, to avoid solving
+            the KKT system twice.
+
+    Returns:
+        A :class:`StructureReport`. It does *not* raise; call
+        :meth:`StructureReport.raise_if_unsolvable` for that.
+    """
+    x = np.asarray(x, dtype=float)
+    n = x.shape[0]
+    names = list(names) if names is not None else [f"x{i}" for i in range(n)]
+    if len(names) != n:
+        raise ValueError(f"got {len(names)} names for {n} variables")
+
+    mask = np.asarray(measured_mask(sigma))
+    a = np.asarray(jacobian_of(residual_fn, x, params), dtype=float)
+    # Equilibrate rows and columns before any rank decision.
+    a_s = np.asarray(scaling.r)[:, None] * a * np.asarray(scaling.d)[None, :]
+    m = a_s.shape[0]
+
+    rank_a, sv_a, tol, _ = _rank_and_spectrum(a_s, rank_tol)
+    a_u = a_s[:, ~mask]
+    n_u = int((~mask).sum())
+    rank_u, sv_u, _, gap = _rank_and_spectrum(a_u, tol)
+
+    unobservable: list[str] = []
+    if n_u and rank_u < n_u:
+        # Right singular vectors below the threshold span the null
+        # space; a direction implicates a *set* of variables, not one.
+        _, _, vh = np.linalg.svd(a_u, full_matrices=True)
+        u_names = [nm for nm, mk in zip(names, mask) if not mk]
+        implicated: set[str] = set()
+        for k in range(rank_u, len(u_names)):
+            vec = np.abs(vh[k])
+            if vec.max() <= 0:
+                continue
+            for j in np.where(vec > 0.1 * vec.max())[0]:
+                implicated.add(u_names[j])
+        unobservable = [nm for nm in u_names if nm in implicated]
+
+    reasons = []
+    if rank_a < m:
+        reasons.append(
+            f"the {m} constraints are linearly dependent (rank {rank_a})"
+        )
+    if n_u and rank_u < n_u:
+        reasons.append(
+            f"{n_u - rank_u} unmeasured variable(s) cannot be determined "
+            "from the constraints"
+        )
+    solvable = not reasons
+
+    redundancy: dict[str, float] = {}
+    classes: dict[str, str] = {}
+    if solvable:
+        if covariance is None:
+            covariance = reconciled_covariance(
+                residual_fn, x, sigma, scaling=scaling, params=params
+            )
+        var = np.diag(np.asarray(covariance, dtype=float))
+        sig = np.asarray(sigma, dtype=float)
+        for i, nm in enumerate(names):
+            if mask[i]:
+                # Var(x_hat_i - y_i) = sigma_i^2 - Var(x_hat_i); zero
+                # means nothing checks this measurement, which is the
+                # same quantity the measurement test divides by, so
+                # "non-redundant" and "not testable" cannot disagree.
+                red = float(1.0 - var[i] / (sig[i] ** 2))
+                redundancy[nm] = min(max(red, 0.0), 1.0)
+                classes[nm] = (
+                    MEASURED_REDUNDANT
+                    if red > REDUNDANCY_TOL
+                    else MEASURED_JUST_DETERMINED
+                )
+            else:
+                classes[nm] = UNMEASURED_OBSERVABLE
+    else:
+        for i, nm in enumerate(names):
+            if mask[i]:
+                classes[nm] = MEASURED_REDUNDANT
+            elif nm in unobservable:
+                classes[nm] = UNMEASURED_UNOBSERVABLE
+            else:
+                classes[nm] = UNMEASURED_OBSERVABLE
+
+    reason = "; ".join(reasons)
+    if solvable and gap < 1e3:
+        reason = (
+            f"no clean rank gap (ratio {gap:.3g}); the classification is "
+            "sensitive to rank_tol"
+        )
+
+    return StructureReport(
+        classes=classes,
+        degree_of_redundancy=int(m - rank_u),
+        redundancy=redundancy,
+        rank_A=rank_a,
+        rank_A_unmeasured=rank_u,
+        n_equations=m,
+        n_measured=int(mask.sum()),
+        n_unmeasured=n_u,
+        singular_values_A=sv_a,
+        singular_values_A_unmeasured=sv_u,
+        rank_tol=tol,
+        rank_gap=gap,
+        solvable=solvable,
+        reason=reason,
+        unobservable=unobservable,
+        names=names,
+    )

--- a/src/difflow_gas/__init__.py
+++ b/src/difflow_gas/__init__.py
@@ -145,6 +145,24 @@ from difflow_gas.flowsheets import (
 from difflow_gas import verify
 from difflow_gas.verify import ResidualReport, residual_report, residuals_from_values
 
+# ---------------------------------------------------------------------
+# Differentiable residuals and data reconciliation
+# ---------------------------------------------------------------------
+
+from difflow_gas.residuals import (
+    GasStateLayout,
+    gas_state_layout,
+    network_residuals,
+    residual_names,
+)
+from difflow_gas.reconcile import (
+    measurement_sigma,
+    network_residual_fn,
+    perturb,
+    reconcile_network,
+    reconciled_values,
+)
+
 __all__ = [
     "__version__",
     # physics
@@ -217,6 +235,17 @@ __all__ = [
     "ResidualReport",
     "residual_report",
     "residuals_from_values",
+    # differentiable residuals
+    "GasStateLayout",
+    "gas_state_layout",
+    "network_residuals",
+    "residual_names",
+    # data reconciliation
+    "reconcile_network",
+    "network_residual_fn",
+    "measurement_sigma",
+    "perturb",
+    "reconciled_values",
 ]
 
 

--- a/src/difflow_gas/reconcile.py
+++ b/src/difflow_gas/reconcile.py
@@ -1,0 +1,204 @@
+"""Data reconciliation of a gas transmission network.
+
+A thin layer over :mod:`difflow.reconciliation`: it builds the residual
+closure from a network and a layout, supplies plausible meter
+accuracies, and converts a reconciled state back into the ``p_bar`` /
+``q_kg_s`` dicts that :mod:`difflow_gas.verify` consumes --- so a
+reconciliation can be checked with the same verifier as any other
+solution of the same network.
+
+Note that measured boundary flows are deliberately *not* stored in a
+:class:`~difflow_gas.network.GasNetwork`: real nominations do not sum
+to zero, and the network object rejects supplies that do not. They live
+in the measurement vector, and making them balance is precisely what
+the reconciliation does.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Sequence
+
+import jax
+import jax.numpy as jnp
+from jax import Array
+
+from difflow.reconciliation import ReconcileResult, reconcile
+
+from difflow_gas.network import GasNetwork
+from difflow_gas.residuals import GasStateLayout, network_residuals
+
+
+def network_residual_fn(
+    network: GasNetwork,
+    layout: GasStateLayout,
+    *,
+    ratios: dict[str, float] | None = None,
+    cv_drops_bar: dict[str, float] | None = None,
+    **kwargs: Any,
+):
+    """Close a network and layout into an ``F(x, params) -> Array``.
+
+    ``params``, when given, is merged into the ``efficiencies``
+    argument of :func:`~difflow_gas.residuals.network_residuals`, so
+    ``jax.grad`` with respect to it answers "how would the reconciled
+    state move if this pipe were dirtier?" --- a different question
+    from estimating the efficiency, which is done by putting it in the
+    layout instead.
+    """
+    def residual_fn(x, params=None):
+        eff = dict(kwargs.pop("efficiencies", None) or {})
+        if params:
+            eff.update(params)
+        return network_residuals(
+            x, network, layout, ratios=ratios,
+            cv_drops_bar=cv_drops_bar, efficiencies=eff or None, **kwargs,
+        )
+
+    return residual_fn
+
+
+def measurement_sigma(
+    layout: GasStateLayout,
+    *,
+    sigma_p_bar: float = 0.3,
+    sigma_q_kg_s: float = 1.0,
+    sigma_supply_kg_s: float = 1.5,
+    sigma_ratio: float = 0.005,
+    sigma_eta: float = float("inf"),
+    sigma_dp_bar: float = float("inf"),
+    unmeasured: Sequence[str] = (),
+    overrides: dict[str, float] | None = None,
+) -> Array:
+    """Per-variable measurement accuracies for a gas network state.
+
+    Defaults reflect transmission practice: pressure transmitters are
+    good, flow meters less so, and nominated boundary flows are the
+    least reliable numbers in the system. Efficiencies and valve drops
+    default to ``inf``, i.e. estimated rather than measured.
+
+    Args:
+        layout: the state layout.
+        sigma_p_bar: node pressure accuracy (bar).
+        sigma_q_kg_s: arc flow meter accuracy (kg/s).
+        sigma_supply_kg_s: boundary flow / nomination accuracy (kg/s).
+        sigma_ratio: compressor ratio set-point readback accuracy.
+        sigma_eta: pipe efficiency accuracy; ``inf`` estimates it, a
+            finite value acts as a prior.
+        sigma_dp_bar: control valve drop accuracy.
+        unmeasured: variable names to force to ``inf``.
+        overrides: variable name -> sigma, applied last.
+
+    Returns:
+        Standard deviations, shape ``(layout.size,)``.
+    """
+    inf = float("inf")
+    values = (
+        [sigma_p_bar] * layout.n_p
+        + [sigma_q_kg_s] * layout.n_q
+        + [sigma_supply_kg_s] * layout.n_s
+        + [sigma_eta] * len(layout.efficiency_arcs)
+        + [sigma_ratio] * len(layout.ratio_arcs)
+        + [sigma_dp_bar] * len(layout.cv_arcs)
+    )
+    sigma = dict(zip(layout.names, values))
+    for name in unmeasured:
+        if name not in sigma:
+            raise KeyError(f"{name!r} is not a variable of this layout")
+        sigma[name] = inf
+    for name, val in (overrides or {}).items():
+        if name not in sigma:
+            raise KeyError(f"{name!r} is not a variable of this layout")
+        sigma[name] = val
+    return jnp.array([sigma[n] for n in layout.names], dtype=jnp.float64)
+
+
+def perturb(
+    x_true: Array,
+    sigma: Array,
+    key,
+    *,
+    layout: GasStateLayout | None = None,
+    gross_errors: dict[str, float] | None = None,
+) -> Array:
+    """Add measurement noise, and optionally a gross error, to a state.
+
+    Unmeasured entries (infinite sigma) are left untouched, so the
+    result can be handed straight to :func:`reconcile_network`.
+
+    Args:
+        x_true: the true state.
+        sigma: standard deviations; ``inf`` entries get no noise.
+        key: a ``jax.random`` key.
+        layout: needed only when ``gross_errors`` is given.
+        gross_errors: variable name -> bias **in multiples of that
+            variable's sigma**.
+
+    Returns:
+        The simulated measurement vector.
+    """
+    sigma = jnp.asarray(sigma, dtype=jnp.float64)
+    noise = jax.random.normal(key, x_true.shape)
+    finite = jnp.isfinite(sigma)
+    y = x_true + jnp.where(finite, jnp.where(finite, sigma, 0.0) * noise, 0.0)
+    for name, n_sigma in (gross_errors or {}).items():
+        if layout is None:
+            raise ValueError("a layout is required to place gross errors")
+        i = layout.index(name)
+        y = y.at[i].add(n_sigma * sigma[i])
+    return y
+
+
+def reconcile_network(
+    network: GasNetwork,
+    y: Array,
+    sigma: Array,
+    layout: GasStateLayout,
+    *,
+    ratios: dict[str, float] | None = None,
+    cv_drops_bar: dict[str, float] | None = None,
+    **kwargs: Any,
+) -> ReconcileResult:
+    """Reconcile measured pressures, flows and nominations of a network.
+
+    Args:
+        network: the network the measurements belong to.
+        y: measurement vector, packed by ``layout``.
+        sigma: standard deviations; ``inf`` = unmeasured.
+        layout: the state layout.
+        ratios: compressor ratios not carried in the state.
+        cv_drops_bar: control valve drops not carried in the state.
+        **kwargs: forwarded to :func:`difflow.reconciliation.reconcile`.
+
+    Returns:
+        A :class:`~difflow.reconciliation.ReconcileResult` whose
+        ``names`` are ``layout.names``.
+
+    Example:
+        >>> layout = gas_state_layout(net)
+        >>> sigma = measurement_sigma(layout)
+        >>> y = perturb(x_true, sigma, jax.random.PRNGKey(0))
+        >>> res = reconcile_network(net, y, sigma, layout, ratios={"cs1": 1.2})
+    """
+    kwargs.setdefault("names", layout.names)
+    kwargs.setdefault("unmeasured_scale", layout.default_scale)
+    residual_fn = network_residual_fn(
+        network, layout, ratios=ratios, cv_drops_bar=cv_drops_bar
+    )
+    return reconcile(residual_fn, y, sigma, **kwargs)
+
+
+def reconciled_values(
+    result: ReconcileResult, layout: GasStateLayout
+) -> tuple[dict[str, float], dict[str, float], dict[str, float]]:
+    """Split a reconciled state into ``(p_bar, q_kg_s, supply_kg_s)``.
+
+    The dicts are plain floats, ready for
+    :func:`difflow_gas.verify.residuals_from_values` --- which is how a
+    reconciliation gets checked by the same verifier as a sequential
+    solve.
+    """
+    x = result.x
+    p = {n: float(x[layout.index(f"p_{n}")]) for n in layout.nodes}
+    q = {a: float(x[layout.index(f"q_{a}")]) for a in layout.arcs}
+    s = {n: float(x[layout.index(f"s_{n}")]) for n in layout.supply_nodes}
+    return p, q, s

--- a/src/difflow_gas/residuals.py
+++ b/src/difflow_gas/residuals.py
@@ -1,0 +1,432 @@
+"""JAX-traceable equation-oriented residuals of a gas network.
+
+:mod:`difflow_gas.verify` evaluates the same equation set, but on plain
+Python floats packed in dicts: it is a *reporting* tool, and its
+``_absmax`` helper (a Python ``max`` over the residual values) makes it
+impossible to trace. This module is the differentiable twin --- one
+flat state vector in, one residual array out --- so that
+``jax.jacobian`` yields the constraint Jacobian that data
+reconciliation, observability analysis and equation-oriented
+optimization all need.
+
+The two must agree, and :mod:`tests.gas.test_residuals` asserts that
+entry by entry.
+
+State vector
+------------
+
+:class:`GasStateLayout` packs, in this order:
+
+===================  ==========================================
+block                entries
+===================  ==========================================
+``p_<node>``         node pressures (bar), sorted node order
+``q_<arc>``          signed arc flows (kg/s), sorted arc order
+``s_<node>``         node boundary flows (kg/s, + into network)
+``eta_<arc>``        optional pipe efficiency multipliers
+``ratio_<arc>``      optional compressor pressure ratios
+``dp_<arc>``         optional control valve drops (bar)
+===================  ==========================================
+
+The boundary flows are *state*, not parameters. That is deliberate:
+with the supplies fixed, the node-balance block of the Jacobian is the
+network's incidence matrix, whose rank is only ``n_nodes - 1``, so the
+Jacobian loses full row rank for purely structural reasons. Carrying
+the supplies as variables gives every balance row a ``+1`` in its own
+column and restores full rank. It also keeps unbalanced *measured*
+nominations out of :class:`~difflow_gas.network.GasNetwork`, which
+rejects supplies that do not sum to zero.
+
+Residual blocks
+---------------
+
+Ordered to match the dicts of
+:func:`difflow_gas.verify.residuals_from_values`, with one addition:
+
+1. nodal mass balance, one per node (kg/s),
+2. resistance law of every pipe and resistor (bar^2),
+3. pressure equality of every valve and short pipe (bar),
+4. control valve drop relation (bar),
+5. **compressor relation** ``p_to - ratio * p_from`` (bar).
+
+``verify`` omits block 5 because a sequential solve satisfies it by
+construction. A reconciliation or equation-oriented formulation cannot
+omit it: the relation is what ties the two sides of a compressor
+station together, and dropping it leaves the downstream pressures
+unconstrained.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Sequence
+
+import jax.numpy as jnp
+from jax import Array
+
+from difflow.params_mixin import ParamsMixin
+
+from difflow_gas.network import GasNetwork
+from difflow_gas.physics import EPS_FLOW
+
+#: Pa^2 -> bar^2, the conversion applied to ``network.beta``
+BETA_PA2_TO_BAR2 = 1.0e10
+
+
+def _kind_arcs(network: GasNetwork, kinds: Sequence[str]) -> list[str]:
+    """Sorted ids of the arcs whose kind is one of ``kinds``."""
+    return sorted(
+        aid for aid, a in network.arcs.items() if a.kind in kinds
+    )
+
+
+@dataclass
+class GasStateLayout(ParamsMixin):
+    """Packing of a gas network state into a flat vector.
+
+    Build one with :func:`gas_state_layout` rather than by hand; it
+    snapshots the derived node list, which
+    :attr:`~difflow_gas.network.GasNetwork.nodes` recomputes on every
+    access.
+
+    Attributes:
+        nodes: node ids, sorted (pressure block order)
+        arcs: arc ids, sorted (flow block order)
+        supply_nodes: nodes carrying a boundary flow variable
+        efficiency_arcs: pipes/resistors whose efficiency multiplier is
+            a state variable rather than 1.0
+        ratio_arcs: compressors whose pressure ratio is a state
+            variable rather than a fixed parameter
+        cv_arcs: control valves whose drop is a state variable
+    """
+
+    nodes: list[str]
+    arcs: list[str]
+    supply_nodes: list[str]
+    efficiency_arcs: list[str] = field(default_factory=list)
+    ratio_arcs: list[str] = field(default_factory=list)
+    cv_arcs: list[str] = field(default_factory=list)
+
+    @property
+    def n_p(self) -> int:
+        return len(self.nodes)
+
+    @property
+    def n_q(self) -> int:
+        return len(self.arcs)
+
+    @property
+    def n_s(self) -> int:
+        return len(self.supply_nodes)
+
+    @property
+    def n_extra(self) -> int:
+        return (
+            len(self.efficiency_arcs)
+            + len(self.ratio_arcs)
+            + len(self.cv_arcs)
+        )
+
+    @property
+    def size(self) -> int:
+        """Length of the packed state vector."""
+        return self.n_p + self.n_q + self.n_s + self.n_extra
+
+    @property
+    def names(self) -> list[str]:
+        """Variable names, in packed order."""
+        return (
+            [f"p_{n}" for n in self.nodes]
+            + [f"q_{a}" for a in self.arcs]
+            + [f"s_{n}" for n in self.supply_nodes]
+            + [f"eta_{a}" for a in self.efficiency_arcs]
+            + [f"ratio_{a}" for a in self.ratio_arcs]
+            + [f"dp_{a}" for a in self.cv_arcs]
+        )
+
+    @property
+    def default_scale(self) -> Array:
+        """Typical magnitude of each entry, for scaling unmeasured ones.
+
+        Pressures in bar and flows in kg/s both sit around 50 in a
+        transmission network; the dimensionless extras are O(1).
+        """
+        return jnp.array(
+            [50.0] * self.n_p
+            + [50.0] * self.n_q
+            + [50.0] * self.n_s
+            + [1.0] * self.n_extra,
+            dtype=jnp.float64,
+        )
+
+    def index(self, name: str) -> int:
+        """Position of a named variable in the packed vector."""
+        try:
+            return self.names.index(name)
+        except ValueError:
+            raise KeyError(
+                f"{name!r} is not a state variable of this layout; "
+                f"expected one of {self.names}"
+            ) from None
+
+    def indices(self, names: Sequence[str]) -> list[int]:
+        """Positions of several named variables."""
+        return [self.index(n) for n in names]
+
+    @property
+    def slice_p(self) -> slice:
+        return slice(0, self.n_p)
+
+    @property
+    def slice_q(self) -> slice:
+        return slice(self.n_p, self.n_p + self.n_q)
+
+    @property
+    def slice_s(self) -> slice:
+        return slice(self.n_p + self.n_q, self.n_p + self.n_q + self.n_s)
+
+    @property
+    def slice_extra(self) -> slice:
+        return slice(self.n_p + self.n_q + self.n_s, self.size)
+
+    def pack(
+        self,
+        p_bar: dict[str, float],
+        q_kg_s: dict[str, float],
+        s_kg_s: dict[str, float] | None = None,
+        extra: dict[str, float] | None = None,
+    ) -> Array:
+        """Flatten pressures, flows, supplies and extras into a vector.
+
+        Args:
+            p_bar: node id -> pressure (bar)
+            q_kg_s: arc id -> signed flow (kg/s)
+            s_kg_s: node id -> boundary flow (kg/s); missing entries
+                default to 0.0
+            extra: name -> value for the ``eta_``/``ratio_``/``dp_``
+                entries; missing efficiencies and ratios default to
+                1.0, missing valve drops to 0.0
+
+        Returns:
+            The packed state, shape ``(layout.size,)``.
+        """
+        s_kg_s = s_kg_s or {}
+        extra = extra or {}
+        values = (
+            [p_bar[n] for n in self.nodes]
+            + [q_kg_s[a] for a in self.arcs]
+            + [s_kg_s.get(n, 0.0) for n in self.supply_nodes]
+            + [extra.get(f"eta_{a}", 1.0) for a in self.efficiency_arcs]
+            + [extra.get(f"ratio_{a}", 1.0) for a in self.ratio_arcs]
+            + [extra.get(f"dp_{a}", 0.0) for a in self.cv_arcs]
+        )
+        return jnp.asarray(values, dtype=jnp.float64)
+
+    def unpack(
+        self, x: Array
+    ) -> tuple[dict[str, Array], dict[str, Array],
+               dict[str, Array], dict[str, Array]]:
+        """Split a packed state into ``(p_bar, q_kg_s, s_kg_s, extra)``.
+
+        The values stay as JAX scalars, so this is safe under
+        ``jit``/``grad``.
+        """
+        x = jnp.asarray(x)
+        p = {n: x[i] for i, n in enumerate(self.nodes)}
+        off = self.n_p
+        q = {a: x[off + i] for i, a in enumerate(self.arcs)}
+        off += self.n_q
+        s = {n: x[off + i] for i, n in enumerate(self.supply_nodes)}
+        off += self.n_s
+        extra: dict[str, Array] = {}
+        for i, a in enumerate(self.efficiency_arcs):
+            extra[f"eta_{a}"] = x[off + i]
+        off += len(self.efficiency_arcs)
+        for i, a in enumerate(self.ratio_arcs):
+            extra[f"ratio_{a}"] = x[off + i]
+        off += len(self.ratio_arcs)
+        for i, a in enumerate(self.cv_arcs):
+            extra[f"dp_{a}"] = x[off + i]
+        return p, q, s, extra
+
+
+def gas_state_layout(
+    network: GasNetwork,
+    *,
+    efficiency_arcs: Sequence[str] = (),
+    ratio_arcs: Sequence[str] = (),
+    cv_arcs: Sequence[str] = (),
+    supply_nodes: Sequence[str] | None = None,
+) -> GasStateLayout:
+    """Build the state layout of a network.
+
+    Args:
+        network: the network whose state is to be packed.
+        efficiency_arcs: pipes or resistors whose efficiency multiplier
+            is an unknown (fouling, roughness drift) instead of 1.0.
+        ratio_arcs: compressors whose pressure ratio is a state
+            variable instead of a fixed parameter.
+        cv_arcs: control valves whose drop is a state variable.
+        supply_nodes: nodes carrying a boundary flow variable; defaults
+            to every node with an entry in ``network.supply_kg_s``.
+
+    Returns:
+        A :class:`GasStateLayout`.
+
+    Raises:
+        ValueError: if any named arc is missing or of the wrong kind.
+    """
+    for aid in efficiency_arcs:
+        if aid not in network.arcs:
+            raise ValueError(f"efficiency arc {aid!r} is not in the network")
+        if network.arcs[aid].kind not in ("pipe", "resistor"):
+            raise ValueError(
+                f"efficiency arc {aid!r} is a {network.arcs[aid].kind}, "
+                "but only pipes and resistors have a resistance law"
+            )
+    for aid in ratio_arcs:
+        if network.arcs.get(aid) is None or network.arcs[aid].kind != "compressor":
+            raise ValueError(f"ratio arc {aid!r} is not a compressor")
+    for aid in cv_arcs:
+        if (
+            network.arcs.get(aid) is None
+            or network.arcs[aid].kind != "control_valve"
+        ):
+            raise ValueError(f"cv arc {aid!r} is not a control valve")
+
+    nodes = list(network.nodes)
+    if supply_nodes is None:
+        supply_nodes = sorted(network.supply_kg_s)
+    unknown = set(supply_nodes) - set(nodes)
+    if unknown:
+        raise ValueError(f"supply nodes not in the network: {sorted(unknown)}")
+
+    return GasStateLayout(
+        nodes=nodes,
+        arcs=sorted(network.arcs),
+        supply_nodes=list(supply_nodes),
+        efficiency_arcs=sorted(efficiency_arcs),
+        ratio_arcs=sorted(ratio_arcs),
+        cv_arcs=sorted(cv_arcs),
+    )
+
+
+def residual_names(network: GasNetwork, layout: GasStateLayout) -> list[str]:
+    """Names of the residual entries, in the order they are returned."""
+    return (
+        [f"balance_{n}" for n in layout.nodes]
+        + [f"resistance_{a}" for a in _kind_arcs(network, ("pipe", "resistor"))]
+        + [f"equality_{a}" for a in _kind_arcs(network, ("valve", "short_pipe"))]
+        + [f"cv_{a}" for a in _kind_arcs(network, ("control_valve",))]
+        + [f"compressor_{a}" for a in _kind_arcs(network, ("compressor",))]
+    )
+
+
+def _signed_square(q: Array, eps_flow: float) -> Array:
+    """``q |q|``, optionally smoothed as ``q sqrt(q^2 + eps^2)``.
+
+    The smoothed form is C-infinity everywhere, which matters because
+    the exact ``q |q|`` has a discontinuous second derivative at zero.
+    At the default ``eps_flow`` the relative bias is ``eps^2 / (2 q^2)``
+    --- around 5e-9 at 1 kg/s, far below any meter's precision --- but
+    pass ``eps_flow=0.0`` to recover ``verify``'s exact form.
+    """
+    if eps_flow > 0.0:
+        return q * jnp.sqrt(q * q + eps_flow * eps_flow)
+    return q * jnp.abs(q)
+
+
+def network_residuals(
+    x: Array,
+    network: GasNetwork,
+    layout: GasStateLayout,
+    *,
+    ratios: dict[str, float] | None = None,
+    cv_drops_bar: dict[str, float] | None = None,
+    efficiencies: dict[str, float] | None = None,
+    eps_flow: float = EPS_FLOW,
+) -> Array:
+    """Full equation-oriented residual vector of a network state.
+
+    Traceable, jittable and differentiable: ``x`` and the values in
+    ``ratios``, ``cv_drops_bar`` and ``efficiencies`` may all be JAX
+    values, while everything taken from ``network`` and ``layout`` is
+    static Python. Passing a coefficient here rather than baking it
+    into ``network.beta`` is what makes it differentiable ---
+    :class:`~difflow_gas.network.GasNetwork` validates its arguments
+    with Python comparisons and so cannot be built under a trace.
+
+    Args:
+        x: packed state, shape ``(layout.size,)``, from
+            :meth:`GasStateLayout.pack`.
+        network: the network the state belongs to.
+        layout: the packing used for ``x``.
+        ratios: compressor arc id -> pressure ratio, for stations whose
+            ratio is *not* in the state (defaults to 1.0).
+        cv_drops_bar: control valve arc id -> drop (bar), for valves
+            whose drop is not in the state (defaults to 0.0).
+        efficiencies: pipe/resistor arc id -> multiplier on ``beta``,
+            for arcs whose efficiency is not in the state (defaults to
+            1.0). Values above 1.0 mean *more* resistance, i.e.
+            fouling. Use this to differentiate the reconciled state
+            with respect to a fixed pipe coefficient; put the entry in
+            the layout instead to *estimate* it.
+        eps_flow: smoothing of ``|q|`` in the resistance law (kg/s);
+            0.0 gives the exact non-smooth form.
+
+    Returns:
+        Residuals in the order given by :func:`residual_names`, mixing
+        kg/s (balances), bar^2 (resistance) and bar (the rest).
+
+    Example:
+        >>> layout = gas_state_layout(net)
+        >>> x = layout.pack(p_bar, q_kg_s, net.supply_kg_s)
+        >>> A = jax.jacobian(network_residuals)(x, net, layout)
+    """
+    ratios = ratios or {}
+    cv_drops_bar = cv_drops_bar or {}
+    efficiencies = efficiencies or {}
+    p, q, s, extra = layout.unpack(x)
+
+    zero = jnp.asarray(0.0, dtype=jnp.float64)
+
+    balance = []
+    for node in layout.nodes:
+        acc = s.get(node, zero)
+        for aid, a in network.arcs.items():
+            if a.from_node == node:
+                acc = acc - q[aid]
+            if a.to_node == node:
+                acc = acc + q[aid]
+        balance.append(acc)
+
+    resistance = []
+    for aid in _kind_arcs(network, ("pipe", "resistor")):
+        a = network.arcs[aid]
+        beta_bar2 = network.beta[aid] / BETA_PA2_TO_BAR2
+        eta = extra.get(f"eta_{aid}", efficiencies.get(aid, 1.0))
+        resistance.append(
+            p[a.from_node] ** 2
+            - p[a.to_node] ** 2
+            - eta * beta_bar2 * _signed_square(q[aid], eps_flow)
+        )
+
+    equality = []
+    for aid in _kind_arcs(network, ("valve", "short_pipe")):
+        a = network.arcs[aid]
+        equality.append(p[a.from_node] - p[a.to_node])
+
+    control_valve = []
+    for aid in _kind_arcs(network, ("control_valve",)):
+        a = network.arcs[aid]
+        dp = extra.get(f"dp_{aid}", cv_drops_bar.get(aid, 0.0))
+        control_valve.append(p[a.from_node] - p[a.to_node] - dp)
+
+    compressor = []
+    for aid in _kind_arcs(network, ("compressor",)):
+        a = network.arcs[aid]
+        ratio = extra.get(f"ratio_{aid}", ratios.get(aid, 1.0))
+        compressor.append(p[a.to_node] - ratio * p[a.from_node])
+
+    blocks = balance + resistance + equality + control_valve + compressor
+    return jnp.stack([jnp.asarray(b, dtype=jnp.float64) for b in blocks])

--- a/src/difflow_gas/residuals.py
+++ b/src/difflow_gas/residuals.py
@@ -1,16 +1,19 @@
 """JAX-traceable equation-oriented residuals of a gas network.
 
-:mod:`difflow_gas.verify` evaluates the same equation set, but on plain
-Python floats packed in dicts: it is a *reporting* tool, and its
-``_absmax`` helper (a Python ``max`` over the residual values) makes it
-impossible to trace. This module is the differentiable twin --- one
-flat state vector in, one residual array out --- so that
+This module is the single definition of a network's equation set: one
+flat state vector in, one residual array out, fully traceable, so that
 ``jax.jacobian`` yields the constraint Jacobian that data
 reconciliation, observability analysis and equation-oriented
 optimization all need.
 
-The two must agree, and :mod:`tests.gas.test_residuals` asserts that
-entry by entry.
+:mod:`difflow_gas.verify` is the reporting layer over it, unflattening
+the same vector into labelled dicts of floats. It reports every block
+below except the compressor relation, which a sequential solve
+satisfies by construction.
+
+The equations are checked against an independent restatement in
+:func:`tests.gas.test_residuals.reference_residuals` rather than
+against ``verify``, which would be checking this code against itself.
 
 State vector
 ------------
@@ -40,8 +43,7 @@ rejects supplies that do not sum to zero.
 Residual blocks
 ---------------
 
-Ordered to match the dicts of
-:func:`difflow_gas.verify.residuals_from_values`, with one addition:
+Returned in this order, labelled by :func:`residual_names`:
 
 1. nodal mass balance, one per node (kg/s),
 2. resistance law of every pipe and resistor (bar^2),
@@ -49,11 +51,11 @@ Ordered to match the dicts of
 4. control valve drop relation (bar),
 5. **compressor relation** ``p_to - ratio * p_from`` (bar).
 
-``verify`` omits block 5 because a sequential solve satisfies it by
-construction. A reconciliation or equation-oriented formulation cannot
-omit it: the relation is what ties the two sides of a compressor
-station together, and dropping it leaves the downstream pressures
-unconstrained.
+``verify`` reports blocks 1-4 and drops block 5, because a sequential
+solve satisfies it by construction and there is nothing to check. A
+reconciliation or equation-oriented formulation cannot drop it: the
+relation is what ties the two sides of a compressor station together,
+and without it the downstream pressures are unconstrained.
 """
 
 from __future__ import annotations

--- a/src/difflow_gas/verify.py
+++ b/src/difflow_gas/verify.py
@@ -15,6 +15,16 @@ The only iterated equations of a converged sequential solve are the
 chord laws, whose residual is the tear convergence error; everything
 else should sit at floating-point noise. Reporting is in bar / bar^2
 because those are the natural magnitudes to eyeball.
+
+The equations themselves live in :func:`difflow_gas.residuals.
+network_residuals`, which is the single definition of the network's
+equation set; this module is the reporting layer over it, turning the
+flat residual vector into the labelled dicts that are easier to read.
+Note that the report deliberately omits the compressor block that
+``network_residuals`` also returns: ``p_to = ratio * p_from`` holds by
+construction for whatever ratio a sequential solve was built with, so
+there is nothing to check. An equation-oriented or reconciliation
+formulation does have to carry it.
 """
 
 from __future__ import annotations
@@ -23,6 +33,11 @@ from dataclasses import dataclass, field
 
 from difflow_gas.flowsheets import arc_flow_stream, node_pressure_stream
 from difflow_gas.network import Decomposition, GasNetwork
+from difflow_gas.residuals import (
+    gas_state_layout,
+    network_residuals,
+    residual_names,
+)
 from difflow_gas.streams import FLOW_KEY
 
 
@@ -90,37 +105,35 @@ def residuals_from_values(
         cv_drops_bar: control valve drops (bar) the state was solved
             with; defaults to 0 for every control valve.
     """
-    cv_drops_bar = cv_drops_bar or {}
+    layout = gas_state_layout(network)
+    # eps_flow=0 selects the exact q|q| rather than its smoothed form:
+    # a verification should report the equations as written, not the
+    # C-infinity surrogate a solver differentiates.
+    values = network_residuals(
+        layout.pack(p_bar, q_kg_s, network.supply_kg_s),
+        network,
+        layout,
+        cv_drops_bar=cv_drops_bar,
+        eps_flow=0.0,
+    )
 
-    imbalance = {}
-    for node in network.nodes:
-        acc = network.supply_kg_s.get(node, 0.0)
-        for aid, a in network.arcs.items():
-            if a.from_node == node:
-                acc -= q_kg_s[aid]
-            if a.to_node == node:
-                acc += q_kg_s[aid]
-        imbalance[node] = acc
-
-    resistance = {}
-    equality = {}
-    control_valve = {}
-    for aid, a in network.arcs.items():
-        f, t = a.from_node, a.to_node
-        if a.kind in ("pipe", "resistor"):
-            beta_bar2 = network.beta[aid] / 1e10  # Pa^2 -> bar^2
-            resistance[aid] = (
-                p_bar[f] ** 2 - p_bar[t] ** 2
-                - beta_bar2 * q_kg_s[aid] * abs(q_kg_s[aid])
-            )
-        elif a.kind in ("valve", "short_pipe"):
-            equality[aid] = p_bar[f] - p_bar[t]
-        elif a.kind == "control_valve":
-            control_valve[aid] = (
-                p_bar[f] - p_bar[t] - cv_drops_bar.get(aid, 0.0)
-            )
-        # compressors: p_to = ratio p_from holds by construction for
-        # whatever ratio the state was solved with; nothing to check
+    imbalance: dict[str, float] = {}
+    resistance: dict[str, float] = {}
+    equality: dict[str, float] = {}
+    control_valve: dict[str, float] = {}
+    blocks = {
+        "balance_": imbalance,
+        "resistance_": resistance,
+        "equality_": equality,
+        "cv_": control_valve,
+        # "compressor_" is intentionally not reported; see the module
+        # docstring.
+    }
+    for name, value in zip(residual_names(network, layout), values):
+        for prefix, target in blocks.items():
+            if name.startswith(prefix):
+                target[name[len(prefix):]] = float(value)
+                break
 
     def _absmax(d):
         return max((abs(v) for v in d.values()), default=0.0)

--- a/tests/gas/test_reconciliation.py
+++ b/tests/gas/test_reconciliation.py
@@ -1,0 +1,401 @@
+"""Data reconciliation of gas networks.
+
+Covers the full story of ``examples/28_data_reconciliation.ipynb``:
+reconciling noisy measurements, the precision the constraints buy,
+finding a bad meter, estimating an unmeasured pipe efficiency, and the
+observability boundary that estimation runs into.
+"""
+
+import math
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+jax.config.update("jax_enable_x64", True)
+
+import difflow_gas as dg
+from difflow_gas import verify
+from difflow_gas.reconcile import (
+    measurement_sigma,
+    network_residual_fn,
+    perturb,
+    reconcile_network,
+    reconciled_values,
+)
+from difflow_gas.residuals import gas_state_layout
+from difflow.reconciliation import (
+    ReconciliationStructureError,
+    global_test,
+    measurement_test,
+    sensor_ranking,
+    serial_elimination,
+    solve_reconciliation,
+)
+from tests.gas.test_network import triangle
+
+RATIOS = {"cs1": 1.2}
+P_SLACK_PA = 60.0e5
+LOOP_VARS = ["q_p2", "q_p3", "q_p4", "p_b", "p_c", "p_d"]
+
+
+def five_node() -> dg.GasNetwork:
+    """Source, one compressor station, and a b-c-d loop.
+
+    The network of ``examples/20_gas_network_flowsheets.ipynb``:
+    realistic Weymouth coefficients, 60 bar, 120 kg/s.
+    """
+    return dg.GasNetwork(
+        arcs={
+            "p1": ("src", "a", "pipe"),
+            "cs1": ("a", "b", "compressor"),
+            "p2": ("b", "c", "pipe"),
+            "p3": ("b", "d", "pipe"),
+            "p4": ("c", "d", "pipe"),
+        },
+        beta={
+            aid: dg.weymouth_beta(
+                length_m=length, diameter_m=0.6, roughness_m=1e-4
+            )
+            for aid, length in [
+                ("p1", 20e3), ("p2", 40e3), ("p3", 60e3), ("p4", 80e3)
+            ]
+        },
+        supply_kg_s={"src": 120.0, "c": -50.0, "d": -70.0},
+        pressure_bounds_bar={n: (30.0, 80.0) for n in "abcd" } | {"src": (30.0, 80.0)},
+    )
+
+
+def _solve(net, root, p_slack_pa, ratios=None):
+    fs, dec = dg.build_network_flowsheet(
+        net, root=root, p_slack_pa=p_slack_pa, ratios=ratios
+    )
+    streams = fs.solve(tol=1e-12, max_iter=500)
+    return (
+        verify.node_pressures_bar(streams, dec),
+        verify.arc_flows_kg_s(streams, dec),
+    )
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture(scope="module")
+def five():
+    """``(net, layout, residual_fn, x_true, sigma)`` for the 5-node network."""
+    net = five_node()
+    p_bar, q = _solve(net, "src", P_SLACK_PA, RATIOS)
+    layout = gas_state_layout(net)
+    residual_fn = network_residual_fn(net, layout, ratios=RATIOS)
+    x_true = layout.pack(p_bar, q, net.supply_kg_s)
+    sigma = measurement_sigma(layout)
+    return net, layout, residual_fn, x_true, sigma
+
+
+@pytest.fixture(scope="module")
+def five_noisy(five):
+    net, layout, _, x_true, sigma = five
+    y = perturb(x_true, sigma, jax.random.PRNGKey(0))
+    return reconcile_network(net, y, sigma, layout, ratios=RATIOS), y
+
+
+# =============================================================================
+# The triangle, against its closed form
+# =============================================================================
+
+
+class TestTriangleAnalytic:
+    def test_noise_free_state_is_a_fixed_point(self):
+        """Reconciling consistent data must change nothing."""
+        net = triangle()
+        p_bar, q = _solve(net, "n0", 50.0e5)
+        layout = gas_state_layout(net)
+        x_true = layout.pack(p_bar, q, net.supply_kg_s)
+        sigma = measurement_sigma(layout)
+
+        res = reconcile_network(net, x_true, sigma, layout)
+
+        assert res.converged
+        assert res.objective == pytest.approx(0.0, abs=1e-12)
+        np.testing.assert_allclose(
+            np.asarray(res.x), np.asarray(x_true), atol=1e-9
+        )
+
+    def test_recovers_the_closed_form_split(self):
+        """x^2 - 200 x + 3400 = 0 for the p01 flow."""
+        net = triangle()
+        p_bar, q = _solve(net, "n0", 50.0e5)
+        layout = gas_state_layout(net)
+        sigma = measurement_sigma(layout)
+        y = perturb(
+            layout.pack(p_bar, q, net.supply_kg_s), sigma, jax.random.PRNGKey(2)
+        )
+        res = reconcile_network(net, y, sigma, layout)
+
+        exact = 100.0 - math.sqrt(100.0**2 - 3400.0)
+        assert res.x_named["q_p01"] == pytest.approx(exact, rel=0.05)
+        assert res.converged
+
+
+# =============================================================================
+# The 5-node network
+# =============================================================================
+
+
+class TestFiveNodeReconciliation:
+    def test_noisy_measurements_are_made_consistent(self, five, five_noisy):
+        """Balances and pipe laws are O(1) before and ~0 after."""
+        net, layout, _, _, _ = five
+        res, y = five_noisy
+
+        before = verify.residuals_from_values(
+            {n: float(y[layout.index(f"p_{n}")]) for n in layout.nodes},
+            {a: float(y[layout.index(f"q_{a}")]) for a in layout.arcs},
+            net,
+        )
+        assert before.max_node_imbalance_kg_s > 0.1
+        assert before.max_resistance_residual_bar2 > 1.0
+
+        assert res.converged
+        assert res.residual_norm < 1e-9
+
+    def test_verify_accepts_the_reconciled_state(self, five, five_noisy):
+        """Close the loop through the plugin's own equation checker."""
+        net, layout, _, _, _ = five
+        res, _ = five_noisy
+        p_bar, q, supply = reconciled_values(res, layout)
+
+        after = verify.residuals_from_values(p_bar, q, net)
+        # verify uses the network's nominations, which are the truth
+        # here; the reconciled supplies are what must balance.
+        assert after.max_resistance_residual_bar2 < 1e-6
+        assert abs(sum(supply.values())) < 1e-8, "nominations must close"
+
+    def test_reconciliation_sharpens_every_estimate(self, five, five_noisy):
+        net, layout, _, _, sigma = five
+        res, _ = five_noisy
+        for i, name in enumerate(layout.names):
+            assert res.std[name] < float(sigma[i]), (
+                f"{name}: sd {res.std[name]:.4f} not below sigma {sigma[i]:.4f}"
+            )
+
+    def test_the_chord_flow_gains_least(self, five, five_noisy):
+        """q_p4 carries the least flow and is the least improved.
+
+        Pinned because it is the hook for the sensor-placement section
+        of the notebook.
+        """
+        _, _, _, _, sigma = five
+        res, _ = five_noisy
+        gain = {
+            name: 1.0 - (res.std[name] / float(sigma[i])) ** 2
+            for i, name in enumerate(res.names)
+        }
+        flows = {k: v for k, v in gain.items() if k.startswith("q_")}
+        assert min(flows, key=flows.get) == "q_p4"
+        assert flows["q_p4"] == pytest.approx(0.58, abs=0.05)
+        assert flows["q_p3"] == pytest.approx(0.93, abs=0.05)
+
+    def test_degrees_of_redundancy(self, five_noisy):
+        res, _ = five_noisy
+        assert res.structure.degree_of_redundancy == 10
+        assert res.structure.solvable
+
+    def test_clean_data_passes_the_global_test(self, five):
+        net, layout, _, x_true, sigma = five
+        res = reconcile_network(net, x_true, sigma, layout, ratios=RATIOS)
+        assert not global_test(res).detected
+
+    def test_gradient_through_the_reconciliation(self, five):
+        """d(reconciled flow)/d(pipe coefficient) is finite and signed."""
+        net, layout, residual_fn, x_true, sigma = five
+        y = perturb(x_true, sigma, jax.random.PRNGKey(1))
+        res = reconcile_network(net, y, sigma, layout, ratios=RATIOS)
+
+        def q_p3_hat(efficiency):
+            return solve_reconciliation(
+                residual_fn, y, sigma, x0=x_true, scaling=res.scaling,
+                params={"p3": efficiency}, n_steps=12,
+            )[0][layout.index("q_p3")]
+
+        g = jax.grad(q_p3_hat)(1.0)
+        assert jnp.isfinite(g)
+        assert float(g) < 0.0, "a dirtier pipe must carry less flow"
+
+
+# =============================================================================
+# Gross errors
+# =============================================================================
+
+
+class TestGrossErrors:
+    def test_biased_flow_meter_is_identified(self, five):
+        net, layout, _, x_true, sigma = five
+        y = perturb(
+            x_true, sigma, jax.random.PRNGKey(0),
+            layout=layout, gross_errors={"q_p3": 8.0},
+        )
+        res = reconcile_network(net, y, sigma, layout, ratios=RATIOS)
+
+        gt = global_test(res)
+        assert gt.detected
+        assert gt.statistic > gt.critical
+
+        mt = measurement_test(res)
+        assert mt.suspect == "q_p3"
+        assert abs(mt.z["q_p3"]) > 5.0
+        ranked = mt.ranked()
+        assert abs(ranked[0][1]) > 2.0 * abs(ranked[1][1]), (
+            "the suspect should stand clear of the next candidate"
+        )
+
+    def test_error_on_a_weakly_redundant_sensor_smears(self, five):
+        """A bias on the least redundant meter may be misattributed.
+
+        Documented rather than wished away: least squares spreads a
+        gross error over its neighbours, and the thinner the redundancy
+        the more the blame moves.
+        """
+        net, layout, _, x_true, sigma = five
+        y = perturb(
+            x_true, sigma, jax.random.PRNGKey(5),
+            layout=layout, gross_errors={"q_p4": 8.0},
+        )
+        res = reconcile_network(net, y, sigma, layout, ratios=RATIOS)
+
+        assert global_test(res).detected
+        mt = measurement_test(res)
+        assert mt.suspect in {"q_p4", "q_p2", "q_p3", "s_c", "s_d"}
+
+    def test_serial_elimination_clears_the_data(self, five):
+        net, layout, residual_fn, x_true, sigma = five
+        y = perturb(
+            x_true, sigma, jax.random.PRNGKey(0),
+            layout=layout, gross_errors={"q_p3": 8.0},
+        )
+        steps = serial_elimination(
+            residual_fn, y, sigma, names=layout.names,
+            unmeasured_scale=layout.default_scale,
+        )
+        assert steps[0].detected
+        assert steps[0].suspect == "q_p3"
+        assert not steps[-1].detected
+        assert steps[-1].removed == "q_p3"
+        assert steps[-1].dof == steps[0].dof - 1, (
+            "discarding a measurement costs a degree of redundancy"
+        )
+
+
+# =============================================================================
+# Joint parameter estimation and observability
+# =============================================================================
+
+
+class TestEfficiencyEstimation:
+    @staticmethod
+    def _setup(net, unmeasured=(), sigma_eta=float("inf")):
+        layout = gas_state_layout(net, efficiency_arcs=["p3"])
+        residual_fn = network_residual_fn(net, layout, ratios=RATIOS)
+        sigma = measurement_sigma(
+            layout, sigma_eta=sigma_eta, unmeasured=unmeasured
+        )
+        return layout, residual_fn, sigma
+
+    def test_clean_data_gives_unit_efficiency(self, five):
+        net, _, _, _, _ = five
+        p_bar, q = _solve(net, "src", P_SLACK_PA, RATIOS)
+        layout, _, sigma = self._setup(net)
+        x_true = layout.pack(p_bar, q, net.supply_kg_s, {"eta_p3": 1.0})
+
+        res = reconcile_network(net, x_true, sigma, layout, ratios=RATIOS)
+        assert res.x_named["eta_p3"] == pytest.approx(1.0, abs=1e-6)
+        assert res.structure.degree_of_redundancy == 9, (
+            "estimating a parameter costs one degree of redundancy"
+        )
+        assert res.std["eta_p3"] == pytest.approx(0.043, abs=0.005)
+
+    def test_recovers_a_fouled_pipe(self, five):
+        """A pipe 15% more resistive than the model is detected as such."""
+        net, _, _, _, _ = five
+        fouled = five_node()
+        fouled.beta["p3"] = net.beta["p3"] * 1.15
+        p_bar, q = _solve(fouled, "src", P_SLACK_PA, RATIOS)
+
+        layout, _, sigma = self._setup(net)
+        x_true = layout.pack(p_bar, q, fouled.supply_kg_s, {"eta_p3": 1.0})
+        y = perturb(x_true, sigma, jax.random.PRNGKey(3))
+
+        # the residual model uses the CLEAN beta, so eta must absorb 1.15
+        res = reconcile_network(net, y, sigma, layout, ratios=RATIOS)
+        eta = res.x_named["eta_p3"]
+        assert abs(eta - 1.15) < 3.0 * res.std["eta_p3"], (
+            f"eta = {eta:.4f} +- {res.std['eta_p3']:.4f}, expected 1.15"
+        )
+
+    def test_unmeasured_loop_plus_efficiency_is_unobservable(self, five):
+        """The rank boundary: six unknowns fit, seven do not."""
+        net, _, _, _, _ = five
+        p_bar, q = _solve(net, "src", P_SLACK_PA, RATIOS)
+        layout, _, sigma = self._setup(net, unmeasured=LOOP_VARS)
+        x_true = layout.pack(p_bar, q, net.supply_kg_s, {"eta_p3": 1.0})
+
+        with pytest.raises(ReconciliationStructureError) as exc:
+            reconcile_network(net, x_true, sigma, layout, ratios=RATIOS)
+        assert "eta_p3" in str(exc.value)
+
+    def test_the_same_loop_is_observable_without_the_efficiency(self, five):
+        """The compressor relation is what buys the loop its observability.
+
+        With eta dropped, the six unmeasured loop variables are still
+        determined, because ``p_b = ratio * p_a`` ties the loop to the
+        measured pressure upstream of the station. That relation is the
+        one :mod:`difflow_gas.verify` omits.
+        """
+        net, layout, _, x_true, _ = five
+        sigma = measurement_sigma(layout, unmeasured=LOOP_VARS)
+        res = reconcile_network(net, x_true, sigma, layout, ratios=RATIOS)
+
+        assert res.converged
+        assert res.structure.solvable
+        assert res.structure.degree_of_redundancy == 4
+
+    def test_a_prior_restores_solvability(self, five):
+        """Shrinking a weakly identified parameter beats failing on it."""
+        net, _, _, _, _ = five
+        p_bar, q = _solve(net, "src", P_SLACK_PA, RATIOS)
+        layout, _, sigma = self._setup(
+            net, unmeasured=LOOP_VARS, sigma_eta=0.1
+        )
+        x_true = layout.pack(p_bar, q, net.supply_kg_s, {"eta_p3": 1.0})
+
+        res = reconcile_network(net, x_true, sigma, layout, ratios=RATIOS)
+        assert res.converged
+        assert res.std["eta_p3"] <= 0.1 + 1e-9, (
+            "the posterior cannot be looser than the prior"
+        )
+
+    def test_sensor_ranking_prefers_a_loop_flow_meter(self, five):
+        """The best sensor for eta is a meter on the loop flows."""
+        net, _, _, _, _ = five
+        p_bar, q = _solve(net, "src", P_SLACK_PA, RATIOS)
+        layout, residual_fn, sigma = self._setup(
+            net, unmeasured=LOOP_VARS, sigma_eta=0.1
+        )
+        x_true = layout.pack(p_bar, q, net.supply_kg_s, {"eta_p3": 1.0})
+
+        ranked = sensor_ranking(
+            residual_fn, x_true, sigma, target="eta_p3",
+            candidates=LOOP_VARS, candidate_sigma=1.0, names=layout.names,
+        )
+        assert ranked[0]["candidate"].startswith("q_")
+        assert ranked[0]["variance_reduction"] > 0.3
+        reductions = [d["variance_reduction"] for d in ranked]
+        assert reductions == sorted(reductions, reverse=True)
+        assert all(d["sd_after"] <= d["sd_before"] + 1e-12 for d in ranked)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/gas/test_residuals.py
+++ b/tests/gas/test_residuals.py
@@ -1,0 +1,352 @@
+"""Tests for difflow_gas.residuals.
+
+The point of the module is to be the traceable twin of
+:mod:`difflow_gas.verify`, so the load-bearing tests are the
+entry-by-entry round trip against it and the demonstration that
+``jax.jit`` and ``jax.jacobian`` work where ``verify`` cannot.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+jax.config.update("jax_enable_x64", True)
+
+import difflow_gas as dg
+from difflow_gas import verify
+from difflow_gas.residuals import (
+    gas_state_layout,
+    network_residuals,
+    residual_names,
+)
+from tests.gas.test_network import mixed_network, triangle
+
+P_SLACK = 50.0e5
+MIXED_RATIOS = {"cs_1": 1.2}
+MIXED_CV_BAR = {"cv_1": 2.0}
+
+
+def _solve(net, root, ratios=None, cv_drops_pa=None):
+    """Solve a network and return ``(p_bar, q_kg_s, dec)``."""
+    fs, dec = dg.build_network_flowsheet(
+        net, root=root, p_slack_pa=P_SLACK,
+        ratios=ratios, cv_drops_pa=cv_drops_pa,
+    )
+    streams = fs.solve(tol=1e-12, max_iter=500)
+    return (
+        verify.node_pressures_bar(streams, dec),
+        verify.arc_flows_kg_s(streams, dec),
+        dec,
+    )
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture(scope="module")
+def triangle_state():
+    net = triangle()
+    p_bar, q, _ = _solve(net, "n0")
+    return net, p_bar, q
+
+
+@pytest.fixture(scope="module")
+def mixed_state():
+    net = mixed_network()
+    cv_pa = {k: v * 1e5 for k, v in MIXED_CV_BAR.items()}
+    p_bar, q, _ = _solve(net, "s1", ratios=MIXED_RATIOS, cv_drops_pa=cv_pa)
+    return net, p_bar, q
+
+
+# =============================================================================
+# Agreement with verify
+# =============================================================================
+
+
+class TestRoundTripAgainstVerify:
+    """Same equations, same numbers, different representation."""
+
+    @staticmethod
+    def _compare(net, p_bar, q, **kw):
+        layout = gas_state_layout(net)
+        x = layout.pack(p_bar, q, net.supply_kg_s)
+        # eps_flow=0 recovers verify's exact non-smooth q|q|.
+        got = network_residuals(x, net, layout, eps_flow=0.0, **kw)
+        names = residual_names(net, layout)
+
+        report = verify.residuals_from_values(
+            p_bar, q, net, cv_drops_bar=kw.get("cv_drops_bar")
+        )
+        expected = {}
+        expected.update(
+            {f"balance_{k}": v for k, v in report.node_imbalance.items()}
+        )
+        expected.update(
+            {f"resistance_{k}": v
+             for k, v in report.resistance_residual_bar2.items()}
+        )
+        expected.update(
+            {f"equality_{k}": v for k, v in report.equality_dp_bar.items()}
+        )
+        expected.update(
+            {f"cv_{k}": v for k, v in report.control_valve_residual_bar.items()}
+        )
+        for i, name in enumerate(names):
+            if name in expected:
+                assert float(got[i]) == pytest.approx(
+                    expected[name], abs=1e-12
+                ), f"{name} disagrees with verify"
+        return names, got
+
+    def test_triangle(self, triangle_state):
+        net, p_bar, q = triangle_state
+        names, _ = self._compare(net, p_bar, q)
+        assert names == [
+            "balance_n0", "balance_n1", "balance_n2",
+            "resistance_p01", "resistance_p02", "resistance_p12",
+        ]
+
+    def test_mixed_network_covers_every_arc_kind(self, mixed_state):
+        """pipe, resistor, valve, short pipe, control valve, compressor."""
+        net, p_bar, q = mixed_state
+        names, _ = self._compare(
+            net, p_bar, q, ratios=MIXED_RATIOS, cv_drops_bar=MIXED_CV_BAR
+        )
+        assert any(n.startswith("equality_") for n in names)
+        assert any(n.startswith("cv_") for n in names)
+        assert any(n.startswith("compressor_") for n in names)
+
+    def test_residuals_vanish_at_the_sequential_solution(self, triangle_state):
+        net, p_bar, q = triangle_state
+        layout = gas_state_layout(net)
+        x = layout.pack(p_bar, q, net.supply_kg_s)
+        r = network_residuals(x, net, layout, eps_flow=0.0)
+        assert float(jnp.max(jnp.abs(r))) < 1e-9
+
+
+class TestCompressorResidual:
+    """The block verify deliberately omits."""
+
+    def test_present_and_zero_at_the_solution(self, mixed_state):
+        net, p_bar, q = mixed_state
+        layout = gas_state_layout(net)
+        names = residual_names(net, layout)
+        assert "compressor_cs_1" in names
+
+        x = layout.pack(p_bar, q, net.supply_kg_s)
+        r = network_residuals(
+            x, net, layout, ratios=MIXED_RATIOS, cv_drops_bar=MIXED_CV_BAR
+        )
+        i = names.index("compressor_cs_1")
+        assert float(r[i]) == pytest.approx(0.0, abs=1e-9)
+
+    def test_nonzero_for_the_wrong_ratio(self, mixed_state):
+        net, p_bar, q = mixed_state
+        layout = gas_state_layout(net)
+        names = residual_names(net, layout)
+        x = layout.pack(p_bar, q, net.supply_kg_s)
+        r = network_residuals(
+            x, net, layout, ratios={"cs_1": 1.5}, cv_drops_bar=MIXED_CV_BAR
+        )
+        i = names.index("compressor_cs_1")
+        assert abs(float(r[i])) > 1.0
+
+    def test_verify_does_not_check_it(self, mixed_state):
+        """verify reports ok for a ratio the compressor is not running.
+
+        This is why a reconciliation formulation cannot reuse verify's
+        equation set as-is.
+        """
+        net, p_bar, q = mixed_state
+        report = verify.residuals_from_values(
+            p_bar, q, net, cv_drops_bar=MIXED_CV_BAR
+        )
+        assert report.ok
+
+
+# =============================================================================
+# Traceability -- the reason the module exists
+# =============================================================================
+
+
+class TestTraceability:
+    def test_jit(self, triangle_state):
+        net, p_bar, q = triangle_state
+        layout = gas_state_layout(net)
+        x = layout.pack(p_bar, q, net.supply_kg_s)
+        fn = jax.jit(lambda xx: network_residuals(xx, net, layout))
+        assert bool(jnp.all(jnp.isfinite(fn(x))))
+
+    def test_jacobian_is_finite_and_correctly_shaped(self, triangle_state):
+        net, p_bar, q = triangle_state
+        layout = gas_state_layout(net)
+        x = layout.pack(p_bar, q, net.supply_kg_s)
+        a = jax.jacobian(network_residuals)(x, net, layout)
+        assert a.shape == (len(residual_names(net, layout)), layout.size)
+        assert bool(jnp.all(jnp.isfinite(a)))
+
+    def test_balance_rows_have_unit_supply_entries(self, triangle_state):
+        """Each balance row carries a +1 in its own supply column.
+
+        That is what gives the Jacobian full row rank; with the
+        supplies held fixed the balance block is the incidence matrix,
+        whose rank is only ``n_nodes - 1``.
+        """
+        net, p_bar, q = triangle_state
+        layout = gas_state_layout(net)
+        x = layout.pack(p_bar, q, net.supply_kg_s)
+        a = np.asarray(jax.jacobian(network_residuals)(x, net, layout))
+        names = residual_names(net, layout)
+        for node in layout.nodes:
+            row = names.index(f"balance_{node}")
+            col = layout.index(f"s_{node}")
+            assert a[row, col] == pytest.approx(1.0)
+        assert np.linalg.matrix_rank(a) == a.shape[0]
+
+    def test_gradient_wrt_efficiency(self, triangle_state):
+        """A pipe coefficient passed as an argument stays differentiable."""
+        net, p_bar, q = triangle_state
+        layout = gas_state_layout(net)
+        x = layout.pack(p_bar, q, net.supply_kg_s)
+        names = residual_names(net, layout)
+        i = names.index("resistance_p01")
+
+        g = jax.grad(
+            lambda e: network_residuals(
+                x, net, layout, efficiencies={"p01": e}
+            )[i]
+        )(1.0)
+        assert jnp.isfinite(g)
+        # more resistance -> the law's residual falls
+        assert float(g) < 0.0
+
+
+# =============================================================================
+# Layout
+# =============================================================================
+
+
+class TestLayout:
+    def test_pack_unpack_round_trip(self, triangle_state):
+        net, p_bar, q = triangle_state
+        layout = gas_state_layout(net)
+        x = layout.pack(p_bar, q, net.supply_kg_s)
+        p2, q2, s2, extra = layout.unpack(x)
+
+        assert extra == {}
+        for n in layout.nodes:
+            assert float(p2[n]) == pytest.approx(p_bar[n])
+        for a in layout.arcs:
+            assert float(q2[a]) == pytest.approx(q[a])
+        for n in layout.supply_nodes:
+            assert float(s2[n]) == pytest.approx(net.supply_kg_s[n])
+
+    def test_names_match_size_and_order(self, triangle_state):
+        net, _, _ = triangle_state
+        layout = gas_state_layout(net, efficiency_arcs=["p01"])
+        assert len(layout.names) == layout.size
+        assert layout.names[0].startswith("p_")
+        assert layout.names[-1] == "eta_p01"
+        assert layout.index("eta_p01") == layout.size - 1
+        assert layout.default_scale.shape == (layout.size,)
+
+    def test_index_rejects_unknown_names(self, triangle_state):
+        net, _, _ = triangle_state
+        layout = gas_state_layout(net)
+        with pytest.raises(KeyError, match="not a state variable"):
+            layout.index("q_nope")
+
+    def test_layout_rejects_wrong_arc_kinds(self, mixed_state):
+        net, _, _ = mixed_state
+        with pytest.raises(ValueError, match="only pipes and resistors"):
+            gas_state_layout(net, efficiency_arcs=["cs_1"])
+        with pytest.raises(ValueError, match="not a compressor"):
+            gas_state_layout(net, ratio_arcs=["pipe_1"])
+
+    def test_efficiency_as_state_and_as_argument_agree(self, triangle_state):
+        """The same eta gives the same residual either way it is supplied.
+
+        In the state it is *estimated*; as an argument it is a fixed
+        parameter you can differentiate with respect to. The physics is
+        identical.
+        """
+        net, p_bar, q = triangle_state
+        state_layout = gas_state_layout(net, efficiency_arcs=["p01"])
+        plain_layout = gas_state_layout(net)
+        i = residual_names(net, plain_layout).index("resistance_p01")
+
+        from_state = network_residuals(
+            state_layout.pack(p_bar, q, net.supply_kg_s, {"eta_p01": 1.5}),
+            net, state_layout, eps_flow=0.0,
+        )[residual_names(net, state_layout).index("resistance_p01")]
+        from_arg = network_residuals(
+            plain_layout.pack(p_bar, q, net.supply_kg_s),
+            net, plain_layout, efficiencies={"p01": 1.5}, eps_flow=0.0,
+        )[i]
+        assert float(from_state) == pytest.approx(float(from_arg), abs=1e-12)
+
+    def test_state_efficiency_takes_precedence_over_the_argument(
+        self, triangle_state
+    ):
+        """A variable being estimated ignores any fixed value passed in."""
+        net, p_bar, q = triangle_state
+        layout = gas_state_layout(net, efficiency_arcs=["p01"])
+        i = residual_names(net, layout).index("resistance_p01")
+        x = layout.pack(p_bar, q, net.supply_kg_s, {"eta_p01": 1.0})
+
+        with_arg = network_residuals(
+            x, net, layout, efficiencies={"p01": 9.0}, eps_flow=0.0
+        )[i]
+        without = network_residuals(x, net, layout, eps_flow=0.0)[i]
+        assert float(with_arg) == pytest.approx(float(without), abs=1e-12)
+
+
+# =============================================================================
+# Smoothing
+# =============================================================================
+
+
+class TestSmoothing:
+    def test_bias_is_negligible_at_the_solution(self, triangle_state):
+        net, p_bar, q = triangle_state
+        layout = gas_state_layout(net)
+        x = layout.pack(p_bar, q, net.supply_kg_s)
+        exact = network_residuals(x, net, layout, eps_flow=0.0)
+        smooth = network_residuals(x, net, layout)
+        assert float(jnp.max(jnp.abs(exact - smooth))) < 1e-8
+
+    def test_zero_flow_row_degenerates_in_flow_but_not_pressure(
+        self, triangle_state
+    ):
+        """A pipe at zero flow cannot tell you its flow.
+
+        The resistance row's flow entry vanishes there, which is
+        physical rather than an artefact: with no pressure drop there
+        is nothing to infer a flow from. Smoothing keeps the row
+        differentiable without pretending the information is there.
+        """
+        net, p_bar, q = triangle_state
+        layout = gas_state_layout(net)
+        zero_q = dict.fromkeys(q, 0.0)
+        x = layout.pack(p_bar, zero_q, net.supply_kg_s)
+        a = np.asarray(jax.jacobian(network_residuals)(x, net, layout))
+        names = residual_names(net, layout)
+
+        row = names.index("resistance_p01")
+        col = layout.index("q_p01")
+        # d/dq [q sqrt(q^2 + eps^2)] = eps at q = 0, so the entry is
+        # exactly beta_bar2 * eps rather than zero -- small enough to
+        # lose the flow, large enough to keep the Jacobian defined.
+        beta_bar2 = net.beta["p01"] / 1e10
+        assert a[row, col] == pytest.approx(
+            -beta_bar2 * dg.EPS_FLOW, rel=1e-9
+        )
+        assert abs(a[row, col]) < 1e-3, "flow sensitivity is negligible at q = 0"
+        assert abs(a[row, layout.index("p_n0")]) > 1.0, "pressure entry survives"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/gas/test_residuals.py
+++ b/tests/gas/test_residuals.py
@@ -1,9 +1,16 @@
 """Tests for difflow_gas.residuals.
 
-The point of the module is to be the traceable twin of
-:mod:`difflow_gas.verify`, so the load-bearing tests are the
-entry-by-entry round trip against it and the demonstration that
-``jax.jit`` and ``jax.jacobian`` work where ``verify`` cannot.
+This module holds the single definition of a gas network's equation
+set; :mod:`difflow_gas.verify` is a reporting layer over it. That means
+``verify`` cannot serve as an oracle for these tests --- it would be
+checking the code against itself --- so :func:`reference_residuals`
+below restates the equations independently, straight from the physics
+as written in :mod:`difflow_gas.physics`, and that is what the
+load-bearing test compares against.
+
+Keeping the oracle in the test file rather than in production code is
+deliberate: a second implementation is worth having precisely as a
+check, and worth nothing as an import.
 """
 
 import jax
@@ -25,6 +32,52 @@ from tests.gas.test_network import mixed_network, triangle
 P_SLACK = 50.0e5
 MIXED_RATIOS = {"cs_1": 1.2}
 MIXED_CV_BAR = {"cv_1": 2.0}
+
+
+def reference_residuals(
+    p_bar, q_kg_s, network, *, ratios=None, cv_drops_bar=None
+):
+    """Independent restatement of the network equations, in plain Python.
+
+    Written from the physics as stated in :mod:`difflow_gas.physics`:
+    the squared-pressure law is ``p_from^2 - p_to^2 = beta q |q|`` with
+    ``p`` in Pa and ``beta`` in Pa^2/(kg/s)^2, so in bar and bar^2 the
+    coefficient is ``beta / 1e10``. Signed flows are positive along the
+    arc's reference direction, and supplies are positive into the
+    network.
+
+    Returns ``{residual_name: value}`` using the same names as
+    :func:`difflow_gas.residuals.residual_names`.
+    """
+    ratios = ratios or {}
+    cv_drops_bar = cv_drops_bar or {}
+    supply = network.supply_kg_s
+    out = {}
+
+    for node in sorted(network.nodes):
+        inflow = sum(
+            q_kg_s[aid] for aid, a in network.arcs.items() if a.to_node == node
+        )
+        outflow = sum(
+            q_kg_s[aid] for aid, a in network.arcs.items() if a.from_node == node
+        )
+        out[f"balance_{node}"] = supply.get(node, 0.0) + inflow - outflow
+
+    for aid in sorted(network.arcs):
+        a = network.arcs[aid]
+        p_from, p_to, q = p_bar[a.from_node], p_bar[a.to_node], q_kg_s[aid]
+        if a.kind in ("pipe", "resistor"):
+            coeff = network.beta[aid] * 1e-10           # Pa^2 -> bar^2
+            out[f"resistance_{aid}"] = (
+                p_from * p_from - p_to * p_to - coeff * q * abs(q)
+            )
+        elif a.kind in ("valve", "short_pipe"):
+            out[f"equality_{aid}"] = p_from - p_to
+        elif a.kind == "control_valve":
+            out[f"cv_{aid}"] = p_from - p_to - cv_drops_bar.get(aid, 0.0)
+        elif a.kind == "compressor":
+            out[f"compressor_{aid}"] = p_to - ratios.get(aid, 1.0) * p_from
+    return out
 
 
 def _solve(net, root, ratios=None, cv_drops_pa=None):
@@ -66,39 +119,25 @@ def mixed_state():
 # =============================================================================
 
 
-class TestRoundTripAgainstVerify:
-    """Same equations, same numbers, different representation."""
+class TestAgainstIndependentOracle:
+    """The equations must match a from-scratch restatement of the physics."""
 
     @staticmethod
     def _compare(net, p_bar, q, **kw):
         layout = gas_state_layout(net)
         x = layout.pack(p_bar, q, net.supply_kg_s)
-        # eps_flow=0 recovers verify's exact non-smooth q|q|.
+        # eps_flow=0 gives the equations as written, not the smoothed form
         got = network_residuals(x, net, layout, eps_flow=0.0, **kw)
         names = residual_names(net, layout)
+        expected = reference_residuals(p_bar, q, net, **kw)
 
-        report = verify.residuals_from_values(
-            p_bar, q, net, cv_drops_bar=kw.get("cv_drops_bar")
-        )
-        expected = {}
-        expected.update(
-            {f"balance_{k}": v for k, v in report.node_imbalance.items()}
-        )
-        expected.update(
-            {f"resistance_{k}": v
-             for k, v in report.resistance_residual_bar2.items()}
-        )
-        expected.update(
-            {f"equality_{k}": v for k, v in report.equality_dp_bar.items()}
-        )
-        expected.update(
-            {f"cv_{k}": v for k, v in report.control_valve_residual_bar.items()}
+        assert set(names) == set(expected), (
+            "the residual set differs from the reference"
         )
         for i, name in enumerate(names):
-            if name in expected:
-                assert float(got[i]) == pytest.approx(
-                    expected[name], abs=1e-12
-                ), f"{name} disagrees with verify"
+            assert float(got[i]) == pytest.approx(expected[name], abs=1e-12), (
+                f"{name} disagrees with the reference implementation"
+            )
         return names, got
 
     def test_triangle(self, triangle_state):
@@ -118,6 +157,71 @@ class TestRoundTripAgainstVerify:
         assert any(n.startswith("equality_") for n in names)
         assert any(n.startswith("cv_") for n in names)
         assert any(n.startswith("compressor_") for n in names)
+
+    def test_the_oracle_is_sensitive(self, triangle_state):
+        """Guard the guard: a perturbed state must break the comparison."""
+        net, p_bar, q = triangle_state
+        layout = gas_state_layout(net)
+        x = layout.pack(p_bar, q, net.supply_kg_s)
+        perturbed = x.at[layout.index("q_p01")].add(1.0)
+
+        got = network_residuals(perturbed, net, layout, eps_flow=0.0)
+        expected = reference_residuals(p_bar, q, net)
+        names = residual_names(net, layout)
+        assert any(
+            abs(float(got[i]) - expected[n]) > 1e-6 for i, n in enumerate(names)
+        ), "the comparison would not notice a wrong answer"
+
+
+class TestVerifyReportingLayer:
+    """verify unflattens the residual vector onto the right keys.
+
+    It delegates to ``network_residuals``, so the numbers are not in
+    question --- the mapping from residual names to report dicts is.
+    """
+
+    def test_report_keys_match_the_network(self, mixed_state):
+        net, p_bar, q = mixed_state
+        report = verify.residuals_from_values(
+            p_bar, q, net, cv_drops_bar=MIXED_CV_BAR
+        )
+        assert set(report.node_imbalance) == set(net.nodes)
+        assert set(report.resistance_residual_bar2) == {
+            a for a, arc in net.arcs.items() if arc.kind in ("pipe", "resistor")
+        }
+        assert set(report.equality_dp_bar) == {
+            a for a, arc in net.arcs.items()
+            if arc.kind in ("valve", "short_pipe")
+        }
+        assert set(report.control_valve_residual_bar) == {
+            a for a, arc in net.arcs.items() if arc.kind == "control_valve"
+        }
+
+    def test_report_values_match_the_shared_core(self, mixed_state):
+        net, p_bar, q = mixed_state
+        expected = reference_residuals(
+            p_bar, q, net, ratios=MIXED_RATIOS, cv_drops_bar=MIXED_CV_BAR
+        )
+        report = verify.residuals_from_values(
+            p_bar, q, net, cv_drops_bar=MIXED_CV_BAR
+        )
+        for arc, value in report.resistance_residual_bar2.items():
+            assert value == pytest.approx(expected[f"resistance_{arc}"], abs=1e-12)
+        for node, value in report.node_imbalance.items():
+            assert value == pytest.approx(expected[f"balance_{node}"], abs=1e-12)
+
+    def test_report_omits_the_compressor_block(self, mixed_state):
+        """Documented behaviour: a sequential solve satisfies it by construction.
+
+        The shared core returns a compressor residual; the report drops
+        it, so `.ok` stays true for a state solved with any ratio.
+        """
+        net, p_bar, q = mixed_state
+        report = verify.residuals_from_values(
+            p_bar, q, net, cv_drops_bar=MIXED_CV_BAR
+        )
+        assert not hasattr(report, "compressor_residual_bar")
+        assert report.ok
 
     def test_residuals_vanish_at_the_sequential_solution(self, triangle_state):
         net, p_bar, q = triangle_state

--- a/tests/test_reconciliation.py
+++ b/tests/test_reconciliation.py
@@ -1,0 +1,541 @@
+"""Tests for difflow.reconciliation.
+
+The load-bearing tests are the linear ones: on a linear constraint the
+KKT system is solved exactly in a single step, so there is no iteration
+tolerance to hide behind and the results are checked against the
+closed-form weighted least squares solution.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+jax.config.update("jax_enable_x64", True)
+
+from difflow.reconciliation import (
+    MEASURED_JUST_DETERMINED,
+    MEASURED_REDUNDANT,
+    UNMEASURED_OBSERVABLE,
+    ReconciliationStructureError,
+    auto_scaling,
+    classify,
+    global_test,
+    identity_scaling,
+    kkt_matrix,
+    measurement_sensitivity,
+    measurement_test,
+    reconcile,
+    reconciled_covariance,
+    sensor_value,
+    serial_elimination,
+    solve_reconciliation,
+)
+
+
+# =============================================================================
+# Fixtures and helpers
+# =============================================================================
+
+
+def one_balance(x, params=None):
+    """A single linear constraint: x0 + x1 = 10."""
+    return jnp.array([x[0] + x[1] - 10.0])
+
+
+def closed_form_wls(a, b, y, sigma):
+    """x_hat = y - Sigma A^T (A Sigma A^T)^-1 (A y - b), fully measured."""
+    sig = np.diag(np.asarray(sigma) ** 2)
+    a = np.asarray(a, dtype=float)
+    r = a @ np.asarray(y) - np.asarray(b)
+    return np.asarray(y) - sig @ a.T @ np.linalg.solve(a @ sig @ a.T, r)
+
+
+@pytest.fixture(scope="module")
+def random_linear():
+    """A random full-row-rank linear system, 6 equations in 10 variables."""
+    rng = np.random.default_rng(0)
+    a = rng.normal(size=(6, 10))
+    b = rng.normal(size=6)
+    sigma = jnp.asarray(rng.uniform(0.5, 2.0, size=10))
+    y = jnp.asarray(rng.normal(size=10) * 2.0)
+
+    def residual_fn(x, params=None):
+        return jnp.asarray(a) @ x - jnp.asarray(b)
+
+    return residual_fn, a, b, y, sigma
+
+
+# =============================================================================
+# Linear exactness
+# =============================================================================
+
+
+class TestLinearExactness:
+    """A linear problem must be solved exactly, in one step."""
+
+    def test_two_variable_closed_form(self):
+        """x0 + x1 = 10 with sigma = (1, 2) puts 4x the adjustment on x1."""
+        y = jnp.array([6.0, 6.0])
+        sigma = jnp.array([1.0, 2.0])
+        res = reconcile(one_balance, y, sigma, names=["a", "b"])
+
+        assert res.x[0] == pytest.approx(5.6, abs=1e-12)
+        assert res.x[1] == pytest.approx(4.4, abs=1e-12)
+        assert res.objective == pytest.approx(0.8, abs=1e-12)
+        assert res.converged
+        assert res.residual_norm < 1e-12
+
+    def test_matches_closed_form_wls(self, random_linear):
+        residual_fn, a, b, y, sigma = random_linear
+        res = reconcile(residual_fn, y, sigma)
+        expected = closed_form_wls(a, b, y, sigma)
+        np.testing.assert_allclose(np.asarray(res.x), expected, atol=1e-10)
+
+    def test_solved_in_one_step(self, random_linear):
+        """One KKT solve is exact for a linear system; iterating adds nothing."""
+        residual_fn, _, _, y, sigma = random_linear
+        sc = auto_scaling(residual_fn, y, sigma)
+        x1, _ = solve_reconciliation(
+            residual_fn, y, sigma, x0=y, scaling=sc, n_steps=1, correct=False
+        )
+        x20, _ = solve_reconciliation(
+            residual_fn, y, sigma, x0=y, scaling=sc, n_steps=20, correct=False
+        )
+        np.testing.assert_allclose(np.asarray(x1), np.asarray(x20), atol=1e-14)
+
+    def test_unmeasured_variable_absorbs_the_imbalance(self):
+        """With x1 unmeasured, x0 is untouched and the residual is zero."""
+        y = jnp.array([6.0, jnp.nan])
+        sigma = jnp.array([1.0, jnp.inf])
+        res = reconcile(one_balance, y, sigma, names=["a", "b"])
+
+        assert res.x[0] == pytest.approx(6.0, abs=1e-12)
+        assert res.x[1] == pytest.approx(4.0, abs=1e-12)
+        assert res.objective == pytest.approx(0.0, abs=1e-20)
+        assert res.structure.degree_of_redundancy == 0
+
+    def test_nan_measurement_does_not_leak(self):
+        """A nan at an unmeasured entry must not poison the solution."""
+        y = jnp.array([6.0, jnp.nan])
+        sigma = jnp.array([1.0, jnp.inf])
+        res = reconcile(one_balance, y, sigma)
+        assert bool(jnp.all(jnp.isfinite(res.x)))
+
+
+# =============================================================================
+# Covariance
+# =============================================================================
+
+
+class TestCovariance:
+    """The KKT inverse reproduces, and generalizes, the textbook formula."""
+
+    def test_matches_projection_formula(self, random_linear):
+        """[K^-1]_11 == Sigma - Sigma A^T (A Sigma A^T)^-1 A Sigma."""
+        residual_fn, a, _, y, sigma = random_linear
+        sc = auto_scaling(residual_fn, y, sigma)
+        cov = np.asarray(
+            reconciled_covariance(residual_fn, y, sigma, scaling=sc)
+        )
+
+        sig = np.diag(np.asarray(sigma) ** 2)
+        proj = sig - sig @ a.T @ np.linalg.solve(a @ sig @ a.T, a @ sig)
+        np.testing.assert_allclose(cov, proj, atol=1e-10)
+
+    def test_reduces_uncertainty(self, random_linear):
+        """Reconciliation can only sharpen a measurement, never blunt it."""
+        residual_fn, _, _, y, sigma = random_linear
+        res = reconcile(residual_fn, y, sigma)
+        var = np.diag(np.asarray(res.covariance))
+        assert np.all(var <= np.asarray(sigma) ** 2 + 1e-12)
+        assert np.all(var > 0)
+
+    def test_sensitivity_identity_linear(self, random_linear):
+        """S Sigma S^T == Sigma_xhat exactly when the constraints are linear."""
+        residual_fn, _, _, y, sigma = random_linear
+        sc = auto_scaling(residual_fn, y, sigma)
+        s = np.asarray(
+            measurement_sensitivity(residual_fn, y, sigma, x0=y, scaling=sc)
+        )
+        cov = np.asarray(
+            reconciled_covariance(residual_fn, y, sigma, scaling=sc)
+        )
+        sig = np.diag(np.asarray(sigma) ** 2)
+        np.testing.assert_allclose(s @ sig @ s.T, cov, atol=1e-10)
+
+    def test_sensitivity_identity_with_unmeasured(self, random_linear):
+        """The identity survives entries that carry no measurement."""
+        residual_fn, _, _, y, sigma = random_linear
+        sigma = sigma.at[jnp.array([2, 5, 7])].set(jnp.inf)
+        sc = auto_scaling(residual_fn, y, sigma)
+        cov = np.asarray(
+            reconciled_covariance(residual_fn, y, sigma, scaling=sc)
+        )
+        w = np.diag(np.where(np.isfinite(sigma), 1.0 / np.asarray(sigma) ** 2, 0.0))
+        # P W P^T == P  is the identity behind S Sigma S^T == P.
+        np.testing.assert_allclose(cov @ w @ cov.T, cov, atol=1e-10)
+
+    def test_own_measurement_is_shrunk_not_amplified(self, random_linear):
+        residual_fn, _, _, y, sigma = random_linear
+        sc = auto_scaling(residual_fn, y, sigma)
+        s = np.asarray(
+            measurement_sensitivity(residual_fn, y, sigma, x0=y, scaling=sc)
+        )
+        diag = np.diag(s)
+        assert np.all(diag > 0), "an estimate must move with its own measurement"
+        assert np.all(diag <= 1.0 + 1e-9), "it must not move by more than it"
+
+
+# =============================================================================
+# Gradients
+# =============================================================================
+
+
+class TestGradients:
+    """Reconciliation is differentiable end to end."""
+
+    def test_gradient_wrt_measurement(self, random_linear):
+        residual_fn, _, _, y, sigma = random_linear
+        sc = auto_scaling(residual_fn, y, sigma)
+
+        def first_estimate(yy):
+            return solve_reconciliation(
+                residual_fn, yy, sigma, x0=y, scaling=sc, n_steps=6
+            )[0][0]
+
+        g = jax.grad(first_estimate)(y)
+        assert bool(jnp.all(jnp.isfinite(g)))
+        assert float(g[0]) > 0.0
+
+    def test_gradient_wrt_sigma_is_finite(self, random_linear):
+        """Loosening a sensor lowers the weighted objective."""
+        residual_fn, _, _, y, sigma = random_linear
+
+        def objective(s):
+            sc = auto_scaling(residual_fn, y, s)
+            x, _ = solve_reconciliation(
+                residual_fn, y, s, x0=y, scaling=sc, n_steps=6
+            )
+            return jnp.sum(((x - y) / s) ** 2)
+
+        g = jax.grad(objective)(sigma)
+        assert bool(jnp.all(jnp.isfinite(g)))
+        assert bool(jnp.all(g <= 1e-9)), f"expected non-positive, got {g}"
+
+    def test_gradient_wrt_params(self):
+        """params is a differentiable argument of the residual function."""
+        def residual_fn(x, theta):
+            return jnp.array([x[0] + theta * x[1] - 10.0])
+
+        y = jnp.array([6.0, 6.0])
+        sigma = jnp.array([1.0, 2.0])
+
+        def estimate(theta):
+            sc = auto_scaling(residual_fn, y, sigma, params=theta)
+            x, _ = solve_reconciliation(
+                residual_fn, y, sigma, x0=y, scaling=sc,
+                params=theta, n_steps=6,
+            )
+            return x[0]
+
+        g = jax.grad(estimate)(1.0)
+        assert jnp.isfinite(g)
+        assert float(g) != 0.0
+
+
+# =============================================================================
+# Structure: observability, redundancy, solvability
+# =============================================================================
+
+
+class TestStructure:
+    """Solvability and observability are one test, decided before solving."""
+
+    def test_all_measured_is_fully_redundant(self, random_linear):
+        residual_fn, _, _, y, sigma = random_linear
+        res = reconcile(residual_fn, y, sigma)
+        st = res.structure
+        assert st.solvable
+        assert st.degree_of_redundancy == 6
+        assert all(c == MEASURED_REDUNDANT for c in st.classes.values())
+        assert all(0.0 < r <= 1.0 for r in st.redundancy.values())
+
+    def test_unmeasured_observable_is_classified(self):
+        y = jnp.array([6.0, jnp.nan])
+        sigma = jnp.array([1.0, jnp.inf])
+        res = reconcile(one_balance, y, sigma, names=["a", "b"])
+        assert res.structure.classes["b"] == UNMEASURED_OBSERVABLE
+        assert res.structure.classes["a"] == MEASURED_JUST_DETERMINED
+        assert res.structure.redundancy["a"] == pytest.approx(0.0, abs=1e-9)
+
+    def test_unobservable_raises_naming_the_variable(self):
+        """Two unknowns in one equation cannot both be recovered."""
+        def residual_fn(x, params=None):
+            return jnp.array([x[0] + x[1] + x[2] - 10.0])
+
+        y = jnp.array([6.0, jnp.nan, jnp.nan])
+        sigma = jnp.array([1.0, jnp.inf, jnp.inf])
+        with pytest.raises(ReconciliationStructureError, match="Unobservable"):
+            reconcile(residual_fn, y, sigma, names=["a", "b", "c"])
+
+    def test_unobservable_error_names_the_right_variables(self):
+        def residual_fn(x, params=None):
+            return jnp.array([x[0] + x[1] + x[2] - 10.0])
+
+        y = jnp.array([6.0, jnp.nan, jnp.nan])
+        sigma = jnp.array([1.0, jnp.inf, jnp.inf])
+        with pytest.raises(ReconciliationStructureError) as exc:
+            reconcile(residual_fn, y, sigma, names=["a", "b", "c"])
+        message = str(exc.value)
+        assert "b" in message and "c" in message
+
+    def test_prior_restores_solvability(self):
+        """A finite sigma on an unobservable unknown makes it estimable."""
+        def residual_fn(x, params=None):
+            return jnp.array([x[0] + x[1] + x[2] - 10.0])
+
+        y = jnp.array([6.0, 2.0, jnp.nan])
+        sigma = jnp.array([1.0, 0.5, jnp.inf])
+        res = reconcile(residual_fn, y, sigma, names=["a", "b", "c"])
+        assert res.converged
+
+    @staticmethod
+    def _classify_linear(a):
+        """Classify a system whose variables are all unmeasured."""
+        def residual_fn(x, params=None):
+            return jnp.asarray(a) @ x
+
+        return classify(
+            residual_fn,
+            jnp.ones(a.shape[1]),
+            jnp.full(a.shape[1], jnp.inf),
+            scaling=identity_scaling(*reversed(a.shape)),
+            names=["u", "v"],
+        )
+
+    def test_ill_conditioned_but_full_rank_is_solvable(self):
+        """Singular values well above the threshold keep the problem solvable."""
+        st = self._classify_linear(jnp.array([[1.0, 0.0], [0.0, 1e-4]]))
+        assert st.solvable
+        assert st.rank_A_unmeasured == 2
+
+    def test_genuine_null_direction_is_detected(self):
+        st = self._classify_linear(jnp.array([[1.0, 1.0], [1.0, 1.0]]))
+        assert not st.solvable
+        assert st.rank_A_unmeasured == 1
+        assert set(st.unobservable) == {"u", "v"}
+
+    def test_rank_is_taken_from_the_svd_not_the_gram_matrix(self):
+        """Rank must come from svd(A), never from eigvals(A.T @ A).
+
+        Squaring the matrix squares its condition number, so a
+        singular value at the threshold reappears as its square and a
+        rank-deficient system is reported as full rank. Here the
+        smallest singular value is genuinely below the threshold, while
+        the corresponding Gram eigenvalue is far below anything a
+        threshold on ``A.T @ A`` would reject in the same units.
+        """
+        a = np.array([[1.0, 0.0], [0.0, 1e-9]])
+        st = self._classify_linear(jnp.asarray(a))
+
+        sv = np.linalg.svd(a, compute_uv=False)
+        assert sv[1] < st.rank_tol, "premise: the small value is below tolerance"
+        assert st.rank_A_unmeasured == 1, "SVD sees the deficiency"
+        assert not st.solvable
+
+        # The same threshold applied to the Gram spectrum would not.
+        gram_eigs = np.linalg.eigvalsh(a.T @ a)
+        assert gram_eigs.min() < st.rank_tol**2
+
+    def test_kkt_matrix_shape_and_blocks(self):
+        a = jnp.array([[1.0, 2.0, 3.0]])
+        w = jnp.array([1.0, 0.0, 4.0])
+        k = kkt_matrix(a, w)
+        assert k.shape == (4, 4)
+        np.testing.assert_allclose(np.asarray(k[:3, :3]), np.diag([1.0, 0.0, 4.0]))
+        np.testing.assert_allclose(np.asarray(k[3:, :3]), np.asarray(a))
+        np.testing.assert_allclose(np.asarray(k[:3, 3:]), np.asarray(a).T)
+        assert float(k[3, 3]) == 0.0
+
+
+# =============================================================================
+# Scaling
+# =============================================================================
+
+
+class TestScaling:
+    """Scaling makes the formulation independent of the unit system."""
+
+    @staticmethod
+    def _problem(unit):
+        """x0 + x1 = 10 * unit, measured in units of `unit`."""
+        def residual_fn(x, params=None):
+            return jnp.array([x[0] + x[1] - 10.0 * unit])
+
+        y = jnp.array([6.0, 6.0]) * unit
+        sigma = jnp.array([1.0, 2.0]) * unit
+        return residual_fn, y, sigma
+
+    def test_unit_invariance(self):
+        """The same problem in units 1e5 apart gives the same answer."""
+        f1, y1, s1 = self._problem(1.0)
+        f2, y2, s2 = self._problem(1e5)
+        r1 = reconcile(f1, y1, s1)
+        r2 = reconcile(f2, y2, s2)
+        np.testing.assert_allclose(
+            np.asarray(r2.x) / 1e5, np.asarray(r1.x), rtol=1e-10
+        )
+        assert r2.objective == pytest.approx(r1.objective, rel=1e-10)
+
+    def test_scaled_kkt_is_better_conditioned(self):
+        """Scaling is on by default because the raw system degrades fast."""
+        from difflow.reconciliation.core import jacobian_of, measured_mask
+
+        f, y, sigma = self._problem(1e5)
+        a = jacobian_of(f, y)
+
+        raw = kkt_matrix(a, jnp.where(measured_mask(sigma), 1.0 / sigma**2, 0.0))
+        sc = auto_scaling(f, y, sigma)
+        scaled = kkt_matrix(
+            sc.r[:, None] * a * sc.d[None, :],
+            jnp.where(measured_mask(sigma), 1.0, 0.0),
+        )
+        cond_raw = float(np.linalg.cond(np.asarray(raw)))
+        cond_scaled = float(np.linalg.cond(np.asarray(scaled)))
+        assert cond_scaled < 1e3, f"scaled condition number {cond_scaled:.3g}"
+        assert cond_raw > 1e6 * cond_scaled, (
+            f"raw {cond_raw:.3g} vs scaled {cond_scaled:.3g}"
+        )
+
+
+# =============================================================================
+# Gross error detection
+# =============================================================================
+
+
+class TestGrossError:
+    """The global test's statistic and degrees of freedom must be right."""
+
+    def test_global_test_dof_equals_degree_of_redundancy(self, random_linear):
+        """E[objective] == degrees of redundancy, for several unmeasured counts.
+
+        This is the property that fixes both the statistic and its
+        distribution: the objective is chi-squared on ``m - rank(A_U)``,
+        not on the number of equations.
+        """
+        residual_fn, a, b, _, sigma = random_linear
+        # A truth that satisfies the constraints exactly.
+        x_true = jnp.asarray(np.linalg.lstsq(a, b, rcond=None)[0])
+        n_draws = 4000
+
+        for n_unmeasured, expected_dof in [(0, 6), (1, 5), (2, 4)]:
+            sig = np.asarray(sigma).copy()
+            sig[:n_unmeasured] = np.inf
+            sig_j = jnp.asarray(sig)
+            mask = jnp.isfinite(sig_j)
+
+            # The structure is fixed across draws, so check it once and
+            # then vmap the traced core over the whole batch.
+            res = reconcile(residual_fn, x_true, sig_j)
+            assert res.structure.degree_of_redundancy == expected_dof
+            sc = res.scaling
+
+            noise = jax.random.normal(
+                jax.random.PRNGKey(7 + n_unmeasured), (n_draws, 10)
+            ) * jnp.where(mask, sig_j, 0.0)
+
+            @jax.jit
+            @jax.vmap
+            def objective(y):
+                x, _ = solve_reconciliation(
+                    residual_fn, y, sig_j, x0=y, scaling=sc, n_steps=3
+                )
+                return jnp.sum(
+                    jnp.where(mask, ((x - y) / jnp.where(mask, sig_j, 1.0)) ** 2, 0.0)
+                )
+
+            mean = float(jnp.mean(objective(x_true + noise)))
+            assert mean == pytest.approx(expected_dof, rel=0.06), (
+                f"{n_unmeasured} unmeasured: E[objective] = {mean:.3f}, "
+                f"expected {expected_dof}"
+            )
+
+    def test_global_test_accepts_clean_data(self, random_linear):
+        residual_fn, a, b, _, sigma = random_linear
+        x_true = jnp.asarray(np.linalg.lstsq(a, b, rcond=None)[0])
+        res = reconcile(residual_fn, x_true, sigma)
+        gt = global_test(res)
+        assert not gt.detected
+        assert gt.dof == 6
+        assert gt.statistic == pytest.approx(0.0, abs=1e-15)
+
+    def test_global_test_rejects_a_gross_error(self, random_linear):
+        residual_fn, a, b, _, sigma = random_linear
+        x_true = np.linalg.lstsq(a, b, rcond=None)[0]
+        y = np.asarray(x_true).copy()
+        y[3] += 20.0 * float(sigma[3])
+        res = reconcile(residual_fn, jnp.asarray(y), sigma)
+
+        gt = global_test(res)
+        assert gt.detected
+        assert gt.statistic > gt.critical
+
+        mt = measurement_test(res)
+        assert mt.detected
+        assert mt.suspect == res.names[3]
+
+    def test_measurement_test_marks_untestable_entries(self):
+        """A measurement nothing checks gets nan, not a spurious z."""
+        y = jnp.array([6.0, jnp.nan])
+        sigma = jnp.array([1.0, jnp.inf])
+        res = reconcile(one_balance, y, sigma, names=["a", "b"])
+        mt = measurement_test(res)
+        assert not mt.testable["a"], "a is unchecked, so it cannot be tested"
+        assert np.isnan(mt.z["a"])
+        assert not mt.detected
+
+    def test_serial_elimination_clears_the_global_test(self, random_linear):
+        residual_fn, a, b, _, sigma = random_linear
+        x_true = np.linalg.lstsq(a, b, rcond=None)[0]
+        rng = np.random.default_rng(11)
+        y = x_true + rng.normal(size=10) * np.asarray(sigma)
+        y[3] += 20.0 * float(sigma[3])
+
+        steps = serial_elimination(residual_fn, jnp.asarray(y), sigma)
+        assert steps[0].detected, "the seeded error must be detected"
+        assert steps[0].suspect is not None
+        assert not steps[-1].detected, "elimination must end on clean data"
+        assert steps[-1].removed is not None
+
+
+# =============================================================================
+# Sensor placement
+# =============================================================================
+
+
+class TestSensorPlacement:
+    def test_a_sensor_never_increases_uncertainty(self, random_linear):
+        residual_fn, _, _, y, sigma = random_linear
+        sigma = sigma.at[4].set(jnp.inf)
+        out = sensor_value(
+            residual_fn, y, sigma, target=4, candidate=4, candidate_sigma=1.0
+        )
+        assert out["sd_after"] <= out["sd_before"] + 1e-12
+        assert out["variance_reduction"] > 0.0
+
+    def test_ranking_is_ordered(self, random_linear):
+        residual_fn, _, _, y, sigma = random_linear
+        sigma = sigma.at[4].set(jnp.inf)
+        ranked = sensor_ranking = __import__(
+            "difflow.reconciliation", fromlist=["sensor_ranking"]
+        ).sensor_ranking(
+            residual_fn, y, sigma, target=4,
+            candidates=[0, 1, 2, 4], candidate_sigma=0.5,
+        )
+        reductions = [d["variance_reduction"] for d in ranked]
+        assert reductions == sorted(reductions, reverse=True)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
difflow could solve flowsheets and fit parameters, but not reconcile
noisy plant data against a model. This adds constrained weighted least
squares over any differentiable residual function, plus the statistics
and structural analysis that make it usable.

New `difflow.reconciliation` (domain-agnostic):
- `reconcile` solves min (x-y)'W(x-y) s.t. F(x,theta)=0 by Gauss-Newton
  on the KKT system, with one implicit-function-theorem correction so
  gradients w.r.t. y, sigma and theta are exact.
- An infinite sigma marks a variable to be *estimated* rather than
  reconciled, so joint parameter estimation is the same solve; a finite
  sigma on an unmetered variable acts as a prior.
- Covariance from the inverse KKT matrix, which reduces to the textbook
  projection when everything is measured and generalizes when it is not.
- Observability/redundancy classification runs before the solve, so an
  ill-posed problem raises a named error rather than returning NaN.
  Solvability and observability are the same condition: A_U must have
  full column rank.
- Global chi-squared test, measurement test and serial elimination for
  gross errors; sensor placement by variance reduction.
- Automatic variable and residual scaling, on by default: the KKT matrix
  mixes W (1/variable^2) with A (residual/variable), so its conditioning
  otherwise depends on the unit system.

New `difflow_gas.residuals` / `difflow_gas.reconcile`:
- `network_residuals` is a JAX-traceable twin of `verify`, which is
  float/dict-valued and cannot be traced. Tests assert they agree
  entry by entry.
- Adds the compressor relation p_to = ratio * p_from, which `verify`
  omits because a sequential solve satisfies it by construction. A
  reconciliation cannot omit it, and it turns out to be what makes the
  example network's loop observable.
- Boundary flows are state variables, not fixed parameters: otherwise
  the balance block is the incidence matrix and the KKT system is
  singular structurally. This also keeps unbalanced measured
  nominations out of GasNetwork, which rejects them.

Also: docs/data-reconciliation.md wired into the book, and
examples/28_data_reconciliation.ipynb working the gas case end to end.

Verified: 1326 tests pass (67 new), the notebook executes clean, and
the book builds.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0115wVXe4gdrijT1yvb6YjcM