### PR TITLE
feat: register the core units and add a machine-readable catalog

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,7 @@ difflow/
 │   │   ├── database.py    # Species property database
 │   │   ├── flowsheet.py   # Flowsheet with recycle solving
 │   │   ├── uncertainty.py # Sensitivity & UQ
+│   ├── catalog.py     # Machine-readable schema of every unit operation
 │   ├── reconciliation/ # Data reconciliation, gross error detection, observability
 │   │   ├── params_mixin.py # ParamsMixin base class for Params dataclasses
 │   │   ├── units/         # Steady-state unit operations

--- a/docs/streams-and-flowsheets.md
+++ b/docs/streams-and-flowsheets.md
@@ -458,6 +458,47 @@ protein_a = OperationRegistry.get('protein_a_chromatography')
 
 ---
 
+## Operation Catalog
+
+The registry answers *what units exist*. `difflow.catalog` answers *what you can do with one*: how many streams go in and out, what parameters it takes, which are required, and which hold code rather than data.
+
+```python
+from difflow import catalog, describe_operation
+
+spec = describe_operation("Flash")
+spec.ports.inlets          # ['inlet']
+spec.ports.n_outlets       # 2
+spec.required_parameters() # ['T']
+spec.equations             # LaTeX governing equations
+spec.to_dict()             # JSON-serializable, for a UI or code generator
+```
+
+`catalog()` returns a schema for every registered operation, optionally filtered:
+
+```python
+reactors = catalog(category="reactors")
+```
+
+All of it is **derived by introspection**, not from a second hand-maintained table: parameters come from `dataclasses.fields` of the unit's `Params` class, ports from the `__call__` signature, and equations from the `equations` class attribute the units already carry. The catalog therefore cannot drift from the code, and an operation whose signature is unannotated is reported as *unknown* rather than guessed at — `Splitter` returns a bare `tuple`, so its `n_outlets` is `None`.
+
+### Which operations are declarative
+
+`is_declarative` marks the operations whose parameters are all data, so a form or a JSON file could supply them:
+
+```python
+[name for name, spec in catalog().items() if not spec.is_declarative]
+```
+
+The handful that are not are the reactors, and always because of the rate law — see [Declarative Kinetics](unit-operations-chemical.md) for building that from data instead.
+
+### Core units and the registry
+
+The core reactors, separators, columns and exchangers are registered when `difflow` is imported, so they appear in `catalog()` alongside the plugin units with no `load_plugins()` call needed.
+
+One name is deliberately not the class name: `difflow_gas` registers a `Compressor`, and plugins load *after* the core, so the EOS-consistent `difflow.Compressor` is catalogued as **`EOSCompressor`**. Registering both under the bare name would silently drop one.
+
+---
+
 ## Best Practices
 
 ### Stream Naming Conventions

--- a/src/difflow/__init__.py
+++ b/src/difflow/__init__.py
@@ -230,6 +230,15 @@ from difflow import estimation
 # Data reconciliation submodule
 from difflow import reconciliation
 
+# Operation catalog
+from difflow.catalog import (
+    OperationSchema,
+    ParameterSpec,
+    PortSpec,
+    catalog,
+    describe_operation,
+)
+
 # Economics submodule
 from difflow import economics
 
@@ -476,6 +485,12 @@ __all__ = [
     "estimation",
     # Data reconciliation
     "reconciliation",
+    # Operation catalog
+    "catalog",
+    "describe_operation",
+    "OperationSchema",
+    "ParameterSpec",
+    "PortSpec",
     # Economics
     "economics",
     # Visualization (optional)
@@ -511,3 +526,17 @@ __all__ = [
     "DAEResult",
     "DynamicFlashDrum",
 ]
+
+
+# ---------------------------------------------------------------------
+# Populate the operation registry with the core units.
+#
+# The registry was previously filled only by plugins, so it held the
+# bio, carbon-capture, gas and REE units but none of the reactors,
+# separators, columns or exchangers. This runs last because it reads
+# __all__ to discover them.
+# ---------------------------------------------------------------------
+
+from difflow.catalog import register_core_operations as _register_core_operations
+
+_register_core_operations()

--- a/src/difflow/catalog.py
+++ b/src/difflow/catalog.py
@@ -1,0 +1,464 @@
+"""A machine-readable catalog of unit operations.
+
+The registry knows a name, a class, a category and a description. That
+is enough to *list* operations, but not enough to build anything
+against them: a form needs to know what parameters a unit takes and
+which are required, and a canvas needs to know how many streams go in
+and come out before anything is instantiated.
+
+This module derives that from the code itself rather than from a second
+hand-maintained table:
+
+* **parameters** come from ``dataclasses.fields`` of the unit's
+  ``Params`` class --- name, type, default, whether it is required, and
+  whether it is a callable (which is what a declarative front end
+  cannot author; see :mod:`difflow.kinetics`).
+* **ports** come from the ``__call__`` signature: parameters annotated
+  as :data:`~difflow.streams.Stream` are inlets, and the leading
+  ``Stream`` entries of the return tuple are outlets.
+* **equations** come from the ``equations`` class attribute the unit
+  operations already carry.
+
+Deriving rather than declaring means the catalog cannot drift from the
+code, and that an operation whose signature is unannotated is reported
+as *unknown* rather than guessed at.
+
+    >>> from difflow.catalog import describe_operation
+    >>> spec = describe_operation("Flash")
+    >>> spec.ports.n_outlets
+    2
+    >>> [p.name for p in spec.parameters if p.required]
+    ['T']
+
+Every schema is JSON-serializable through :meth:`OperationSchema.to_dict`,
+which is what a GUI, a CLI or a code generator would consume.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import inspect
+import typing
+from dataclasses import dataclass, field
+from typing import Any
+
+from difflow.params_mixin import ParamsMixin
+
+#: module name -> category, for the core unit operations
+CORE_CATEGORIES = {
+    "cstr": "reactors",
+    "pfr": "reactors",
+    "fed_batch": "reactors",
+    "flash": "separations",
+    "distillation": "distillation",
+    "heat_exchanger": "heat_transfer",
+    "lle": "extraction",
+    "eos_units": "pressure_change",
+    "gas_turbine": "power",
+}
+
+#: classes in ``difflow.units`` that are not themselves operations
+NOT_OPERATIONS = frozenset({"UnitBase", "ReactorBase", "DistributionCoeffs"})
+
+#: registry name -> class name, where the two deliberately differ.
+#: ``difflow_gas`` also registers a "Compressor", so the EOS-consistent
+#: one takes a qualified name rather than silently overwriting it (or
+#: being overwritten, since plugins load after the core).
+CORE_NAME_OVERRIDES = {"Compressor": "EOSCompressor"}
+
+
+@dataclass
+class PortSpec(ParamsMixin):
+    """Stream connectivity of an operation.
+
+    Attributes:
+        inlets: names of the stream-typed arguments, in call order.
+        n_outlets: number of outlet streams, or ``None`` when the return
+            annotation does not say.
+        variadic: whether the operation takes any number of inlets
+            (``*inlets``), as a mixer does.
+    """
+
+    inlets: list[str] = field(default_factory=list)
+    n_outlets: int | None = None
+    variadic: bool = False
+
+    @property
+    def n_inlets(self) -> int | None:
+        """Number of inlets, or ``None`` if variadic."""
+        return None if self.variadic else len(self.inlets)
+
+
+@dataclass
+class ParameterSpec(ParamsMixin):
+    """One field of an operation's ``Params`` class.
+
+    Attributes:
+        name: field name.
+        type: the annotation, as written.
+        default: the default, rendered as a string; ``None`` if required.
+        required: whether the field has no default.
+        is_callable: whether the field holds a function or an arbitrary
+            object rather than data. These are the fields a declarative
+            front end cannot fill in.
+        units: physical units, when the field declares them in its
+            dataclass metadata.
+        description: help text, when the field declares it.
+    """
+
+    name: str
+    type: str
+    default: str | None = None
+    required: bool = False
+    is_callable: bool = False
+    units: str | None = None
+    description: str | None = None
+
+
+@dataclass
+class OperationSchema(ParamsMixin):
+    """Everything known about one unit operation, as data.
+
+    Attributes:
+        name: the name it is registered under.
+        class_name: the Python class, which may differ from ``name``.
+        module: where the class lives.
+        category: registry category, for grouping in a palette.
+        description: one-line summary.
+        plugin: the package that registered it.
+        equations: LaTeX governing equations, if the unit declares any.
+        ports: stream connectivity.
+        parameters: the ``Params`` fields.
+        params_class: name of the ``Params`` dataclass, if one was found.
+    """
+
+    name: str
+    class_name: str
+    module: str
+    category: str
+    description: str
+    plugin: str
+    equations: list[str] = field(default_factory=list)
+    ports: PortSpec = field(default_factory=PortSpec)
+    parameters: list[ParameterSpec] = field(default_factory=list)
+    params_class: str | None = None
+
+    @property
+    def is_declarative(self) -> bool:
+        """Whether every parameter is data a form could supply."""
+        return not any(p.is_callable for p in self.parameters)
+
+    @property
+    def callable_parameters(self) -> list[str]:
+        """Fields that hold code rather than data."""
+        return [p.name for p in self.parameters if p.is_callable]
+
+    def required_parameters(self) -> list[str]:
+        return [p.name for p in self.parameters if p.required]
+
+    def to_dict(self) -> dict:
+        """A plain, JSON-serializable dictionary."""
+        return {
+            "name": self.name,
+            "class_name": self.class_name,
+            "module": self.module,
+            "category": self.category,
+            "description": self.description,
+            "plugin": self.plugin,
+            "equations": list(self.equations),
+            "params_class": self.params_class,
+            "declarative": self.is_declarative,
+            "ports": {
+                "inlets": list(self.ports.inlets),
+                "n_inlets": self.ports.n_inlets,
+                "n_outlets": self.ports.n_outlets,
+                "variadic": self.ports.variadic,
+            },
+            "parameters": [dataclasses.asdict(p) for p in self.parameters],
+        }
+
+
+# ---------------------------------------------------------------------
+# Introspection
+# ---------------------------------------------------------------------
+
+
+def _stream_repr() -> str:
+    from difflow.streams import Stream
+
+    return str(Stream)
+
+
+def _is_stream(annotation: Any) -> bool:
+    """Whether an annotation denotes a :data:`~difflow.streams.Stream`.
+
+    Two forms have to be recognised. Where the alias has been evaluated
+    it renders as ``dict[str, Array | float]``, which must be matched
+    *exactly*: the info payload every unit returns alongside its outlets
+    is ``dict[str, Array]``, and a loose match counts it as a stream.
+    Where a module uses ``from __future__ import annotations`` the
+    annotation survives as the literal string ``"Stream"``.
+    """
+    if annotation is inspect.Parameter.empty:
+        return False
+    text = str(annotation).strip().strip("'\"")
+    return text == _stream_repr() or text == "Stream"
+
+
+def _split_top_level(text: str) -> list[str]:
+    """Split ``a, b[c, d], e`` on its top-level commas."""
+    parts, depth, current = [], 0, ""
+    for ch in text:
+        if ch in "[(":
+            depth += 1
+        elif ch in "])":
+            depth -= 1
+        if ch == "," and depth == 0:
+            parts.append(current)
+            current = ""
+        else:
+            current += ch
+    if current.strip():
+        parts.append(current)
+    return [p.strip() for p in parts]
+
+
+def _outlet_count(ret: Any) -> int | None:
+    """Number of leading ``Stream`` entries in a return annotation."""
+    if ret is inspect.Signature.empty:
+        return None
+    args = typing.get_args(ret)
+    if args:
+        return sum(1 for a in args if _is_stream(a))
+    # a string annotation, e.g. "tuple[Stream, dict]"
+    text = str(ret).strip().strip("'\"")
+    if text.startswith("tuple[") and text.endswith("]"):
+        return sum(1 for p in _split_top_level(text[6:-1]) if _is_stream(p))
+    return None
+
+
+def _ports(cls: type) -> PortSpec:
+    """Derive stream connectivity from the ``__call__`` signature."""
+    try:
+        sig = inspect.signature(cls.__call__)
+    except (TypeError, ValueError):
+        return PortSpec()
+
+    inlets, variadic = [], False
+    for name, param in sig.parameters.items():
+        if name == "self":
+            continue
+        if param.kind is inspect.Parameter.VAR_POSITIONAL:
+            # *inlets on a mixer: any number of streams
+            variadic = True
+            inlets.append(name)
+            continue
+        if param.kind is inspect.Parameter.VAR_KEYWORD:
+            continue
+        if _is_stream(param.annotation):
+            inlets.append(name)
+
+    # outlets are the Stream entries of the return tuple; the trailing
+    # dict is the info payload every unit returns alongside them
+    return PortSpec(
+        inlets=inlets,
+        n_outlets=_outlet_count(sig.return_annotation),
+        variadic=variadic,
+    )
+
+
+def _params_class(cls: type) -> type | None:
+    """The ``Params`` dataclass a unit is constructed from.
+
+    Taken from the annotation of ``__init__``'s first argument, falling
+    back to the ``<ClassName>Params`` naming convention.
+    """
+    try:
+        sig = inspect.signature(cls.__init__)
+    except (TypeError, ValueError):
+        return None
+    for name, param in sig.parameters.items():
+        if name == "self":
+            continue
+        ann = param.annotation
+        if dataclasses.is_dataclass(ann):
+            return ann
+        if isinstance(ann, str) and ann.endswith("Params"):
+            found = getattr(inspect.getmodule(cls), ann, None)
+            if dataclasses.is_dataclass(found):
+                return found
+        break
+    guess = getattr(inspect.getmodule(cls), f"{cls.__name__}Params", None)
+    return guess if dataclasses.is_dataclass(guess) else None
+
+
+def _is_code(annotation: Any) -> bool:
+    """Whether a field holds a function or an arbitrary object."""
+    text = str(annotation)
+    return "Callable" in text or text.strip() in ("typing.Any", "Any")
+
+
+def _parameters(params_cls: type | None) -> list[ParameterSpec]:
+    """Describe every field of a ``Params`` dataclass."""
+    if params_cls is None:
+        return []
+    specs = []
+    for f in dataclasses.fields(params_cls):
+        has_default = (
+            f.default is not dataclasses.MISSING
+            or f.default_factory is not dataclasses.MISSING  # type: ignore[misc]
+        )
+        default = None
+        if f.default is not dataclasses.MISSING:
+            default = repr(f.default)
+        elif f.default_factory is not dataclasses.MISSING:  # type: ignore[misc]
+            default = f"{f.default_factory.__name__}()"  # type: ignore[misc]
+        specs.append(ParameterSpec(
+            name=f.name,
+            type=str(f.type),
+            default=default,
+            required=not has_default,
+            is_callable=_is_code(f.type),
+            units=f.metadata.get("units"),
+            description=f.metadata.get("description"),
+        ))
+    return specs
+
+
+def describe_class(
+    cls: type,
+    *,
+    name: str | None = None,
+    category: str = "general",
+    description: str = "",
+    plugin: str = "core",
+) -> OperationSchema:
+    """Build a schema for a unit operation class.
+
+    Works on any class, registered or not, which is what makes it
+    usable on a plugin's units before they are wired in.
+    """
+    params_cls = _params_class(cls)
+    doc = (description or cls.__doc__ or "").strip()
+    return OperationSchema(
+        name=name or cls.__name__,
+        class_name=cls.__name__,
+        module=cls.__module__,
+        category=category,
+        description=doc.splitlines()[0] if doc else "",
+        plugin=plugin,
+        equations=list(getattr(cls, "equations", []) or []),
+        ports=_ports(cls),
+        parameters=_parameters(params_cls),
+        params_class=params_cls.__name__ if params_cls else None,
+    )
+
+
+def describe_operation(name: str, registry=None) -> OperationSchema:
+    """Schema for a registered operation, by name.
+
+    Args:
+        name: the registered name.
+        registry: the registry to look in; defaults to the global one
+            with plugins loaded.
+
+    Raises:
+        KeyError: if nothing is registered under that name.
+    """
+    registry = registry or _default_registry()
+    info = registry.list_operations().get(name)
+    if info is None:
+        raise KeyError(
+            f"no operation registered as {name!r}; "
+            f"{len(registry.list_operations())} are available"
+        )
+    return describe_class(
+        info.cls, name=info.name, category=info.category,
+        description=info.description, plugin=info.plugin,
+    )
+
+
+def catalog(category: str | None = None, registry=None) -> dict[str, OperationSchema]:
+    """Schemas for every registered operation.
+
+    Args:
+        category: restrict to one category.
+        registry: the registry to read; defaults to the global one.
+
+    Returns:
+        ``{name: OperationSchema}``, sorted by name.
+    """
+    registry = registry or _default_registry()
+    out = {}
+    for name, info in sorted(registry.list_operations().items()):
+        if category is not None and info.category != category:
+            continue
+        out[name] = describe_class(
+            info.cls, name=info.name, category=info.category,
+            description=info.description, plugin=info.plugin,
+        )
+    return out
+
+
+def _default_registry():
+    from difflow.plugins import load_plugins, registry
+
+    load_plugins()
+    return registry
+
+
+# ---------------------------------------------------------------------
+# Core registration
+# ---------------------------------------------------------------------
+
+
+def core_operations() -> dict[str, type]:
+    """The core unit operation classes, by the name to register them as.
+
+    Discovered from ``difflow.units`` rather than listed by hand, so a
+    new unit joins the catalog as soon as it is exported.
+    """
+    import difflow
+
+    found: dict[str, type] = {}
+    for attr in getattr(difflow, "__all__", []):
+        obj = getattr(difflow, attr, None)
+        if not inspect.isclass(obj):
+            continue
+        if not obj.__module__.startswith("difflow.units"):
+            continue
+        if attr.endswith("Params") or attr in NOT_OPERATIONS:
+            continue
+        found[CORE_NAME_OVERRIDES.get(attr, attr)] = obj
+    return found
+
+
+def register_core_operations(registry=None) -> int:
+    """Register the core unit operations.
+
+    The registry was previously populated only by plugins, so the
+    catalog held bio, carbon-capture, gas and REE units but none of the
+    reactors, separators, columns or exchangers that most flowsheets are
+    built from. This closes that gap.
+
+    Args:
+        registry: registry to populate; defaults to the global one.
+
+    Returns:
+        How many operations were registered.
+    """
+    if registry is None:
+        from difflow.plugins import registry as registry  # noqa: PLW0127
+
+    count = 0
+    for name, cls in core_operations().items():
+        module = cls.__module__.rsplit(".", 1)[-1]
+        doc = (cls.__doc__ or "").strip()
+        registry.register(
+            name, cls,
+            category=CORE_CATEGORIES.get(module, "general"),
+            description=doc.splitlines()[0] if doc else "",
+            plugin="core",
+        )
+        count += 1
+    return count

--- a/src/difflow/units/eos_units.py
+++ b/src/difflow/units/eos_units.py
@@ -176,6 +176,22 @@ class Turboexpander:
     (common in cryogenic service) is handled correctly.
     """
 
+    symbol = "EXP"
+    equations = [
+        r"S(T_{\mathrm{isen}}, P_{\mathrm{out}}) = S(T_{\mathrm{in}}, P_{\mathrm{in}})",
+        r"H_{\mathrm{out}} = H_{\mathrm{in}} + \eta\,(H_{\mathrm{isen}} - H_{\mathrm{in}})",
+        r"\dot{W} = \dot{n}\,(H_{\mathrm{in}} - H_{\mathrm{out}})",
+    ]
+    assumptions = [
+        "Adiabatic, steady state; kinetic and potential energy neglected.",
+        "Isentropic efficiency applied to the enthalpy drop.",
+        "Real-fluid properties from the supplied cubic EOS.",
+    ]
+    references = [
+        "Smith, Van Ness, Abbott. Introduction to Chemical Engineering Thermodynamics, 7e, Ch. 6-7.",
+        "Moran, Shapiro, Boettner, Bailey. Fundamentals of Engineering Thermodynamics, 8e, Ch. 6-9.",
+    ]
+
     def __init__(self, params: TurboexpanderParams, thermo: CubicThermo):
         self.params = params
         self.thermo = thermo
@@ -229,6 +245,22 @@ class Compressor:
     shaft work is ``W = H_out - H_in`` (positive, in W).
     """
 
+    symbol = "COMP"
+    equations = [
+        r"S(T_{\mathrm{isen}}, P_{\mathrm{out}}) = S(T_{\mathrm{in}}, P_{\mathrm{in}})",
+        r"H_{\mathrm{out}} = H_{\mathrm{in}} + \frac{H_{\mathrm{isen}} - H_{\mathrm{in}}}{\eta}",
+        r"\dot{W} = \dot{n}\,(H_{\mathrm{out}} - H_{\mathrm{in}})",
+    ]
+    assumptions = [
+        "Adiabatic, steady state; kinetic and potential energy neglected.",
+        "Isentropic efficiency inflates the reversible enthalpy rise.",
+        "Real-fluid properties from the supplied cubic EOS.",
+    ]
+    references = [
+        "Smith, Van Ness, Abbott. Introduction to Chemical Engineering Thermodynamics, 7e, Ch. 6-7.",
+        "Moran, Shapiro, Boettner, Bailey. Fundamentals of Engineering Thermodynamics, 8e, Ch. 6-9.",
+    ]
+
     def __init__(self, params: CompressorParams, thermo: CubicThermo):
         self.params = params
         self.thermo = thermo
@@ -277,6 +309,20 @@ class JTValve:
     ideal-K model misses entirely.
     """
 
+    symbol = "JT"
+    equations = [
+        r"H(T_{\mathrm{out}}, P_{\mathrm{out}}) = H(T_{\mathrm{in}}, P_{\mathrm{in}}) \qquad \text{(isenthalpic)}",
+        r"\mu_{\mathrm{JT}} = \left(\frac{\partial T}{\partial P}\right)_H",
+    ]
+    assumptions = [
+        "Adiabatic throttling with no shaft work.",
+        "Kinetic and potential energy changes neglected.",
+        "Real-fluid enthalpy from the supplied cubic EOS, so the Joule-Thomson temperature change is captured.",
+    ]
+    references = [
+        "Smith, Van Ness, Abbott. Introduction to Chemical Engineering Thermodynamics, 7e, Ch. 6-7.",
+    ]
+
     def __init__(self, params: JTValveParams, thermo: CubicThermo):
         self.params = params
         self.thermo = thermo
@@ -324,6 +370,20 @@ class ComponentSeparator:
 
     Returns ``(residue, product, info)``.
     """
+
+    symbol = "CSEP"
+    equations = [
+        r"F_i^{\mathrm{prod}} = r_i\, F_i^{\mathrm{in}}",
+        r"F_i^{\mathrm{res}} = (1 - r_i)\, F_i^{\mathrm{in}}",
+    ]
+    assumptions = [
+        "Specified per-component recovery; no equilibrium is solved.",
+        "A black-box surrogate for a separation train, not a physical model.",
+        "Outlet temperature and pressure inherited from the inlet.",
+    ]
+    references = [
+        "Seader, Henley, Roper. Separation Process Principles, 3e, Ch. 8 (liquid-liquid extraction).",
+    ]
 
     def __init__(self, params: ComponentSeparatorParams, thermo: CubicThermo):
         self.params = params

--- a/src/difflow/units/gas_turbine.py
+++ b/src/difflow/units/gas_turbine.py
@@ -118,6 +118,20 @@ class GasCompressor:
     The required shaft work is ``W = H_out - H_in`` (positive, in W).
     """
 
+    symbol = "GCOMP"
+    equations = [
+        r"S(T_{\mathrm{isen}}, r_p P_{\mathrm{in}}) = S(T_{\mathrm{in}}, P_{\mathrm{in}})",
+        r"H_{\mathrm{out}} = H_{\mathrm{in}} + \frac{H_{\mathrm{isen}} - H_{\mathrm{in}}}{\eta}",
+    ]
+    assumptions = [
+        "Adiabatic, steady state; ideal-gas properties.",
+        "Isentropic efficiency inflates the reversible enthalpy rise.",
+        "Fixed pressure ratio.",
+    ]
+    references = [
+        "Moran, Shapiro, Boettner, Bailey. Fundamentals of Engineering Thermodynamics, 8e, Ch. 6-9.",
+    ]
+
     def __init__(self, params: GasCompressorParams, thermo: IdealGasThermo):
         self.params = params
         self.thermo = thermo
@@ -168,6 +182,19 @@ class GasTurbine:
 
     The extracted shaft work is ``W = H_in - H_out`` (positive, in W).
     """
+
+    symbol = "GT"
+    equations = [
+        r"S(T_{\mathrm{isen}}, P_{\mathrm{out}}) = S(T_{\mathrm{in}}, P_{\mathrm{in}})",
+        r"H_{\mathrm{out}} = H_{\mathrm{in}} - \eta\,(H_{\mathrm{in}} - H_{\mathrm{isen}})",
+    ]
+    assumptions = [
+        "Adiabatic, steady state; ideal-gas properties.",
+        "Isentropic efficiency applied to the enthalpy drop.",
+    ]
+    references = [
+        "Moran, Shapiro, Boettner, Bailey. Fundamentals of Engineering Thermodynamics, 8e, Ch. 6-9.",
+    ]
 
     def __init__(self, params: GasTurbineParams, thermo: IdealGasThermo):
         self.params = params
@@ -257,6 +284,21 @@ class Combustor:
     Returns ``(product_stream, info)`` where ``info`` carries ``T_out``, the
     ``air_scale`` applied, the ``o2_demand`` and the heat released ``Q``.
     """
+
+    symbol = "CMB"
+    equations = [
+        r"\mathrm{C}_x\mathrm{H}_y + \left(x + \tfrac{y}{4}\right)\mathrm{O}_2 \rightarrow x\,\mathrm{CO}_2 + \tfrac{y}{2}\,\mathrm{H}_2\mathrm{O}",
+        r"\sum_i F_i^{\mathrm{in}} H_i(T_{\mathrm{in}}) = \sum_i F_i^{\mathrm{out}} H_i(T_{\mathrm{out}}) \qquad \text{(adiabatic)}",
+    ]
+    assumptions = [
+        "Complete combustion to CO2 and H2O; no dissociation or NOx.",
+        "Ideal-gas enthalpies referenced to 298.15 K.",
+        "Adiabatic, or a specified outlet temperature.",
+    ]
+    references = [
+        "Turns, S.R. An Introduction to Combustion, 3e, Ch. 2 and 7.",
+        "Moran, Shapiro, Boettner, Bailey. Fundamentals of Engineering Thermodynamics, 8e, Ch. 6-9.",
+    ]
 
     def __init__(self, params: CombustorParams, thermo: IdealGasThermo):
         self.params = params

--- a/src/difflow/units/lle.py
+++ b/src/difflow/units/lle.py
@@ -264,6 +264,21 @@ class LLEEquilibrium:
         nrtl_params: NRTL parameters (optional)
         uniquac_params: UNIQUAC parameters (optional)
     """
+
+    symbol = "LLE"
+    equations = [
+        r"K_i = \frac{y_i^{\mathrm{org}}}{x_i^{\mathrm{aq}}} \qquad \text{(distribution coefficient)}",
+        r"F z_i = E\, y_i^{\mathrm{org}} + R\, x_i^{\mathrm{aq}} \qquad \text{(component balance)}",
+        r"\gamma_i^{\mathrm{aq}} x_i^{\mathrm{aq}} = \gamma_i^{\mathrm{org}} y_i^{\mathrm{org}} \qquad \text{(isoactivity, NRTL/UNIQUAC)}",
+    ]
+    assumptions = [
+        "Two liquid phases at equilibrium, completely separated.",
+        "Either constant distribution coefficients or an activity-coefficient model.",
+        "Isothermal; no phase change other than partitioning.",
+    ]
+    references = [
+        "Seader, Henley, Roper. Separation Process Principles, 3e, Ch. 8 (liquid-liquid extraction).",
+    ]
     solutes: list[str]
     aqueous_carrier: str
     organic_carrier: str

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1,0 +1,222 @@
+"""Tests for difflow.catalog.
+
+The catalog is derived from the code by introspection rather than from
+a hand-maintained table, so these tests mostly check that the
+derivation agrees with what the units actually do --- particularly the
+port arity, where the trap is counting the info dict every unit returns
+as though it were an outlet stream.
+"""
+
+import inspect
+import json
+
+import jax
+import pytest
+
+jax.config.update("jax_enable_x64", True)
+
+import difflow
+from difflow.catalog import (
+    CORE_NAME_OVERRIDES,
+    OperationSchema,
+    catalog,
+    core_operations,
+    describe_class,
+    describe_operation,
+    register_core_operations,
+)
+from difflow.plugins import OperationRegistry
+
+
+@pytest.fixture(scope="module")
+def cat():
+    return catalog()
+
+
+# =============================================================================
+# Core registration
+# =============================================================================
+
+
+class TestCoreRegistration:
+    def test_core_units_are_in_the_catalog(self, cat):
+        """The registry previously held only plugin units."""
+        for name in ["CSTR", "PFR", "Flash", "Mixer", "Splitter", "Heater",
+                     "Cooler", "ShortcutColumn", "CounterCurrentHX"]:
+            assert name in cat, f"{name} missing from the catalog"
+            assert cat[name].plugin == "core"
+
+    def test_registration_happens_on_import(self):
+        """`import difflow` is enough; no explicit call required."""
+        assert "CSTR" in catalog()
+
+    def test_plugin_units_are_still_there(self, cat):
+        plugins = {s.plugin for s in cat.values()}
+        assert {"core", "difflow_gas", "difflow_bio",
+                "difflow_cc", "difflow_ree"} <= plugins
+
+    def test_core_operations_are_discovered_not_listed(self):
+        """Discovery reads __all__, so a new unit joins automatically."""
+        found = core_operations()
+        assert len(found) > 25
+        for cls in found.values():
+            assert cls.__module__.startswith("difflow.units")
+
+    def test_base_classes_are_excluded(self):
+        found = core_operations()
+        assert "UnitBase" not in found
+        assert "ReactorBase" not in found
+
+    def test_the_compressor_name_clash_is_resolved(self, cat):
+        """difflow_gas registers its own Compressor; neither may be lost.
+
+        Plugins load after the core, so registering both under the bare
+        name would silently overwrite the EOS one.
+        """
+        assert CORE_NAME_OVERRIDES["Compressor"] == "EOSCompressor"
+        assert cat["EOSCompressor"].plugin == "core"
+        assert cat["EOSCompressor"].module.endswith("eos_units")
+        assert cat["Compressor"].plugin == "difflow_gas"
+
+    def test_registering_into_a_fresh_registry(self):
+        registry = OperationRegistry()
+        count = register_core_operations(registry)
+        assert count == len(registry.list_operations()) == len(core_operations())
+
+
+# =============================================================================
+# Ports
+# =============================================================================
+
+
+class TestPorts:
+    @pytest.mark.parametrize("name,inlets,n_outlets", [
+        ("CSTR", ["inlet"], 1),
+        ("PFR", ["inlet"], 1),
+        ("Flash", ["inlet"], 2),
+        ("EOSFlash", ["inlet"], 2),
+        ("Heater", ["inlet"], 1),
+        ("ShortcutColumn", ["feed"], 2),
+        ("CounterCurrentHX", ["hot_inlet", "cold_inlet"], 2),
+        ("MultistageCascade", ["feed", "solvent"], 2),
+    ])
+    def test_arity_matches_the_unit(self, cat, name, inlets, n_outlets):
+        ports = cat[name].ports
+        assert ports.inlets == inlets
+        assert ports.n_outlets == n_outlets
+
+    def test_the_info_dict_is_not_counted_as_an_outlet(self, cat):
+        """Every unit returns (outlets..., info); info is `dict[str, Array]`.
+
+        Stream is `dict[str, Array | float]`, so a loose match on the
+        return annotation counts the info payload as a third stream.
+        """
+        assert cat["Flash"].ports.n_outlets == 2       # not 3
+        assert cat["CSTR"].ports.n_outlets == 1        # not 2
+
+    def test_a_mixer_is_variadic(self, cat):
+        ports = cat["Mixer"].ports
+        assert ports.variadic
+        assert ports.n_inlets is None
+        assert ports.n_outlets == 1
+
+    def test_a_fixed_arity_unit_reports_its_inlet_count(self, cat):
+        assert cat["CounterCurrentHX"].ports.n_inlets == 2
+        assert not cat["CounterCurrentHX"].ports.variadic
+
+    def test_string_annotations_are_understood(self, cat):
+        """Modules using `from __future__ import annotations` keep strings."""
+        sig = inspect.signature(difflow.Compressor.__call__)
+        assert isinstance(sig.return_annotation, str), "premise: a string annotation"
+        assert cat["EOSCompressor"].ports.inlets == ["inlet"]
+        assert cat["EOSCompressor"].ports.n_outlets == 1
+
+    def test_unknown_arity_is_reported_not_guessed(self, cat):
+        """Splitter returns a bare `tuple`, so its outlet count is unknown."""
+        assert cat["Splitter"].ports.n_outlets is None
+
+
+# =============================================================================
+# Parameters
+# =============================================================================
+
+
+class TestParameters:
+    def test_required_and_optional_are_distinguished(self, cat):
+        spec = cat["CSTR"]
+        assert "V" in spec.required_parameters()
+        assert "T_damping" not in spec.required_parameters()
+
+    def test_defaults_are_captured(self, cat):
+        by_name = {p.name: p for p in cat["CSTR"].parameters}
+        assert by_name["T_damping"].default == "0.3"
+        assert by_name["V"].default is None
+
+    def test_callable_fields_are_flagged(self, cat):
+        """The fields a form cannot fill in."""
+        assert set(cat["CSTR"].callable_parameters) == {
+            "rate_fn", "eos", "H_mix_fn", "K_eq_fn"
+        }
+        assert not cat["CSTR"].is_declarative
+
+    def test_most_operations_are_declarative(self, cat):
+        non_declarative = [n for n, s in cat.items() if not s.is_declarative]
+        assert len(non_declarative) < 10, non_declarative
+        # every one of them is a reactor, and it is always the rate law
+        for name in non_declarative:
+            assert any(
+                "fn" in p for p in cat[name].callable_parameters
+            ), f"{name}: {cat[name].callable_parameters}"
+
+    def test_params_class_is_found(self, cat):
+        assert cat["CSTR"].params_class == "CSTRParams"
+        assert cat["Flash"].params_class == "FlashParams"
+
+    def test_a_unit_without_params_has_none(self, cat):
+        assert cat["Mixer"].parameters == []
+
+
+# =============================================================================
+# Schema
+# =============================================================================
+
+
+class TestSchema:
+    def test_is_json_serializable(self, cat):
+        payload = json.dumps({n: s.to_dict() for n, s in cat.items()})
+        assert len(payload) > 1000
+        assert json.loads(payload)["Flash"]["ports"]["n_outlets"] == 2
+
+    def test_equations_are_carried_through(self, cat):
+        assert cat["CSTR"].equations, "CSTR declares equations"
+        assert any("\\" in e for e in cat["CSTR"].equations), "LaTeX expected"
+
+    def test_describe_class_works_on_an_unregistered_class(self):
+        """Usable on a plugin's units before they are wired in."""
+        spec = describe_class(difflow.Flash, category="separations")
+        assert isinstance(spec, OperationSchema)
+        assert spec.name == "Flash"
+        assert spec.ports.n_outlets == 2
+
+    def test_describe_operation_rejects_an_unknown_name(self):
+        with pytest.raises(KeyError, match="no operation registered"):
+            describe_operation("NotAUnit")
+
+    def test_catalog_filters_by_category(self, cat):
+        reactors = catalog(category="reactors")
+        assert "CSTR" in reactors and "PFR" in reactors
+        assert "Flash" not in reactors
+        assert all(s.category == "reactors" for s in reactors.values())
+
+    def test_categories_are_assigned_to_core_units(self, cat):
+        assert cat["CSTR"].category == "reactors"
+        assert cat["CounterCurrentHX"].category == "heat_transfer"
+        assert cat["ShortcutColumn"].category == "distillation"
+
+    def test_description_is_a_single_line(self, cat):
+        for name, spec in cat.items():
+            assert "\n" not in spec.description, name
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Groundwork for #174. Independent of #177 — either can merge first.

## The registry had no core units in it

The operation registry held 46 units and **not one was a core unit**. Every entry came from a plugin (bio, carbon capture, gas, REE), so a palette or catalog built on the registry was missing exactly the reactors, separators, columns and exchangers most flowsheets are made of. The core units now register on import: **46 → 75**.

## Registration alone isn't enough to build against

The registry knows a name, a class, a category and a description. A form also needs to know which parameters exist and which are required; a canvas needs stream arity *before* anything is instantiated. `difflow.catalog` derives both:

```python
from difflow import catalog, describe_operation

spec = describe_operation("Flash")
spec.ports.inlets           # ['inlet']
spec.ports.n_outlets        # 2
spec.required_parameters()  # ['T']
spec.to_dict()              # JSON-serializable
```

- **parameters** from `dataclasses.fields` of the `Params` class — including which are required and which hold a callable, i.e. the fields a declarative front end can't fill in
- **ports** from the `__call__` signature: inlets are the `Stream`-annotated arguments, outlets the `Stream` entries of the return tuple
- **equations** from the class attribute the units already carry

It is **derived, not declared**, so it can't drift from the code — and an unannotated signature is reported as *unknown* rather than guessed: `Splitter` returns a bare `tuple`, so its `n_outlets` is `None` instead of a plausible-looking 2.

## Two subtleties in the derivation

Both were bugs I hit and fixed, and both have tests:

- `Stream` is `dict[str, Array | float]`; the **info payload** every unit returns alongside its outlets is `dict[str, Array]`. A loose match counts that payload as an extra outlet — my first version had Flash at 1-in/**3**-out. The check is now an exact comparison.
- Modules using `from __future__ import annotations` keep annotations as *strings*, so `typing.get_args` returns nothing. `"tuple[Stream, dict]"` is parsed as well as the evaluated form.

## One naming decision

`difflow_gas` registers its own `Compressor`, and plugins load **after** the core, so registering both under the bare name would have silently dropped the EOS one. `difflow.Compressor` is catalogued as **`EOSCompressor`** — consistent with the existing `EOSFlash`.

## A contract this surfaced

Registering the core units brought them under `tests/test_report.py::test_metadata_contract_for_registered_units`, which requires `equations` and `references` on every **registered** unit. Until now only plugins had to meet it. Eight core units did not:

`LLEEquilibrium`, `Turboexpander`, `Compressor`, `JTValve`, `ComponentSeparator`, `Combustor`, `GasCompressor`, `GasTurbine`

They now carry equations, assumptions and references. I took the physics from each unit's own docstring, which already described it precisely — e.g. the JT valve's `H(T_out, P_out) = H(T_in, P_in)`, and the opposite efficiency conventions on the compressor (`+ (H_isen − H_in)/η`) and the expander (`+ η(H_isen − H_in)`). Worth a look from someone who knows these units, since I wrote the LaTeX from prose.

## Where this leaves #174

`is_declarative` now answers, mechanically, which operations a form could drive:

```python
[n for n, s in catalog().items() if not s.is_declarative]
# 7 of 75 — all reactors, all the rate law
```

## Verification

`1372 passed, 2 skipped` — 33 new tests, including a parametrised check that port arity matches each unit, explicit regression tests for both derivation subtleties above, and JSON round-tripping of the whole catalog.

**Note:** the branch is named `claude/flowsheet-serialization` — I started on the JSON round-trip, then found that `from_json` needs a name→class registry to deserialize, so this prerequisite had to come first. The serialization work follows on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0115wVXe4gdrijT1yvb6YjcM

---
_Generated by [Claude Code](https://claude.ai/code/session_0115wVXe4gdrijT1yvb6YjcM)_