### PR TITLE
feat: build reactor rate laws from data instead of callables

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,7 @@ difflow/
 │   │   ├── database.py    # Species property database
 │   │   ├── flowsheet.py   # Flowsheet with recycle solving
 │   │   ├── uncertainty.py # Sensitivity & UQ
+│   ├── kinetics.py    # Declarative mass-action rate laws (data, not callables)
 │   ├── reconciliation/ # Data reconciliation, gross error detection, observability
 │   │   ├── params_mixin.py # ParamsMixin base class for Params dataclasses
 │   │   ├── units/         # Steady-state unit operations

--- a/docs/unit-operations-chemical.md
+++ b/docs/unit-operations-chemical.md
@@ -357,6 +357,62 @@ feed_profile = optimal_feed_profile(params, constraints={'max_T': 400.0})
 ---
 
 (separators)=
+## Declarative Kinetics
+
+The reactors above take `rate_fn` as a Python callable. That is expressive, but it is *code*, not data — it cannot be written to a file, built from a form, or round-tripped through a GUI. `mass_action_kinetics` builds the callable from plain dictionaries instead, so a reaction network can be stored, edited and shared as data.
+
+```python
+from difflow import CSTR, CSTRParams, mass_action_kinetics
+
+reactions = [{
+    "equation":  "A -> B",
+    "reactants": {"A": 1.0},
+    "products":  {"B": 1.0},
+    "rate_params": {"A": 1.0e6, "Ea": 50_000.0, "n": 0.0},
+}]
+
+kin = mass_action_kinetics(reactions, species_order=["A", "B"])
+cstr = CSTR(CSTRParams(V=1.5, **kin.params_kwargs()))
+```
+
+`params_kwargs()` supplies `rate_fn`, `stoich`, `rate_params` and `species_order` — every rate-law field the reactors need. The result is numerically identical to the equivalent hand-written callable.
+
+The dictionary format is exactly what [`import_reactions`](thermodynamics.md) returns from a Cantera YAML file, so a published mechanism goes straight into a reactor:
+
+```python
+from difflow import import_reactions
+
+reactions = import_reactions("mech.yaml")
+kin = mass_action_kinetics(reactions, reverse="forward_only")
+```
+
+### The rate law
+
+$$k_j(T) = A_j \, T^{n_j} \exp\!\left(\frac{-E_{a,j}}{R T}\right), \qquad r_j = k_j \prod_i C_i^{\alpha_{ji}}$$
+
+Orders $\alpha$ come from the reactant stoichiometry unless given explicitly via `orders=`, which covers empirical rate laws where the order is not the coefficient. A reversible reaction subtracts the reverse term scaled by its equilibrium constant:
+
+$$r_j = k_j \left( \prod_i C_i^{\alpha_{ji}} - \frac{1}{K_{eq,j}} \prod_i C_i^{\beta_{ji}} \right)$$
+
+**Parameters:**
+- `reactions` — one dict per reaction with `reactants`, `products` and `rate_params` (`A`, `Ea`, `n`); optionally `equation`, `reversible`, `type` and `K_eq`.
+- `species_order` — fixes the rows of `stoich`; defaults to the sorted union of every species mentioned.
+- `reverse` — `"error"` (default), `"forward_only"`, or `"equilibrium"`.
+- `orders` — per-reaction `{species: order}` overrides. `None` keeps stoichiometric orders; `{}` means zeroth order in everything.
+
+### What it refuses, and why
+
+Two specifications raise `KineticsSpecError` rather than being approximated, because in both cases a guess produces a plausible number that is wrong:
+
+- **Reversible reactions, by default.** Forward Arrhenius parameters alone do not determine the reverse rate. Pass `reverse="equilibrium"` with a `K_eq` on each reaction, or `reverse="forward_only"` to drop the reverse term as an explicit, recorded approximation.
+- **Three-body, falloff and other pressure-dependent types.** These need their own rate law; mass action covers elementary reactions only.
+
+### Units
+
+Concentrations mol/m³, temperature K, activation energy J/mol, rates mol/m³/s. Cantera files declare their own units in a `units:` block — a mechanism written in cm³ or kcal/mol imports numerically unchanged and will be **silently wrong**, so check that block before trusting a rate constant.
+
+---
+
 ## Separators
 
 (flash-drum)=

--- a/src/difflow/__init__.py
+++ b/src/difflow/__init__.py
@@ -230,6 +230,13 @@ from difflow import estimation
 # Data reconciliation submodule
 from difflow import reconciliation
 
+# Declarative kinetics
+from difflow.kinetics import (
+    KineticsSpecError,
+    ReactionSet,
+    mass_action_kinetics,
+)
+
 # Economics submodule
 from difflow import economics
 
@@ -476,6 +483,10 @@ __all__ = [
     "estimation",
     # Data reconciliation
     "reconciliation",
+    # Declarative kinetics
+    "mass_action_kinetics",
+    "ReactionSet",
+    "KineticsSpecError",
     # Economics
     "economics",
     # Visualization (optional)

--- a/src/difflow/kinetics.py
+++ b/src/difflow/kinetics.py
@@ -1,0 +1,392 @@
+"""Declarative mass-action kinetics.
+
+The reactor units take a Python callable::
+
+    rate_fn(C, T, rate_params) -> rates
+
+which is expressive but not *data*: it cannot be written to a file,
+built from a form, or round-tripped through a GUI. That callable is the
+only thing standing between difflow's unit operations and a fully
+declarative model specification --- of the 78 ``Params`` dataclasses in
+the package, 73 are already pure data, and the five that are not are
+all reactors, all because of this one field.
+
+:func:`mass_action_kinetics` closes that gap. It takes reactions as
+plain dictionaries --- the format :func:`difflow.import_reactions`
+already produces from Cantera YAML, and equally what a form or a JSON
+file would produce --- and returns everything a reactor needs::
+
+    reactions = import_reactions("mech.yaml")
+    kin = mass_action_kinetics(reactions, species_order=["A", "B"])
+    params = CSTRParams(V=1.0, **kin.params_kwargs())
+
+The rate law is mass action with a modified Arrhenius coefficient,
+
+.. math::
+
+    k_j(T) = A_j \\, T^{n_j} \\exp\\!\\left(-E_{a,j} / R T\\right),
+    \\qquad
+    r_j = k_j \\prod_i C_i^{\\alpha_{ji}}
+
+with reaction orders taken from the reactant stoichiometry unless given
+explicitly. A reversible reaction subtracts the reverse term scaled by
+its equilibrium constant,
+
+.. math::
+
+    r_j = k_j \\left( \\prod_i C_i^{\\alpha_{ji}}
+          - \\frac{1}{K_{eq,j}} \\prod_i C_i^{\\beta_{ji}} \\right).
+
+Units are difflow's throughout: concentrations mol/m^3, temperature K,
+activation energy J/mol, rates mol/m^3/s. Cantera files declare their
+own units in a ``units:`` block; a mechanism written in cm^3 or
+kcal/mol will import numerically unchanged and be silently wrong, so
+check that block before trusting a rate constant.
+
+What this deliberately does *not* do: three-body, falloff and any other
+pressure-dependent reaction type is rejected rather than approximated,
+and a reversible reaction without an equilibrium constant raises rather
+than quietly dropping its reverse term. Both are cases where guessing
+would produce a plausible number that is wrong.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Sequence
+
+import jax.numpy as jnp
+from jax import Array
+
+from difflow.numerics import safe_log
+from difflow.params_mixin import ParamsMixin
+
+#: gas constant, J/(mol K)
+R_GAS = 8.314462618
+
+#: reaction types whose kinetics are plain mass action
+SUPPORTED_TYPES = frozenset({"elementary", "irreversible", ""})
+
+#: Concentration floor inside the log-space product. Small enough that a
+#: reactant at zero contributes an underflowed rate rather than a
+#: spurious one (1e-300 to the first power, exactly 0 beyond), while
+#: never clipping a concentration any real problem could produce.
+#:
+#: The alternative, ``prod(C ** order)``, gives exact zeros but a *nan*
+#: derivative at C = 0, and one nan poisons the whole reactor solve. A
+#: floor 300 orders of magnitude below anything physical is the cheaper
+#: error: away from zero both forms agree exactly, and at zero this one
+#: reports a derivative of 0 where the true first-order value is k.
+CONC_FLOOR = 1e-300
+
+#: how to treat a reaction marked reversible
+REVERSE_MODES = ("error", "forward_only", "equilibrium")
+
+
+class KineticsSpecError(ValueError):
+    """A reaction specification cannot be turned into a rate law.
+
+    Raised for unsupported reaction types, species that are not in the
+    species order, and reversible reactions whose reverse term is not
+    determined. The message names the offending reactions.
+    """
+
+
+@dataclass
+class ReactionSet(ParamsMixin):
+    """A compiled set of mass-action reactions.
+
+    Everything a reactor needs, derived from data rather than code.
+
+    Attributes:
+        species_order: species names, matching the rows of ``stoich``.
+        stoich: net stoichiometry, shape ``(n_species, n_reactions)``,
+            negative for reactants and positive for products.
+        rate_fn: ``rate_fn(C, T, rate_params) -> (n_reactions,)``, the
+            callable the reactor units expect.
+        rate_params: the arrays ``rate_fn`` closes over --- ``A``,
+            ``n``, ``Ea``, ``K_eq``, and the forward and reverse order
+            matrices. A pytree, so it differentiates and jits.
+        equations: one LaTeX rate expression per reaction, following the
+            ``equations`` convention the unit operations use.
+        reactions: the source specification, kept so the set can be
+            written back out.
+        reverse: the reversibility mode this set was built with.
+    """
+
+    species_order: list[str]
+    stoich: Array
+    rate_fn: Callable
+    rate_params: dict
+    equations: list[str] = field(default_factory=list)
+    reactions: list[dict] = field(default_factory=list)
+    reverse: str = "error"
+
+    @property
+    def n_species(self) -> int:
+        return len(self.species_order)
+
+    @property
+    def n_reactions(self) -> int:
+        return int(self.stoich.shape[1])
+
+    def params_kwargs(self) -> dict:
+        """The reactor ``Params`` fields this set supplies.
+
+        Splat into any reactor that takes a rate law::
+
+            CSTRParams(V=1.0, **kin.params_kwargs())
+            PFRParams(V=1.0, n_steps=50, **kin.params_kwargs())
+        """
+        return {
+            "rate_fn": self.rate_fn,
+            "stoich": self.stoich,
+            "rate_params": self.rate_params,
+            "species_order": list(self.species_order),
+        }
+
+    def rates(self, concentrations: dict[str, Any], T: float) -> Array:
+        """Evaluate the rate law directly, for inspection or testing."""
+        return self.rate_fn(concentrations, T, self.rate_params)
+
+    def summary(self) -> str:
+        """Readable table of the reactions and their coefficients."""
+        p = self.rate_params
+        lines = [
+            f"{self.n_reactions} reaction(s) over {self.n_species} species "
+            f"({', '.join(self.species_order)}); reverse mode: {self.reverse}",
+            "",
+            f"{'equation':<34} {'A':>11} {'n':>6} {'Ea (kJ/mol)':>12} {'K_eq':>10}",
+            "-" * 78,
+        ]
+        for j, rxn in enumerate(self.reactions):
+            k_eq = float(p["K_eq"][j])
+            k_eq_s = "-" if not jnp.isfinite(k_eq) else f"{k_eq:10.4g}"
+            lines.append(
+                f"{rxn.get('equation', f'reaction {j}'):<34} "
+                f"{float(p['A'][j]):11.4g} {float(p['n'][j]):6.2f} "
+                f"{float(p['Ea'][j]) / 1000.0:12.2f} {k_eq_s:>10}"
+            )
+        return "\n".join(lines)
+
+
+def _species_in(reactions: Sequence[dict]) -> list[str]:
+    """Sorted union of every species appearing in the reactions."""
+    seen: set[str] = set()
+    for rxn in reactions:
+        seen.update(rxn.get("reactants", {}))
+        seen.update(rxn.get("products", {}))
+    return sorted(seen)
+
+
+def _latex(rxn: dict, reverse: bool) -> str:
+    """LaTeX rate expression for one reaction."""
+    def side(d):
+        return " ".join(
+            (f"C_{{{s}}}" if abs(c - 1.0) < 1e-12 else f"C_{{{s}}}^{{{c:g}}}")
+            for s, c in d.items()
+        ) or "1"
+
+    forward = side(rxn.get("reactants", {}))
+    if not reverse:
+        return f"r = k(T) \\, {forward}"
+    return (
+        f"r = k(T) \\left( {forward} - "
+        f"\\frac{{1}}{{K_{{eq}}}} {side(rxn.get('products', {}))} \\right)"
+    )
+
+
+def mass_action_kinetics(
+    reactions: Sequence[dict],
+    species_order: Sequence[str] | None = None,
+    *,
+    reverse: str = "error",
+    orders: Sequence[dict] | None = None,
+) -> ReactionSet:
+    """Build a rate law and stoichiometry from reaction dictionaries.
+
+    Args:
+        reactions: one dict per reaction, with keys ``reactants`` and
+            ``products`` (``{species: coefficient}``) and
+            ``rate_params`` (``{"A": ..., "Ea": ..., "n": ...}``, where
+            ``Ea`` and ``n`` default to 0). Optional keys: ``equation``
+            (for reporting), ``reversible``, ``type``, and ``K_eq``.
+            This is exactly what :func:`difflow.import_reactions`
+            returns, and equally what a form or JSON file can produce.
+        species_order: species names fixing the rows of ``stoich``.
+            Defaults to the sorted union of every species mentioned;
+            pass it explicitly to match a stream's species order.
+        reverse: how to treat reactions marked reversible.
+            ``"error"`` (default) refuses them, because the reverse
+            rate is not determined by forward Arrhenius parameters
+            alone. ``"forward_only"`` drops the reverse term --- a real
+            approximation, recorded on the result. ``"equilibrium"``
+            uses each reaction's ``K_eq``, which must then be present.
+        orders: optional per-reaction ``{species: order}`` overriding
+            the reaction orders, which otherwise come from the reactant
+            stoichiometry. Use for empirical rate laws where the order
+            is not the coefficient. ``None`` for a reaction keeps its
+            stoichiometric orders; an empty dict makes it zeroth order
+            in everything.
+
+    Returns:
+        A :class:`ReactionSet`.
+
+    Raises:
+        KineticsSpecError: for an unsupported reaction type, a species
+            outside ``species_order``, a reversible reaction under
+            ``reverse="error"``, or a missing ``K_eq`` under
+            ``reverse="equilibrium"``.
+
+    Example:
+        >>> reactions = [{
+        ...     "equation": "A -> B",
+        ...     "reactants": {"A": 1.0}, "products": {"B": 1.0},
+        ...     "rate_params": {"A": 1.0e6, "Ea": 50_000.0, "n": 0.0},
+        ... }]
+        >>> kin = mass_action_kinetics(reactions, ["A", "B"])
+        >>> params = CSTRParams(V=1.0, **kin.params_kwargs())
+    """
+    if reverse not in REVERSE_MODES:
+        raise ValueError(
+            f"reverse={reverse!r} is not one of {REVERSE_MODES}"
+        )
+    reactions = list(reactions)
+    if not reactions:
+        raise KineticsSpecError("no reactions given")
+
+    names = (
+        list(species_order) if species_order is not None
+        else _species_in(reactions)
+    )
+    index = {s: i for i, s in enumerate(names)}
+    n_s, n_r = len(names), len(reactions)
+
+    # ---- validate before building anything -------------------------
+    bad_type = [
+        (j, rxn.get("type"))
+        for j, rxn in enumerate(reactions)
+        if str(rxn.get("type", "elementary")).lower() not in SUPPORTED_TYPES
+    ]
+    if bad_type:
+        detail = ", ".join(f"reaction {j} ({t!r})" for j, t in bad_type)
+        raise KineticsSpecError(
+            f"unsupported reaction type(s): {detail}. Mass action covers "
+            "elementary reactions only; three-body, falloff and other "
+            "pressure-dependent forms need their own rate law and are "
+            "refused rather than approximated."
+        )
+
+    unknown = sorted({
+        s
+        for rxn in reactions
+        for s in list(rxn.get("reactants", {})) + list(rxn.get("products", {}))
+        if s not in index
+    })
+    if unknown:
+        raise KineticsSpecError(
+            f"species not in species_order: {', '.join(unknown)}. "
+            f"species_order is {names}."
+        )
+
+    reversible = [
+        j for j, rxn in enumerate(reactions) if rxn.get("reversible", False)
+    ]
+    if reversible and reverse == "error":
+        listed = ", ".join(
+            f"{j} ({reactions[j].get('equation', '?')})" for j in reversible
+        )
+        raise KineticsSpecError(
+            f"reaction(s) {listed} are marked reversible, but forward "
+            "Arrhenius parameters alone do not determine the reverse "
+            "rate. Pass reverse='equilibrium' and give each one a "
+            "'K_eq', or reverse='forward_only' to drop the reverse term "
+            "as an explicit approximation."
+        )
+    if reverse == "equilibrium":
+        missing = [j for j in reversible if reactions[j].get("K_eq") is None]
+        if missing:
+            raise KineticsSpecError(
+                f"reverse='equilibrium' needs a 'K_eq' on every reversible "
+                f"reaction; missing on reaction(s) {missing}."
+            )
+
+    # ---- build the arrays ------------------------------------------
+    stoich = jnp.zeros((n_s, n_r), dtype=jnp.float64)
+    order_f = jnp.zeros((n_r, n_s), dtype=jnp.float64)
+    order_r = jnp.zeros((n_r, n_s), dtype=jnp.float64)
+    a_vals, n_vals, ea_vals, keq_vals = [], [], [], []
+
+    for j, rxn in enumerate(reactions):
+        reactants = rxn.get("reactants", {})
+        products = rxn.get("products", {})
+        for s, c in reactants.items():
+            stoich = stoich.at[index[s], j].add(-float(c))
+            order_f = order_f.at[j, index[s]].add(float(c))
+        for s, c in products.items():
+            stoich = stoich.at[index[s], j].add(float(c))
+            order_r = order_r.at[j, index[s]].add(float(c))
+
+        # None means "no override, use the stoichiometry"; an empty dict
+        # is an override to zeroth order in everything, so test against
+        # None rather than truthiness
+        if orders is not None and orders[j] is not None:
+            # an explicit empirical order replaces the whole forward row
+            order_f = order_f.at[j, :].set(0.0)
+            for s, o in orders[j].items():
+                if s not in index:
+                    raise KineticsSpecError(
+                        f"order given for {s!r}, which is not in species_order"
+                    )
+                order_f = order_f.at[j, index[s]].set(float(o))
+
+        # Arrhenius coefficients may be traced: the reaction *structure*
+        # is static, but the numbers can come from an optimizer, so
+        # building a set inside jit/grad works.
+        rp = rxn.get("rate_params", {}) or {}
+        a_vals.append(jnp.asarray(rp.get("A", 0.0), dtype=jnp.float64))
+        n_vals.append(jnp.asarray(rp.get("n", 0.0), dtype=jnp.float64))
+        ea_vals.append(jnp.asarray(rp.get("Ea", 0.0), dtype=jnp.float64))
+
+        is_rev = j in reversible and reverse == "equilibrium"
+        keq_vals.append(
+            jnp.asarray(rxn["K_eq"], dtype=jnp.float64) if is_rev
+            else jnp.asarray(jnp.inf, dtype=jnp.float64)
+        )
+
+    rate_params = {
+        "A": jnp.asarray(a_vals, dtype=jnp.float64),
+        "n": jnp.asarray(n_vals, dtype=jnp.float64),
+        "Ea": jnp.asarray(ea_vals, dtype=jnp.float64),
+        # inf disables the reverse term without a branch: 1/inf = 0
+        "K_eq": jnp.asarray(keq_vals, dtype=jnp.float64),
+        "order_f": order_f,
+        "order_r": order_r,
+    }
+
+    def rate_fn(C, T, p):
+        """Mass-action rates, mol/m^3/s. Traceable and differentiable."""
+        c = jnp.stack([jnp.asarray(C[s], dtype=jnp.float64) for s in names])
+        # Products in log space: exp(order . log c) stays differentiable
+        # at c = 0 and gives 1 for a zero order, where c ** 0 would be
+        # the indeterminate 0 ** 0. See CONC_FLOOR for the trade-off.
+        log_c = safe_log(jnp.maximum(c, 0.0), CONC_FLOOR)
+        k = p["A"] * jnp.power(T, p["n"]) * jnp.exp(-p["Ea"] / (R_GAS * T))
+        forward = jnp.exp(p["order_f"] @ log_c)
+        backward = jnp.exp(p["order_r"] @ log_c) / p["K_eq"]
+        return k * (forward - backward)
+
+    equations = [
+        _latex(rxn, reverse == "equilibrium" and j in reversible)
+        for j, rxn in enumerate(reactions)
+    ]
+
+    return ReactionSet(
+        species_order=names,
+        stoich=stoich,
+        rate_fn=rate_fn,
+        rate_params=rate_params,
+        equations=equations,
+        reactions=reactions,
+        reverse=reverse,
+    )

--- a/tests/test_kinetics.py
+++ b/tests/test_kinetics.py
@@ -1,0 +1,457 @@
+"""Tests for difflow.kinetics.
+
+The load-bearing test is `test_matches_a_hand_written_rate_fn`: a
+reactor driven by the declarative rate law must produce exactly what
+the same reactor produces from a hand-written callable. Everything else
+checks the algebra against closed-form values, or checks that a
+specification which cannot be turned into a correct rate law is refused
+rather than approximated.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+jax.config.update("jax_enable_x64", True)
+
+from difflow import CSTR, CSTRParams, get_flows, import_reactions, make_stream
+from difflow.kinetics import (
+    R_GAS,
+    KineticsSpecError,
+    ReactionSet,
+    mass_action_kinetics,
+)
+
+SPECIES = ["A", "B"]
+
+
+def first_order(A=1.0e6, Ea=50_000.0, n=0.0):
+    """A -> B."""
+    return [{
+        "equation": "A -> B",
+        "reactants": {"A": 1.0}, "products": {"B": 1.0},
+        "rate_params": {"A": A, "Ea": Ea, "n": n},
+    }]
+
+
+def reversible(K_eq=4.0):
+    """A <=> B."""
+    return [{
+        "equation": "A <=> B",
+        "reactants": {"A": 1.0}, "products": {"B": 1.0},
+        "rate_params": {"A": 2.0, "Ea": 0.0, "n": 0.0},
+        "reversible": True, "K_eq": K_eq,
+    }]
+
+
+# =============================================================================
+# Stoichiometry
+# =============================================================================
+
+
+class TestStoichiometry:
+    def test_signs_and_coefficients(self):
+        """Negative for reactants, positive for products."""
+        rxns = [{
+            "equation": "2 A -> 3 B",
+            "reactants": {"A": 2.0}, "products": {"B": 3.0},
+            "rate_params": {"A": 1.0},
+        }]
+        kin = mass_action_kinetics(rxns, SPECIES)
+        np.testing.assert_allclose(np.asarray(kin.stoich), [[-2.0], [3.0]])
+
+    def test_shape_is_species_by_reactions(self):
+        kin = mass_action_kinetics(
+            first_order() + first_order(), SPECIES
+        )
+        assert kin.stoich.shape == (2, 2)
+        assert kin.n_species == 2 and kin.n_reactions == 2
+
+    def test_species_order_defaults_to_sorted_union(self):
+        rxns = [{
+            "equation": "B -> A", "reactants": {"B": 1.0}, "products": {"A": 1.0},
+            "rate_params": {"A": 1.0},
+        }]
+        assert mass_action_kinetics(rxns).species_order == ["A", "B"]
+
+    def test_species_order_is_respected(self):
+        """Row order must follow the caller's species order, not sorted."""
+        kin = mass_action_kinetics(first_order(), ["B", "A"])
+        np.testing.assert_allclose(np.asarray(kin.stoich), [[1.0], [-1.0]])
+
+    def test_a_species_on_both_sides_nets_out(self):
+        rxns = [{
+            "equation": "2 A -> A + B",
+            "reactants": {"A": 2.0}, "products": {"A": 1.0, "B": 1.0},
+            "rate_params": {"A": 1.0},
+        }]
+        kin = mass_action_kinetics(rxns, SPECIES)
+        # net -1 in A, but the rate is still second order in A
+        np.testing.assert_allclose(np.asarray(kin.stoich), [[-1.0], [1.0]])
+        assert float(kin.rates({"A": 2.0, "B": 0.0}, 300.0)[0]) == pytest.approx(4.0)
+
+
+# =============================================================================
+# The rate law
+# =============================================================================
+
+
+class TestRateLaw:
+    def test_first_order_matches_arrhenius(self):
+        kin = mass_action_kinetics(first_order(), SPECIES)
+        T, c_a = 350.0, 2.0
+        expected = 1.0e6 * np.exp(-50_000.0 / (R_GAS * T)) * c_a
+        got = float(kin.rates({"A": c_a, "B": 0.0}, T)[0])
+        assert got == pytest.approx(expected, rel=1e-12)
+
+    def test_order_comes_from_reactant_stoichiometry(self):
+        rxns = [{
+            "equation": "2 A -> B", "reactants": {"A": 2.0}, "products": {"B": 1.0},
+            "rate_params": {"A": 3.0, "Ea": 0.0, "n": 0.0},
+        }]
+        kin = mass_action_kinetics(rxns, SPECIES)
+        assert float(kin.rates({"A": 2.0, "B": 0.0}, 300.0)[0]) == pytest.approx(
+            3.0 * 2.0**2
+        )
+
+    def test_temperature_exponent(self):
+        kin = mass_action_kinetics(first_order(A=2.0, Ea=0.0, n=1.5), SPECIES)
+        T = 400.0
+        assert float(kin.rates({"A": 1.0, "B": 0.0}, T)[0]) == pytest.approx(
+            2.0 * T**1.5
+        )
+
+    def test_rate_rises_with_temperature(self):
+        kin = mass_action_kinetics(first_order(), SPECIES)
+        c = {"A": 1.0, "B": 0.0}
+        assert float(kin.rates(c, 400.0)[0]) > float(kin.rates(c, 300.0)[0])
+
+    def test_zero_concentration_is_finite_and_negligible(self):
+        """A missing reactant must give no rate, and no nan.
+
+        The log-space product floors the concentration rather than
+        evaluating 0 ** order, so the rate underflows instead of
+        reaching exactly zero. The residue is 300 orders of magnitude
+        below anything physical.
+        """
+        kin = mass_action_kinetics(first_order(Ea=0.0), SPECIES)
+        r = kin.rates({"A": 0.0, "B": 0.0}, 300.0)
+        assert bool(jnp.all(jnp.isfinite(r)))
+        assert abs(float(r[0])) < 1e-280
+
+    def test_a_zero_order_reactant_still_reacts_at_zero(self):
+        """0 ** 0 is 1, not 0: a zeroth-order rate is concentration-free."""
+        rxns = [{
+            "equation": "A -> B", "reactants": {"A": 1.0}, "products": {"B": 1.0},
+            "rate_params": {"A": 7.0, "Ea": 0.0, "n": 0.0},
+        }]
+        kin = mass_action_kinetics(rxns, SPECIES, orders=[{}])
+        assert float(kin.rates({"A": 0.0, "B": 0.0}, 300.0)[0]) == pytest.approx(7.0)
+
+    def test_explicit_orders_override_stoichiometry(self):
+        """Empirical orders need not equal the coefficients."""
+        rxns = [{
+            "equation": "2 A -> B", "reactants": {"A": 2.0}, "products": {"B": 1.0},
+            "rate_params": {"A": 5.0, "Ea": 0.0, "n": 0.0},
+        }]
+        kin = mass_action_kinetics(rxns, SPECIES, orders=[{"A": 1.0}])
+        # first order in A despite the coefficient of 2 ...
+        assert float(kin.rates({"A": 3.0, "B": 0.0}, 300.0)[0]) == pytest.approx(15.0)
+        # ... while the stoichiometry is untouched
+        np.testing.assert_allclose(np.asarray(kin.stoich), [[-2.0], [1.0]])
+
+    def test_multiple_reactions_are_independent(self):
+        rxns = first_order(A=1.0, Ea=0.0) + [{
+            "equation": "B -> A", "reactants": {"B": 1.0}, "products": {"A": 1.0},
+            "rate_params": {"A": 10.0, "Ea": 0.0, "n": 0.0},
+        }]
+        kin = mass_action_kinetics(rxns, SPECIES)
+        r = kin.rates({"A": 2.0, "B": 3.0}, 300.0)
+        assert float(r[0]) == pytest.approx(2.0)
+        assert float(r[1]) == pytest.approx(30.0)
+
+
+# =============================================================================
+# Reversibility
+# =============================================================================
+
+
+class TestReversibility:
+    def test_refused_by_default(self):
+        """Forward Arrhenius alone does not determine the reverse rate."""
+        with pytest.raises(KineticsSpecError, match="reversible"):
+            mass_action_kinetics(reversible(), SPECIES)
+
+    def test_error_names_the_reaction(self):
+        with pytest.raises(KineticsSpecError) as exc:
+            mass_action_kinetics(reversible(), SPECIES)
+        assert "A <=> B" in str(exc.value)
+
+    def test_forward_only_drops_the_reverse_term(self):
+        kin = mass_action_kinetics(reversible(), SPECIES, reverse="forward_only")
+        # 2 * C_A, with no dependence on C_B at all
+        assert float(kin.rates({"A": 3.0, "B": 8.0}, 300.0)[0]) == pytest.approx(6.0)
+        assert float(kin.rates({"A": 3.0, "B": 0.0}, 300.0)[0]) == pytest.approx(6.0)
+        assert kin.reverse == "forward_only"
+
+    def test_equilibrium_subtracts_the_reverse_term(self):
+        kin = mass_action_kinetics(reversible(K_eq=4.0), SPECIES,
+                                   reverse="equilibrium")
+        # k (C_A - C_B / K_eq) = 2 (3 - 8/4)
+        assert float(kin.rates({"A": 3.0, "B": 8.0}, 300.0)[0]) == pytest.approx(2.0)
+
+    def test_equilibrium_rate_vanishes_at_equilibrium(self):
+        """The defining property: r = 0 when C_B / C_A = K_eq."""
+        kin = mass_action_kinetics(reversible(K_eq=4.0), SPECIES,
+                                   reverse="equilibrium")
+        assert float(kin.rates({"A": 2.0, "B": 8.0}, 300.0)[0]) == pytest.approx(
+            0.0, abs=1e-12
+        )
+
+    def test_equilibrium_reverses_sign_past_equilibrium(self):
+        kin = mass_action_kinetics(reversible(K_eq=4.0), SPECIES,
+                                   reverse="equilibrium")
+        assert float(kin.rates({"A": 1.0, "B": 20.0}, 300.0)[0]) < 0.0
+
+    def test_equilibrium_requires_k_eq(self):
+        rxn = reversible()
+        del rxn[0]["K_eq"]
+        with pytest.raises(KineticsSpecError, match="K_eq"):
+            mass_action_kinetics(rxn, SPECIES, reverse="equilibrium")
+
+    def test_irreversible_reactions_ignore_the_mode(self):
+        for mode in ("error", "forward_only", "equilibrium"):
+            kin = mass_action_kinetics(first_order(Ea=0.0), SPECIES, reverse=mode)
+            assert float(kin.rates({"A": 1.0, "B": 5.0}, 300.0)[0]) == pytest.approx(
+                1.0e6
+            )
+
+
+# =============================================================================
+# Rejected specifications
+# =============================================================================
+
+
+class TestValidation:
+    def test_unsupported_reaction_type_is_refused(self):
+        """Falloff and three-body need their own rate law, not an approximation."""
+        for kind in ("falloff", "three-body", "pressure-dependent-Arrhenius"):
+            rxns = [{**first_order()[0], "type": kind}]
+            with pytest.raises(KineticsSpecError, match="unsupported reaction type"):
+                mass_action_kinetics(rxns, SPECIES)
+
+    def test_unknown_species_is_refused(self):
+        with pytest.raises(KineticsSpecError, match="not in species_order"):
+            mass_action_kinetics(first_order(), ["A"])
+
+    def test_empty_reaction_list_is_refused(self):
+        with pytest.raises(KineticsSpecError, match="no reactions"):
+            mass_action_kinetics([], SPECIES)
+
+    def test_bad_reverse_mode_is_refused(self):
+        with pytest.raises(ValueError, match="reverse="):
+            mass_action_kinetics(first_order(), SPECIES, reverse="maybe")
+
+    def test_order_for_unknown_species_is_refused(self):
+        with pytest.raises(KineticsSpecError, match="not in species_order"):
+            mass_action_kinetics(first_order(), SPECIES, orders=[{"Z": 1.0}])
+
+
+# =============================================================================
+# Differentiability
+# =============================================================================
+
+
+class TestDifferentiability:
+    def test_gradient_wrt_concentration(self):
+        rxns = [{
+            "equation": "2 A -> B", "reactants": {"A": 2.0}, "products": {"B": 1.0},
+            "rate_params": {"A": 3.0, "Ea": 0.0, "n": 0.0},
+        }]
+        kin = mass_action_kinetics(rxns, SPECIES)
+        g = jax.grad(lambda c: kin.rates({"A": c, "B": 0.0}, 300.0)[0])(2.0)
+        # d/dC (3 C^2) = 6 C
+        assert float(g) == pytest.approx(12.0, rel=1e-9)
+
+    def test_gradient_at_zero_concentration_is_finite(self):
+        kin = mass_action_kinetics(first_order(Ea=0.0), SPECIES)
+        g = jax.grad(lambda c: kin.rates({"A": c, "B": 0.0}, 300.0)[0])(0.0)
+        assert bool(jnp.isfinite(g))
+
+    def test_gradient_wrt_temperature_is_positive(self):
+        kin = mass_action_kinetics(first_order(), SPECIES)
+        g = jax.grad(lambda T: kin.rates({"A": 1.0, "B": 0.0}, T)[0])(350.0)
+        assert bool(jnp.isfinite(g)) and float(g) > 0.0
+
+    def test_rate_params_are_a_differentiable_pytree(self):
+        """Fitting a rate constant differentiates through rate_params."""
+        kin = mass_action_kinetics(first_order(), SPECIES)
+
+        def rate(pre_exponential):
+            rp = {**kin.rate_params, "A": jnp.array([pre_exponential])}
+            return kin.rate_fn({"A": 1.0, "B": 0.0}, 350.0, rp)[0]
+
+        g = jax.grad(rate)(1.0e6)
+        assert bool(jnp.isfinite(g)) and float(g) > 0.0
+
+    def test_can_be_built_inside_a_trace(self):
+        """The structure is static, but the coefficients may be traced."""
+        def rate(pre_exponential):
+            kin = mass_action_kinetics(first_order(A=pre_exponential), SPECIES)
+            return kin.rates({"A": 1.0, "B": 0.0}, 350.0)[0]
+
+        assert bool(jnp.isfinite(jax.grad(rate)(1.0e6)))
+        assert bool(jnp.isfinite(jax.jit(rate)(1.0e6)))
+
+    def test_jit(self):
+        kin = mass_action_kinetics(first_order(), SPECIES)
+        fn = jax.jit(lambda c, T: kin.rate_fn({"A": c, "B": 0.0}, T, kin.rate_params))
+        assert bool(jnp.all(jnp.isfinite(fn(1.0, 350.0))))
+
+
+# =============================================================================
+# Driving a real reactor
+# =============================================================================
+
+
+class TestReactorIntegration:
+    def test_matches_a_hand_written_rate_fn(self):
+        """The whole point: a declarative rate law is not an approximation.
+
+        Same reactor, same numbers, one built from a Python callable and
+        one from data.
+        """
+        def hand_rate(C, T, p):
+            k = p["k0"] * jnp.exp(-p["Ea"] / (R_GAS * T))
+            return jnp.array([k * C["A"]])
+
+        hand = CSTRParams(
+            V=1.5, rate_fn=hand_rate, stoich=jnp.array([[-1.0], [1.0]]),
+            rate_params={"k0": 1.0e6, "Ea": 50_000.0},
+            species_order=SPECIES, molar_density=1000.0,
+        )
+        kin = mass_action_kinetics(first_order(), SPECIES)
+        declarative = CSTRParams(V=1.5, molar_density=1000.0, **kin.params_kwargs())
+
+        feed = make_stream({"A": 1.0, "B": 0.0}, T=350.0, P=101325.0)
+
+        def outlet_flows(params):
+            out = CSTR(params)(feed)
+            stream = out[0] if isinstance(out, tuple) else out
+            return {k: float(v) for k, v in get_flows(stream).items()}
+
+        a, b = outlet_flows(hand), outlet_flows(declarative)
+        for species in a:
+            assert a[species] == pytest.approx(b[species], abs=1e-12), (
+                f"{species}: hand {a[species]} vs declarative {b[species]}"
+            )
+        assert b["B"] > 0.9, "the reaction should have run"
+
+    def test_params_kwargs_supplies_every_reactor_field(self):
+        kin = mass_action_kinetics(first_order(), SPECIES)
+        kwargs = kin.params_kwargs()
+        assert set(kwargs) == {"rate_fn", "stoich", "rate_params", "species_order"}
+        CSTRParams(V=1.0, **kwargs)          # must not raise
+
+    def test_gradient_through_the_reactor(self):
+        kin = mass_action_kinetics(first_order(), SPECIES)
+        feed = make_stream({"A": 1.0, "B": 0.0}, T=350.0, P=101325.0)
+
+        def product_flow(pre_exponential):
+            rp = {**kin.rate_params, "A": jnp.array([pre_exponential])}
+            params = CSTRParams(
+                V=1.5, molar_density=1000.0, rate_fn=kin.rate_fn,
+                stoich=kin.stoich, rate_params=rp, species_order=SPECIES,
+            )
+            out = CSTR(params)(feed)
+            stream = out[0] if isinstance(out, tuple) else out
+            return get_flows(stream)["B"]
+
+        g = jax.grad(product_flow)(1.0e6)
+        assert bool(jnp.isfinite(g))
+        assert float(g) > 0.0, "a faster reaction must make more product"
+
+
+# =============================================================================
+# The Cantera path
+# =============================================================================
+
+
+@pytest.fixture(scope="module")
+def reactions():
+    """The repo's Cantera test mechanism, as reaction dictionaries."""
+    return import_reactions("tests/data/test_mechanism.yaml")
+
+
+class TestFromCanteraYAML:
+    def test_import_reactions_output_is_accepted(self, reactions):
+        """No adapter needed between the importer and the rate law."""
+        kin = mass_action_kinetics(reactions, reverse="forward_only")
+        assert kin.n_reactions == len(reactions)
+        assert kin.species_order == ["CH4", "CO", "CO2", "H2", "H2O", "O2"]
+        assert kin.stoich.shape == (6, len(reactions))
+
+    def test_rates_are_finite(self, reactions):
+        kin = mass_action_kinetics(reactions, reverse="forward_only")
+        r = kin.rates({s: 10.0 for s in kin.species_order}, 1200.0)
+        assert bool(jnp.all(jnp.isfinite(r)))
+        assert bool(jnp.all(r > 0)), "forward rates should be positive"
+
+    def test_a_reversible_mechanism_is_refused_by_default(self, reactions):
+        with pytest.raises(KineticsSpecError, match="reversible"):
+            mass_action_kinetics(reactions)
+
+    def test_elements_are_conserved_by_the_stoichiometry(self, reactions):
+        """Carbon balance over every reaction, from the parsed coefficients."""
+        carbon = {"CH4": 1, "CO": 1, "CO2": 1, "H2": 0, "H2O": 0, "O2": 0}
+        kin = mass_action_kinetics(reactions, reverse="forward_only")
+        counts = jnp.array([carbon[s] for s in kin.species_order], dtype=jnp.float64)
+        np.testing.assert_allclose(
+            np.asarray(counts @ kin.stoich), np.zeros(kin.n_reactions), atol=1e-12
+        )
+
+
+# =============================================================================
+# Reporting
+# =============================================================================
+
+
+class TestReporting:
+    def test_equations_follow_the_unit_operation_convention(self):
+        kin = mass_action_kinetics(first_order(), SPECIES)
+        assert len(kin.equations) == 1
+        assert "C_{A}" in kin.equations[0]
+
+    def test_equations_show_the_reverse_term_only_when_used(self):
+        fwd = mass_action_kinetics(reversible(), SPECIES, reverse="forward_only")
+        eq = mass_action_kinetics(reversible(), SPECIES, reverse="equilibrium")
+        assert "K_{eq}" not in fwd.equations[0]
+        assert "K_{eq}" in eq.equations[0]
+
+    def test_order_appears_in_the_latex(self):
+        rxns = [{
+            "equation": "2 A -> B", "reactants": {"A": 2.0}, "products": {"B": 1.0},
+            "rate_params": {"A": 1.0},
+        }]
+        assert "C_{A}^{2}" in mass_action_kinetics(rxns, SPECIES).equations[0]
+
+    def test_summary_reports_the_coefficients(self):
+        kin = mass_action_kinetics(first_order(), SPECIES)
+        text = kin.summary()
+        assert "A -> B" in text and "50.00" in text     # Ea in kJ/mol
+
+    def test_source_reactions_are_kept_for_round_tripping(self):
+        rxns = first_order()
+        kin = mass_action_kinetics(rxns, SPECIES)
+        assert kin.reactions == rxns
+
+    def test_is_a_params_mixin(self):
+        kin = mass_action_kinetics(first_order(), SPECIES)
+        assert isinstance(kin, ReactionSet)
+        assert "stoich" in kin
+        assert kin["reverse"] == "error"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
First step toward #174. Of the 78 `Params` dataclasses in the package, **73 are already pure data**; the five that are not are all reactors, all because of one field:

| | fields | callable fields |
|---|---|---|
| `CSTRParams` | 13 | `rate_fn`, `eos`, `H_mix_fn`, `K_eq_fn` |
| `PFRParams` | 10 | `rate_fn` |
| `GasPFRParams` | 10 | `rate_fn` |
| `FedBatchParams` | 6 | `rate_fn` |
| `BioreactorParams` | 10 | `kinetic_fn` |

`rate_fn` is expressive but it is *code*, not data — it can't be written to a file, built from a form, or round-tripped through a GUI. `mass_action_kinetics` builds it from plain dictionaries instead:

```python
from difflow import CSTR, CSTRParams, mass_action_kinetics

reactions = [{
    "equation":  "A -> B",
    "reactants": {"A": 1.0},
    "products":  {"B": 1.0},
    "rate_params": {"A": 1.0e6, "Ea": 50_000.0, "n": 0.0},
}]

kin = mass_action_kinetics(reactions, species_order=["A", "B"])
cstr = CSTR(CSTRParams(V=1.5, **kin.params_kwargs()))
```

That dict format is exactly what `import_reactions` already returns from Cantera YAML — the two ends existed and simply weren't connected — so a published mechanism now goes straight into a reactor:

```python
kin = mass_action_kinetics(import_reactions("mech.yaml"), reverse="forward_only")
```

## It's a bridge, not a second implementation

The test that matters: a CSTR driven by a hand-written `rate_fn` and by the declarative one agrees to **3e-18** on the outlet flows. Same reactor, same numbers, one built from a callable and one from data.

## What it refuses, and why

Two specifications raise `KineticsSpecError` rather than being approximated, because in both a guess yields a plausible number that is wrong:

- **Reversible reactions, by default.** Forward Arrhenius parameters alone do not determine the reverse rate. `reverse="equilibrium"` uses a `K_eq` per reaction; `reverse="forward_only"` drops the reverse term as an explicit approximation, recorded on the result. The repo's own test mechanism is entirely reversible, so this is the common path, not an edge case.
- **Three-body, falloff and other pressure-dependent types**, which need their own rate law.

## One numerical decision worth reviewing

The concentration products are taken in **log space**, not as `prod(C ** order)`. I measured both:

| at `C = 0` | value | derivative |
|---|---|---|
| `prod(C ** order)` | exact 0 | **nan** |
| `exp(order · log C)` | underflows to ~0 | 0, finite |

The power form is more accurate on value and unusable on gradients — one nan poisons the entire reactor solve. The log form's floor sits 300 orders of magnitude below anything physical, so a missing reactant underflows to zero rather than inventing a rate. Away from zero the two agree exactly. The trade-off is that at exactly `C = 0` a first-order reaction reports a derivative of 0 where the true value is `k`; that's documented at the constant.

## Also included

- LaTeX rate expressions in the `equations` attribute the unit operations already use, and the source reactions kept on the result — both aimed at #174, where a UI needs to *display* and *persist* a model it didn't author.
- Arrhenius coefficients may be traced, so a set can be built inside `jit`/`grad` for parameter fitting; the reaction structure stays static.
- A `Declarative Kinetics` section in `docs/unit-operations-chemical.md`.

## Verification

`1384 passed, 2 skipped` — 45 new tests covering stoichiometry signs and ordering, the rate law against closed-form values, all three reversibility modes (including that the equilibrium rate vanishes exactly at equilibrium and reverses sign past it), every rejected specification, gradients and `jit`, the CSTR equivalence above, and the Cantera mechanism end to end with a carbon balance over the parsed stoichiometry.

Not addressed here: `CSTRParams.eos`, `H_mix_fn` and `K_eq_fn` are still callables. Those are thermo, not kinetics, and want a separate declarative path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0115wVXe4gdrijT1yvb6YjcM

---
_Generated by [Claude Code](https://claude.ai/code/session_0115wVXe4gdrijT1yvb6YjcM)_