### PR TITLE
feat: a local editor and a no-install published page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,8 @@ difflow/
 │   ├── serialize.py   # Flowsheet <-> JSON round trip
 │   ├── codegen.py     # Flowsheet -> runnable Python source
 │   ├── kinetics.py    # Declarative mass-action rate laws (data, not callables)
+│   ├── publish.py     # Flowsheet -> self-contained interactive HTML (no install)
+│   ├── gui.py         # Local browser editor (python -m difflow.gui)
 │   ├── reconciliation/ # Data reconciliation, gross error detection, observability
 │   │   ├── params_mixin.py # ParamsMixin base class for Params dataclasses
 │   │   ├── units/         # Steady-state unit operations

--- a/docs/streams-and-flowsheets.md
+++ b/docs/streams-and-flowsheets.md
@@ -577,6 +577,84 @@ One name is deliberately not the class name: `difflow_gas` registers a `Compress
 
 ---
 
+## The Local Editor
+
+`difflow.gui` serves a single-page flowsheet editor on `localhost`, with the installed package doing the solving:
+
+```bash
+python -m difflow.gui plant.json          # opens a browser
+python -m difflow.gui --port 9000 --no-browser
+```
+
+or from Python, on a flowsheet you already have:
+
+```python
+from difflow import gui
+
+gui.serve(fs, path="plant.json")
+```
+
+The page shows a palette of every registered operation with its port arity, a diagram of the topology, editable parameter fields per unit, and a panel that switches between solved stream values and the generated Python. **Solve** re-solves the edited model; **Save** writes the JSON; **Python** shows what `codegen.to_python` would produce.
+
+Everything on the page is derived from `catalog()`, so plugin units appear with no extra work, and a field the catalog reports as holding code is listed as *set in code* rather than given a text box that could only reject what you type.
+
+The point is not to replace writing Python. It is to make the tedious parts quick — seeing the topology, changing one parameter and re-solving, checking what a unit expects — while leaving the door open in both directions: export a script, edit it, and read the result back through `serialize`. An editor you can only enter is worse than none.
+
+It is stdlib only (`http.server`), binds to `127.0.0.1`, and is meant for a single local user. It is a development tool, not a hardened service — do not expose it to a network.
+
+### For tests and embedding
+
+`make_server` builds the server without starting it, which is what a test wants:
+
+```python
+from difflow.gui import FlowsheetSession, make_server
+
+server = make_server(FlowsheetSession(fs), port=0)   # 0 => any free port
+```
+
+The routes are `GET /api/catalog`, `GET /api/flowsheet`, `GET /api/code`, and `POST /api/flowsheet`, `/api/solve`, `/api/save`. A failed solve or a rejected edit comes back as `{"ok": false, "error": ...}` rather than a traceback at the socket, so a bad edit from the browser cannot take the server down.
+
+One wrinkle worth knowing: JSON has no literal for the non-finite floats, and `JSON.parse` rejects the `Infinity` that Python's `json` writes. This is the *common* case, not an exotic one — `mass_action_kinetics` puts `inf` in `K_eq` for every irreversible reaction — so those values travel as the strings `"Infinity"`, `"-Infinity"` and `"NaN"`, and are restored on the way back.
+
+---
+
+## Publishing a Model
+
+`difflow.publish` turns a flowsheet into a **self-contained HTML page** that anyone can open with nothing installed — no Python, no server, no network. It is the form a model needs for a paper's supplementary material or a project page.
+
+```python
+from difflow import publish, SweepAxis
+
+publish(
+    fs,
+    axes=[
+        SweepAxis("reactor.V", 0.5, 5.0, n=21, label="Reactor volume", units="m³"),
+        SweepAxis("heater.T_out", 320.0, 400.0, n=9, label="Inlet temperature", units="K"),
+    ],
+    outputs={"conversion": lambda streams: 1 - streams["out"]["F_A"] / 1.0},
+    path="model.html",
+    title="Reactor sizing",
+)
+```
+
+Axis keys use the same `"<unit>.<param>"` dot notation as `make_objective_fn`, so they name a **unit** parameter — feed conditions are not addressable this way. To vary a feed, put a `Heater` or a `Mixer` in front of it and sweep that.
+
+The page carries sliders for each axis, the outputs, and their sensitivities. This works because the solve is *pre-computed*: `sweep` evaluates the flowsheet on the grid with `jax.vmap`, takes gradients with `jax.grad`, and bakes the results into the page, which interpolates between them in a few lines of JavaScript.
+
+That is a deliberate trade, and its limits should be stated plainly. JAX has no WebAssembly build, so a browser cannot run the real solver; the published page is an interpolation of a grid, not a live model. It is exact at the grid points and only as good as the grid between them, and it can only vary what the axes name. When you need the real thing, use the local editor above, or the generated script.
+
+`sweep` is available on its own when you want the grid as data rather than as a page:
+
+```python
+from difflow import sweep
+
+result = sweep(fs, axes, outputs)
+result.values["conversion"]      # shape (21, 9)
+result.gradients["conversion"]   # d(conversion)/d(axis), same shape per axis
+```
+
+---
+
 ## Best Practices
 
 ### Stream Naming Conventions

--- a/src/difflow/__init__.py
+++ b/src/difflow/__init__.py
@@ -237,8 +237,9 @@ from difflow.kinetics import (
     mass_action_kinetics,
 )
 
-# Flowsheet serialization and code generation
-from difflow import codegen, serialize
+# Flowsheet serialization, code generation and publishing
+from difflow import codegen, gui, publish as publish_module, serialize
+from difflow.publish import SweepAxis, SweepResult, publish, sweep
 
 # Operation catalog
 from difflow.catalog import (
@@ -499,9 +500,14 @@ __all__ = [
     "mass_action_kinetics",
     "ReactionSet",
     "KineticsSpecError",
-    # Flowsheet serialization and code generation
+    # Flowsheet serialization, code generation and publishing
     "serialize",
     "codegen",
+    "publish",
+    "sweep",
+    "SweepAxis",
+    "SweepResult",
+    "gui",
     # Operation catalog
     "catalog",
     "describe_operation",

--- a/src/difflow/gui.py
+++ b/src/difflow/gui.py
@@ -1,0 +1,598 @@
+"""A local editor for flowsheets, served to the browser.
+
+Researchers already have difflow installed, so the browser does not need
+to run the solver --- it only needs to reach one. This serves a small
+HTTP API and a single-page editor on ``localhost``, with the real
+package doing the work:
+
+    python -m difflow.gui plant.json
+
+The point is not to replace writing Python. It is to make the parts
+that are tedious in Python --- seeing the topology, adjusting a
+parameter and re-solving, checking what a unit expects --- quick, while
+leaving the door open: the editor exports the model as a script
+(:mod:`difflow.codegen`) or as JSON (:mod:`difflow.serialize`), and
+reads JSON back. An editor you can only enter is worse than none.
+
+Everything comes from :mod:`difflow.catalog`, so the palette lists
+whatever is registered, plugins included, with the ports and parameter
+schema each unit actually declares.
+
+Deliberately stdlib only: a development tool that made difflow depend
+on a web framework would be a poor trade. It binds to 127.0.0.1 and is
+meant for a single local user --- it is not hardened for exposure to a
+network.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import webbrowser
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+
+DEFAULT_PORT = 8756
+#: only ever bound on the loopback interface
+HOST = "127.0.0.1"
+
+#: JSON has no literal for the non-finite floats. Python's ``json``
+#: writes them as ``Infinity`` / ``NaN``, which the browser's
+#: ``JSON.parse`` rejects outright --- and this is the *common* case,
+#: not an exotic one: :func:`~difflow.kinetics.mass_action_kinetics`
+#: puts ``inf`` in ``K_eq`` for every irreversible reaction. So they go
+#: over the wire as strings and are restored on the way back.
+NON_FINITE = {"Infinity": float("inf"), "-Infinity": float("-inf"),
+              "NaN": float("nan")}
+
+
+def _json_safe(value: Any) -> Any:
+    """Rewrite non-finite floats as the strings in :data:`NON_FINITE`."""
+    if isinstance(value, float):
+        if value != value:
+            return "NaN"
+        if value == float("inf"):
+            return "Infinity"
+        if value == float("-inf"):
+            return "-Infinity"
+        return value
+    if isinstance(value, dict):
+        return {k: _json_safe(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_json_safe(v) for v in value]
+    return value
+
+
+def _json_restore(value: Any) -> Any:
+    """Undo :func:`_json_safe`.
+
+    A string parameter whose value is literally ``"NaN"`` would be
+    turned into a float here. No unit declares one, and the alternative
+    --- an out-of-band encoding threaded through the whole document ---
+    costs more than the case is worth.
+    """
+    if isinstance(value, str):
+        return NON_FINITE.get(value, value)
+    if isinstance(value, dict):
+        return {k: _json_restore(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_json_restore(v) for v in value]
+    return value
+
+
+class FlowsheetSession:
+    """The flowsheet the editor is working on, plus what it can do to it.
+
+    Holds the mutable state so the request handler stays a thin shell
+    over :mod:`difflow.serialize`, :mod:`difflow.codegen` and
+    :mod:`difflow.catalog`.
+    """
+
+    def __init__(self, flowsheet=None, path: str | Path | None = None):
+        self.path = Path(path) if path else None
+        self.flowsheet = flowsheet
+        if flowsheet is None and self.path and self.path.exists():
+            from difflow import serialize
+
+            self.flowsheet = serialize.load(self.path)
+        self._lock = threading.Lock()
+
+    # -- reads --------------------------------------------------------
+
+    def catalog(self) -> dict:
+        from difflow.catalog import catalog
+
+        return {
+            name: spec.to_dict() for name, spec in catalog().items()
+        }
+
+    def document(self) -> dict:
+        from difflow import serialize
+
+        if self.flowsheet is None:
+            return {"flowsheet": None, "path": str(self.path or "")}
+        return {
+            "flowsheet": serialize.to_dict(self.flowsheet),
+            "path": str(self.path or ""),
+        }
+
+    def code(self) -> dict:
+        from difflow import codegen
+
+        if self.flowsheet is None:
+            return {"source": "", "error": "no flowsheet loaded"}
+        try:
+            return {"source": codegen.to_python(self.flowsheet), "error": None}
+        except Exception as exc:                     # surfaced, not swallowed
+            return {"source": "", "error": str(exc)}
+
+    # -- writes -------------------------------------------------------
+
+    def replace(self, document: dict) -> dict:
+        """Adopt a flowsheet sent from the browser."""
+        from difflow import serialize
+
+        with self._lock:
+            self.flowsheet = serialize.from_dict(document)
+        return {"ok": True}
+
+    def save(self) -> dict:
+        from difflow import serialize
+
+        if self.flowsheet is None:
+            return {"ok": False, "error": "no flowsheet loaded"}
+        if self.path is None:
+            return {"ok": False, "error": "no path was given on startup"}
+        serialize.save(self.flowsheet, self.path)
+        return {"ok": True, "path": str(self.path)}
+
+    def solve(self) -> dict:
+        """Solve, and report a failure rather than raising at the socket."""
+        if self.flowsheet is None:
+            return {"ok": False, "error": "no flowsheet loaded"}
+        try:
+            with self._lock:
+                streams = self.flowsheet.solve()
+        except Exception as exc:
+            return {"ok": False, "error": f"{type(exc).__name__}: {exc}"}
+        return {
+            "ok": True,
+            "streams": {
+                name: {
+                    k: (v if isinstance(v, str) else float(v))
+                    for k, v in stream.items()
+                }
+                for name, stream in streams.items()
+            },
+            "converged": getattr(self.flowsheet, "last_solve_converged", None),
+            "iterations": getattr(self.flowsheet, "last_solve_iterations", None),
+        }
+
+
+class _Handler(BaseHTTPRequestHandler):
+    """Routes. The session does the work."""
+
+    session: FlowsheetSession = None            # set by :func:`serve`
+    server_version = "difflow-gui"
+
+    def log_message(self, *args):                # quiet by default
+        pass
+
+    def _send(self, payload: Any, status: int = 200, content="application/json"):
+        if isinstance(payload, bytes):
+            body = payload
+        elif isinstance(payload, str):
+            body = payload.encode("utf-8")
+        else:
+            # allow_nan=False so a leak past _json_safe fails loudly here
+            # rather than as a parse error in the browser
+            body = json.dumps(_json_safe(payload), allow_nan=False).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", f"{content}; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):
+        routes = {
+            "/": lambda: self._send(_PAGE, content="text/html"),
+            # answered so the browser does not log a 404 on every load
+            "/favicon.ico": lambda: self._send(b"", content="image/x-icon"),
+            "/api/catalog": lambda: self._send(self.session.catalog()),
+            "/api/flowsheet": lambda: self._send(self.session.document()),
+            "/api/code": lambda: self._send(self.session.code()),
+        }
+        handler = routes.get(self.path)
+        if handler is None:
+            return self._send({"error": "not found"}, status=404)
+        handler()
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length") or 0)
+        raw = self.rfile.read(length) if length else b"{}"
+        try:
+            payload = _json_restore(json.loads(raw or b"{}"))
+        except json.JSONDecodeError as exc:
+            return self._send({"ok": False, "error": f"bad JSON: {exc}"}, 400)
+
+        try:
+            if self.path == "/api/flowsheet":
+                return self._send(self.session.replace(payload))
+            if self.path == "/api/solve":
+                return self._send(self.session.solve())
+            if self.path == "/api/save":
+                return self._send(self.session.save())
+        except Exception as exc:
+            # a bad edit from the browser must not take the server down
+            return self._send(
+                {"ok": False, "error": f"{type(exc).__name__}: {exc}"}, 400
+            )
+        self._send({"error": "not found"}, status=404)
+
+
+def make_server(session: FlowsheetSession, port: int = DEFAULT_PORT):
+    """Build the HTTP server without starting it.
+
+    Useful for tests, which want a port and a shutdown handle rather
+    than a blocking call.
+    """
+    handler = type("_BoundHandler", (_Handler,), {"session": session})
+    return ThreadingHTTPServer((HOST, port), handler)
+
+
+def serve(
+    flowsheet=None,
+    path: str | Path | None = None,
+    *,
+    port: int = DEFAULT_PORT,
+    open_browser: bool = True,
+) -> None:
+    """Run the editor until interrupted.
+
+    Args:
+        flowsheet: the flowsheet to edit. If omitted and ``path``
+            exists, it is loaded from there.
+        path: file the editor saves to.
+        port: TCP port on the loopback interface.
+        open_browser: open a browser window at startup.
+    """
+    session = FlowsheetSession(flowsheet, path)
+    server = make_server(session, port)
+    url = f"http://{HOST}:{port}/"
+    print(f"difflow editor on {url}   (ctrl-c to stop)")
+    if open_browser:
+        threading.Timer(0.4, lambda: webbrowser.open(url)).start()
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nstopping")
+    finally:
+        server.server_close()
+
+
+def main(argv: list[str] | None = None) -> int:
+    """``python -m difflow.gui [flowsheet.json] [--port N] [--no-browser]``."""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        prog="difflow.gui", description="Local flowsheet editor."
+    )
+    parser.add_argument("path", nargs="?", help="flowsheet JSON to open and save")
+    parser.add_argument("--port", type=int, default=DEFAULT_PORT)
+    parser.add_argument("--no-browser", action="store_true")
+    args = parser.parse_args(argv)
+
+    serve(path=args.path, port=args.port, open_browser=not args.no_browser)
+    return 0
+
+
+_PAGE = """<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>difflow editor</title>
+<style>
+  :root {
+    --surface:#fcfcfb; --panel:#f4f3f0; --ink:#0b0b0b; --ink-soft:#52514e;
+    --grid:#e4e2de; --line:#c9c7c2; --series:#2a78d6; --accent:#eb6834;
+    --bad:#d03b3b; --good:#0ca30c;
+  }
+  * { box-sizing:border-box; }
+  body { margin:0; background:var(--surface); color:var(--ink);
+    font:14px/1.5 ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,
+    Helvetica,Arial,sans-serif; }
+  header { display:flex; align-items:center; gap:.75rem; padding:.7rem 1rem;
+    border-bottom:1px solid var(--grid); background:var(--panel); }
+  header h1 { font-size:.95rem; margin:0; font-weight:650; letter-spacing:-.01em; }
+  header .path { color:var(--ink-soft); font-size:.8rem; }
+  header .spacer { flex:1; }
+  button { font:inherit; font-size:.83rem; padding:.35rem .7rem;
+    border:1px solid var(--line); border-radius:6px; background:var(--surface);
+    color:var(--ink); cursor:pointer; }
+  button:hover { border-color:var(--ink-soft); }
+  button.primary { background:var(--series); border-color:var(--series);
+    color:#fff; }
+  main { display:grid; grid-template-columns:14rem 1fr 21rem; gap:1px;
+    background:var(--grid); min-height:calc(100vh - 3.1rem); }
+  section { background:var(--surface); padding:.9rem 1rem; overflow:auto;
+    max-height:calc(100vh - 3.1rem); }
+  h2 { font-size:.7rem; text-transform:uppercase; letter-spacing:.07em;
+    color:var(--ink-soft); margin:0 0 .7rem; font-weight:650; }
+  .cat { margin-bottom:.9rem; }
+  .cat-name { font-size:.68rem; text-transform:uppercase; letter-spacing:.06em;
+    color:var(--ink-soft); margin:.5rem 0 .25rem; }
+  .op { display:flex; gap:.4rem; align-items:baseline; padding:.25rem .4rem;
+    border-radius:5px; cursor:default; font-size:.82rem; }
+  .op:hover { background:var(--panel); }
+  .op .nm { flex:1; overflow-wrap:anywhere; }
+  .op .ports { color:var(--ink-soft); font-size:.72rem;
+    font-variant-numeric:tabular-nums; white-space:nowrap; }
+  table { width:100%; border-collapse:collapse; }
+  th,td { text-align:left; padding:.3rem .35rem; border-bottom:1px solid var(--grid);
+    font-size:.82rem; }
+  th { color:var(--ink-soft); font-size:.68rem; text-transform:uppercase;
+    letter-spacing:.05em; font-weight:650; }
+  td.num { text-align:right; font-variant-numeric:tabular-nums; }
+  input[type=text] { width:100%; font:inherit; font-size:.8rem; padding:.2rem .35rem;
+    border:1px solid var(--line); border-radius:4px; background:var(--surface);
+    color:var(--ink); }
+  .unit { border:1px solid var(--grid); border-radius:8px; padding:.6rem .75rem;
+    margin-bottom:.6rem; background:var(--panel); }
+  .unit h3 { margin:0 0 .1rem; font-size:.88rem; }
+  .unit .meta { color:var(--ink-soft); font-size:.75rem; margin-bottom:.5rem; }
+  .unit td:first-child { width:14rem; }
+  .unit .units { color:var(--ink-soft); font-size:.72rem; }
+  .code-fields { margin:.5rem 0 0; }
+  .status { font-size:.8rem; padding:.4rem .6rem; border-radius:6px;
+    margin-bottom:.7rem; }
+  .status.err { background:#fbeeee; color:var(--bad);
+    border:1px solid #f3d4d4; }
+  .status.ok { background:#eef7ee; color:#166a16; border:1px solid #d3e8d3; }
+  pre { background:var(--panel); border:1px solid var(--grid); border-radius:8px;
+    padding:.7rem; overflow:auto; font-size:.75rem; line-height:1.45;
+    max-height:24rem; }
+  /* wide tables scroll in place, so the page never scrolls sideways */
+  .scroll { overflow-x:auto; }
+  svg text { font:11px ui-sans-serif,system-ui,sans-serif; }
+</style>
+</head>
+<body>
+<header>
+  <h1>difflow</h1>
+  <span class="path" id="path"></span>
+  <span class="spacer"></span>
+  <button id="solve" class="primary">Solve</button>
+  <button id="save">Save</button>
+  <button id="showcode">Python</button>
+</header>
+
+<main>
+  <section>
+    <h2>Palette</h2>
+    <div id="palette"></div>
+  </section>
+
+  <section>
+    <h2>Flowsheet</h2>
+    <div id="status"></div>
+    <svg id="diagram" viewBox="0 0 600 220" width="100%"
+         role="img" aria-label="Flowsheet topology"></svg>
+    <div id="units"></div>
+  </section>
+
+  <section>
+    <h2 id="rightTitle">Streams</h2>
+    <div id="right"></div>
+  </section>
+</main>
+
+<script>
+let DOC = null, CATALOG = {};
+
+const api = {
+  get: p => fetch(p).then(r => r.json()),
+  post: (p, b) => fetch(p, {method:"POST", headers:{"Content-Type":"application/json"},
+                           body: JSON.stringify(b || {})}).then(r => r.json()),
+};
+function fmt(v) {
+  if (typeof v !== "number" || !isFinite(v)) return String(v);
+  const m = Math.abs(v);
+  if (m !== 0 && (m < 1e-3 || m >= 1e5)) return v.toExponential(3);
+  return v.toFixed(m >= 100 ? 1 : 4);
+}
+function status(msg, kind) {
+  document.getElementById("status").innerHTML =
+    msg ? '<div class="status ' + kind + '">' + msg + '</div>' : "";
+}
+
+/* ---- palette ------------------------------------------------------ */
+function renderPalette() {
+  const groups = {};
+  Object.values(CATALOG).forEach(s => (groups[s.category] ||= []).push(s));
+  const el = document.getElementById("palette");
+  el.innerHTML = Object.keys(groups).sort().map(cat =>
+    '<div class="cat"><div class="cat-name">' + cat.replace(/_/g, " ") + '</div>' +
+    groups[cat].sort((a,b)=>a.name.localeCompare(b.name)).map(s => {
+      const p = s.ports;
+      const arity = (p.variadic ? "n" : p.n_inlets) + "&rarr;" +
+                    (p.n_outlets === null ? "?" : p.n_outlets);
+      return '<div class="op" title="' + (s.description || "").replace(/"/g,"") +
+             '"><span class="nm">' + s.name + '</span>' +
+             '<span class="ports">' + arity + '</span></div>';
+    }).join("") + '</div>'
+  ).join("");
+}
+
+/* ---- diagram ------------------------------------------------------ */
+function renderDiagram() {
+  const svg = document.getElementById("diagram");
+  if (!DOC || !DOC.flowsheet) { svg.innerHTML = ""; return; }
+  const fsheet = DOC.flowsheet;
+  const units = fsheet.units, feeds = Object.keys(fsheet.feeds);
+  const nodes = feeds.map(f => ({id:f, kind:"feed", label:f}))
+    .concat(units.map(u => ({id:u.name, kind:"unit", label:u.name, op:u.operation})));
+
+  /* A unit's inlets name *streams*, not nodes. Resolve each to whoever
+     produces it -- a feed of the same name, or the unit that lists it
+     as an outlet -- or the edge is silently dropped. */
+  const producer = {};
+  feeds.forEach(f => producer[f] = f);
+  units.forEach(u => u.outlets.forEach(o => producer[o] = u.name));
+  /* a recycle maps a source stream onto the destination stream name */
+  const recycles = fsheet.recycles || {};
+  Object.entries(recycles).forEach(([src, dest]) => {
+    if (producer[src] !== undefined) producer[dest] = producer[src];
+  });
+  const recycled = new Set(Object.values(recycles));
+
+  const W = 620, rowH = 96;
+  const cols = Math.max(1, Math.min(nodes.length, 4));
+  const rows = Math.ceil(nodes.length / cols);
+  const H = Math.max(130, rows * rowH + 30);
+  svg.setAttribute("viewBox", "0 0 " + W + " " + H);
+  const step = W / (cols + 1), pos = {};
+  nodes.forEach((n, i) => pos[n.id] =
+    [step * ((i % cols) + 1), 45 + Math.floor(i / cols) * rowH]);
+
+  const HALF = 36, out = [];
+  out.push('<defs><marker id="ar" viewBox="0 0 8 8" refX="7" refY="4" ' +
+    'markerWidth="7" markerHeight="7" orient="auto-start-reverse">' +
+    '<path d="M0,0 L8,4 L0,8 z" fill="#9d9b96"/></marker></defs>');
+  units.forEach(u => {
+    u.inlets.forEach(stream => {
+      const from = producer[stream];
+      if (from === undefined || from === u.name) return;
+      const a = pos[from], b = pos[u.name];
+      if (!a || !b) return;
+      const back = a[0] > b[0], loop = recycled.has(stream);
+      /* A right-to-left edge drawn straight would run through every box
+         between its ends and read as a second arrowhead on a forward
+         line. Route it under the row instead, where a loop belongs. */
+      const dip = Math.max(a[1], b[1]) + 52;   // clears the operation label
+      const d = back
+        ? 'M' + a[0] + ',' + (a[1]+16) + ' C' + a[0] + ',' + dip + ' ' +
+          b[0] + ',' + dip + ' ' + b[0] + ',' + (b[1]+16)
+        : 'M' + (a[0]+HALF) + ',' + a[1] + ' L' + (b[0]-HALF) + ',' + b[1];
+      out.push('<path d="' + d + '" fill="none" stroke="' +
+        (loop ? "#eb6834" : "#9d9b96") + '" stroke-width="1.5"' +
+        (loop ? ' stroke-dasharray="5 3"' : "") + ' marker-end="url(#ar)"/>');
+    });
+  });
+  nodes.forEach(n => {
+    const [x, y] = pos[n.id];
+    const feed = n.kind === "feed";
+    out.push('<rect x="' + (x-HALF) + '" y="' + (y-16) + '" width="' + (2*HALF) +
+      '" height="32" rx="7" fill="' + (feed ? "#2a78d6" : "#fcfcfb") +
+      '" stroke="' + (feed ? "#2a78d6" : "#52514e") + '" stroke-width="1.2"/>');
+    out.push('<text x="' + x + '" y="' + (y+4) + '" text-anchor="middle" fill="' +
+      (feed ? "#fff" : "#0b0b0b") + '">' + n.label + '</text>');
+    if (n.op) out.push('<text x="' + x + '" y="' + (y+28) +
+      '" text-anchor="middle" fill="#52514e" font-size="10">' + n.op + '</text>');
+  });
+  svg.innerHTML = out.join("");
+}
+
+/* ---- units + editable parameters ---------------------------------- */
+function renderUnits() {
+  const el = document.getElementById("units");
+  if (!DOC || !DOC.flowsheet) { el.innerHTML = "<p>No flowsheet loaded.</p>"; return; }
+  el.innerHTML = DOC.flowsheet.units.map((u, ui) => {
+    const spec = CATALOG[u.operation] || {};
+    /* Fields the catalog reports as callable hold code, not data. An
+       empty text box beside one invites typing a value that could only
+       be rejected, so they are listed as read-only instead. */
+    const byName = {};
+    (spec.parameters || []).forEach(p => byName[p.name] = p);
+    const editable = ([k, v]) => !(byName[k] || {}).is_callable &&
+      (v === null || ["number","string","boolean"].includes(typeof v));
+
+    const rows = Object.entries(u.params).filter(editable).map(([k, v]) => {
+      const units = (byName[k] || {}).units;
+      return '<tr><td>' + k + (units ? ' <span class="units">' + units +
+        '</span>' : "") + '</td><td><input type="text" data-unit="' + ui +
+        '" data-key="' + k + '" value="' + (v === null ? "" : v) + '"></td></tr>';
+    }).join("");
+
+    const code = Object.keys(u.params).filter(k => (byName[k] || {}).is_callable);
+    return '<div class="unit"><h3>' + u.name + '</h3>' +
+      '<div class="meta">' + u.operation +
+      ' &nbsp;·&nbsp; ' + u.inlets.join(", ") + ' &rarr; ' + u.outlets.join(", ") +
+      (spec.description ? ' &nbsp;·&nbsp; ' + spec.description : "") + '</div>' +
+      (rows ? '<table><tbody>' + rows + '</tbody></table>'
+            : '<div class="meta">no editable parameters</div>') +
+      (code.length ? '<div class="meta code-fields">set in code: ' +
+        code.join(", ") + '</div>' : "") + '</div>';
+  }).join("");
+
+  el.querySelectorAll("input[data-key]").forEach(inp =>
+    inp.addEventListener("change", e => {
+      const u = DOC.flowsheet.units[+e.target.dataset.unit];
+      const raw = e.target.value.trim();
+      const n = Number(raw);
+      /* isFinite, not !isNaN: JSON.stringify writes Infinity as null,
+         so a non-finite value has to travel back as the string the
+         server sent, which it knows how to restore. */
+      u.params[e.target.dataset.key] =
+        raw === "" ? null : (isFinite(n) && raw !== "" ? n : raw);
+      push();
+    }));
+}
+
+async function push() {
+  const r = await api.post("/api/flowsheet", DOC.flowsheet);
+  status(r.ok ? "" : (r.error || "rejected"), "err");
+}
+
+/* ---- right panel --------------------------------------------------- */
+async function showStreams() {
+  document.getElementById("rightTitle").textContent = "Streams";
+  const r = await api.post("/api/solve");
+  if (!r.ok) { status(r.error, "err"); document.getElementById("right").innerHTML = "";
+               return; }
+  status("Solved" + (r.iterations != null ? " in " + r.iterations + " iterations" : ""), "ok");
+  const names = Object.keys(r.streams);
+  const keys = [...new Set(names.flatMap(n => Object.keys(r.streams[n])))];
+  document.getElementById("right").innerHTML =
+    '<div class="scroll"><table><thead><tr><th>Stream</th>' +
+    keys.map(k => '<th style="text-align:right">' + k + '</th>').join("") +
+    '</tr></thead><tbody>' +
+    names.map(n => '<tr><td>' + n + '</td>' +
+      keys.map(k => '<td class="num">' +
+        (n in r.streams && k in r.streams[n] ? fmt(r.streams[n][k]) : "") +
+        '</td>').join("") + '</tr>').join("") +
+    '</tbody></table></div>';
+}
+
+async function showCode() {
+  document.getElementById("rightTitle").textContent = "Python";
+  const r = await api.get("/api/code");
+  document.getElementById("right").innerHTML = r.error
+    ? '<div class="status err">' + r.error + '</div>'
+    : "<pre>" + r.source.replace(/[&<>]/g, c =>
+        ({"&":"&amp;","<":"&lt;",">":"&gt;"}[c])) + "</pre>";
+}
+
+/* ---- wiring -------------------------------------------------------- */
+document.getElementById("solve").addEventListener("click", showStreams);
+document.getElementById("showcode").addEventListener("click", showCode);
+document.getElementById("save").addEventListener("click", async () => {
+  const r = await api.post("/api/save");
+  status(r.ok ? "Saved to " + r.path : r.error, r.ok ? "ok" : "err");
+});
+
+(async function start() {
+  CATALOG = await api.get("/api/catalog");
+  DOC = await api.get("/api/flowsheet");
+  document.getElementById("path").textContent = DOC.path || "(unsaved)";
+  renderPalette(); renderDiagram(); renderUnits();
+})();
+</script>
+</body>
+</html>
+"""
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/difflow/publish.py
+++ b/src/difflow/publish.py
@@ -1,0 +1,542 @@
+"""Publish a flowsheet as a self-contained interactive page.
+
+difflow's solver cannot run in a browser --- jaxlib has no WebAssembly
+build --- so a live model cannot simply be shipped next to a paper. But
+a *published* model does not need a general solver. Its topology is
+fixed and only a couple of numbers vary, and that much can be computed
+ahead of time:
+
+    publish(fs, axes=[SweepAxis("reactor.V", 0.2, 5.0)],
+            outputs={"product": lambda s: get_flows(s["out"])["B"]},
+            path="reactor.html")
+
+:func:`sweep` evaluates the flowsheet across a grid of parameter values
+with ``jax.vmap``, and :func:`to_html` writes the result as one HTML
+file with sliders. No server, no Python, no JAX --- and nothing to rot,
+which matters for something attached to a paper that has to outlive its
+hosting.
+
+The page interpolates between grid points, so it is exact *at* them and
+approximate between. Take enough points that the curve is smooth and
+that approximation is invisible; the sweep is vectorised, so points are
+cheap.
+
+Exact derivatives are recorded alongside the values, since difflow has
+them for free and nothing else on a static page can supply them. They
+are shown as local sensitivities rather than used for interpolation.
+"""
+
+from __future__ import annotations
+
+import html
+import itertools
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Sequence
+
+import jax
+import jax.numpy as jnp
+
+from difflow.params_mixin import ParamsMixin
+
+#: light-surface palette, matching the difflow documentation charts
+_PALETTE = {
+    "series": "#2a78d6",
+    "accent": "#eb6834",
+    "surface": "#fcfcfb",
+    "panel": "#f4f3f0",
+    "ink": "#0b0b0b",
+    "ink_soft": "#52514e",
+    "grid": "#e4e2de",
+    "line": "#c9c7c2",
+}
+
+
+@dataclass
+class SweepAxis(ParamsMixin):
+    """One parameter to vary, and the range to vary it over.
+
+    Attributes:
+        key: flowsheet parameter, in the dot notation
+            :meth:`~difflow.flowsheet.Flowsheet.make_objective_fn` uses
+            --- ``"<unit>.<param>"``, e.g. ``"reactor.V"``.
+        lo, hi: inclusive bounds.
+        n: grid points. The page interpolates between them, so this
+            sets how faithful it is; 21 is usually plenty for a smooth
+            response.
+        label: axis label; defaults to ``key``.
+        units: shown after the value.
+    """
+
+    key: str
+    lo: float
+    hi: float
+    n: int = 21
+    label: str | None = None
+    units: str = ""
+
+    def __post_init__(self):
+        if self.n < 2:
+            raise ValueError(f"axis {self.key!r} needs at least 2 points")
+        if not self.hi > self.lo:
+            raise ValueError(f"axis {self.key!r}: hi must exceed lo")
+
+    @property
+    def title(self) -> str:
+        return self.label or self.key
+
+    def values(self):
+        return jnp.linspace(self.lo, self.hi, self.n)
+
+
+@dataclass
+class SweepResult(ParamsMixin):
+    """A flowsheet evaluated over a grid of parameter values.
+
+    Attributes:
+        axes: the parameters that were varied.
+        values: output name -> array of shape ``(n_1, ..., n_k)``.
+        gradients: output name -> axis key -> array of the same shape,
+            the exact derivative at each grid point.
+        units: output name -> units, for display.
+        baseline: the parameter values the flowsheet started from.
+    """
+
+    axes: list[SweepAxis]
+    values: dict[str, Any]
+    gradients: dict[str, dict[str, Any]] = field(default_factory=dict)
+    units: dict[str, str] = field(default_factory=dict)
+    baseline: dict[str, float] = field(default_factory=dict)
+
+    @property
+    def shape(self) -> tuple[int, ...]:
+        return tuple(axis.n for axis in self.axes)
+
+    @property
+    def n_points(self) -> int:
+        n = 1
+        for axis in self.axes:
+            n *= axis.n
+        return n
+
+    def to_dict(self) -> dict:
+        """Plain data, ready for JSON and the page."""
+        return {
+            "axes": [
+                {
+                    "key": a.key, "label": a.title, "units": a.units,
+                    "lo": a.lo, "hi": a.hi, "n": a.n,
+                    "values": [float(v) for v in a.values()],
+                }
+                for a in self.axes
+            ],
+            "outputs": [
+                {
+                    "name": name,
+                    "units": self.units.get(name, ""),
+                    "values": jnp.asarray(grid).tolist(),
+                    "gradients": {
+                        key: jnp.asarray(g).tolist()
+                        for key, g in self.gradients.get(name, {}).items()
+                    },
+                }
+                for name, grid in self.values.items()
+            ],
+        }
+
+
+def sweep(
+    flowsheet,
+    axes: Sequence[SweepAxis],
+    outputs: dict[str, Callable],
+    *,
+    units: dict[str, str] | None = None,
+    gradients: bool = True,
+    batch: bool = True,
+) -> SweepResult:
+    """Evaluate a flowsheet across a grid of parameter values.
+
+    Args:
+        flowsheet: the flowsheet to sweep.
+        axes: parameters to vary. One or two read best on a page; more
+            work, but the reader has that many sliders to think about.
+        outputs: name -> ``fn(streams) -> scalar``, the quantities to
+            record.
+        units: name -> units, for display.
+        gradients: also record the exact derivative of each output with
+            respect to each axis at every grid point.
+        batch: evaluate with ``jax.vmap``. Turn off to fall back to a
+            plain loop, which is slower but easier to debug.
+
+    Returns:
+        A :class:`SweepResult`.
+
+    Raises:
+        ValueError: if no axes or no outputs are given.
+    """
+    axes = list(axes)
+    if not axes:
+        raise ValueError("a sweep needs at least one axis")
+    if not outputs:
+        raise ValueError("a sweep needs at least one output")
+
+    keys = [axis.key for axis in axes]
+    mesh = jnp.meshgrid(*[axis.values() for axis in axes], indexing="ij")
+    flat = [m.reshape(-1) for m in mesh]
+    shape = tuple(axis.n for axis in axes)
+
+    values: dict[str, Any] = {}
+    grads: dict[str, dict[str, Any]] = {}
+
+    for name, output_fn in outputs.items():
+        objective = flowsheet.make_objective_fn(output_fn)
+
+        def at(point, objective=objective):
+            return objective({k: point[i] for i, k in enumerate(keys)})
+
+        stacked = jnp.stack(flat, axis=1)          # (n_points, n_axes)
+        if batch:
+            values[name] = jax.vmap(at)(stacked).reshape(shape)
+        else:
+            values[name] = jnp.asarray(
+                [at(p) for p in stacked]
+            ).reshape(shape)
+
+        if gradients:
+            def grad_at(point, objective=objective):
+                return jax.grad(
+                    lambda p: objective({k: p[i] for i, k in enumerate(keys)})
+                )(point)
+
+            if batch:
+                g = jax.vmap(grad_at)(stacked)
+            else:
+                g = jnp.stack([grad_at(p) for p in stacked])
+            grads[name] = {
+                key: g[:, i].reshape(shape) for i, key in enumerate(keys)
+            }
+
+    return SweepResult(
+        axes=axes, values=values, gradients=grads, units=units or {},
+    )
+
+
+# ---------------------------------------------------------------------
+# The page
+# ---------------------------------------------------------------------
+
+
+def to_html(
+    result: SweepResult,
+    *,
+    title: str = "difflow model",
+    description: str = "",
+) -> str:
+    """Render a sweep as one self-contained HTML page.
+
+    The page carries the grid, interpolates between points as the
+    sliders move, and needs nothing at run time --- no network, no
+    Python, no JAX.
+
+    Args:
+        result: the sweep to publish.
+        title: page and document title.
+        description: a paragraph under the title; plain text.
+
+    Returns:
+        A complete HTML document.
+    """
+    from difflow import __version__
+
+    payload = json.dumps(result.to_dict(), separators=(",", ":"))
+    return _TEMPLATE.format(
+        title=html.escape(title),
+        description=html.escape(description),
+        version=html.escape(__version__),
+        n_points=result.n_points,
+        palette=json.dumps(_PALETTE),
+        data=payload,
+    )
+
+
+def publish(
+    flowsheet,
+    axes: Sequence[SweepAxis],
+    outputs: dict[str, Callable],
+    path: str | Path,
+    *,
+    title: str = "difflow model",
+    description: str = "",
+    units: dict[str, str] | None = None,
+    **sweep_kwargs,
+) -> Path:
+    """Sweep a flowsheet and write the interactive page in one step.
+
+    Returns:
+        The path written.
+    """
+    result = sweep(flowsheet, axes, outputs, units=units, **sweep_kwargs)
+    path = Path(path)
+    path.write_text(to_html(result, title=title, description=description))
+    return path
+
+
+_TEMPLATE = """<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{title}</title>
+<style>
+  :root {{
+    --surface: #fcfcfb; --panel: #f4f3f0; --ink: #0b0b0b;
+    --ink-soft: #52514e; --grid: #e4e2de; --line: #c9c7c2;
+    --series: #2a78d6;
+  }}
+  * {{ box-sizing: border-box; }}
+  body {{
+    margin: 0; padding: 2rem 1.25rem; background: var(--surface);
+    color: var(--ink);
+    font: 15px/1.55 ui-sans-serif, system-ui, -apple-system, "Segoe UI",
+          Roboto, Helvetica, Arial, sans-serif;
+  }}
+  main {{ max-width: 62rem; margin: 0 auto; }}
+  h1 {{ font-size: 1.5rem; margin: 0 0 .4rem; letter-spacing: -.01em; }}
+  p.lede {{ color: var(--ink-soft); margin: 0 0 1.75rem; max-width: 46rem; }}
+  .layout {{ display: grid; grid-template-columns: 17rem 1fr; gap: 1.5rem;
+             align-items: start; }}
+  @media (max-width: 46rem) {{ .layout {{ grid-template-columns: 1fr; }} }}
+  .panel {{
+    background: var(--panel); border: 1px solid var(--grid);
+    border-radius: 10px; padding: 1rem 1.1rem;
+  }}
+  .panel h2 {{
+    font-size: .72rem; text-transform: uppercase; letter-spacing: .07em;
+    color: var(--ink-soft); margin: 0 0 .9rem; font-weight: 600;
+  }}
+  .control {{ margin-bottom: 1.1rem; }}
+  .control:last-child {{ margin-bottom: 0; }}
+  .control label {{
+    display: flex; justify-content: space-between; align-items: baseline;
+    font-size: .85rem; margin-bottom: .35rem; gap: .5rem;
+  }}
+  .control .value {{
+    font-variant-numeric: tabular-nums; color: var(--ink);
+    font-weight: 600;
+  }}
+  input[type=range] {{ width: 100%; accent-color: var(--series); }}
+  select {{
+    width: 100%; padding: .35rem .5rem; border: 1px solid var(--line);
+    border-radius: 6px; background: var(--surface); color: var(--ink);
+    font: inherit; font-size: .85rem;
+  }}
+  table {{ width: 100%; border-collapse: collapse; margin-top: .25rem; }}
+  th, td {{
+    text-align: left; padding: .4rem .3rem; font-size: .85rem;
+    border-bottom: 1px solid var(--grid);
+  }}
+  th {{
+    color: var(--ink-soft); font-weight: 600; font-size: .72rem;
+    text-transform: uppercase; letter-spacing: .06em;
+  }}
+  td.num {{ text-align: right; font-variant-numeric: tabular-nums; }}
+  td.sens {{ text-align: right; font-variant-numeric: tabular-nums;
+             color: var(--ink-soft); }}
+  figure {{ margin: 0; }}
+  footer {{
+    margin-top: 2rem; padding-top: 1rem; border-top: 1px solid var(--grid);
+    color: var(--ink-soft); font-size: .8rem;
+  }}
+  code {{ font-size: .82em; background: var(--panel); padding: .1em .35em;
+          border-radius: 4px; }}
+</style>
+</head>
+<body>
+<main>
+  <h1>{title}</h1>
+  <p class="lede">{description}</p>
+
+  <div class="layout">
+    <div class="panel" id="controls">
+      <h2>Parameters</h2>
+      <div id="sliders"></div>
+    </div>
+
+    <div>
+      <figure class="panel" style="margin-bottom:1.5rem">
+        <h2>Response</h2>
+        <div class="control">
+          <label for="output-pick"><span>Plotted quantity</span></label>
+          <select id="output-pick"></select>
+        </div>
+        <svg id="chart" viewBox="0 0 640 300" width="100%"
+             role="img" aria-label="Model response"></svg>
+      </figure>
+
+      <div class="panel">
+        <h2>Values at this point</h2>
+        <table>
+          <thead>
+            <tr><th>Quantity</th><th style="text-align:right">Value</th>
+                <th style="text-align:right">Sensitivity</th></tr>
+          </thead>
+          <tbody id="readout"></tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+
+  <footer>
+    Precomputed with difflow {version} over {n_points} solved operating
+    points; values between grid points are interpolated. Sensitivities are
+    exact derivatives from automatic differentiation, reported per unit of
+    the first parameter.
+  </footer>
+</main>
+
+<script>
+const DATA = {data};
+const C = {palette};
+const state = DATA.axes.map(a => Math.floor(a.n / 2));
+
+/* ---- interpolation ------------------------------------------------ */
+function axisFrac(ai, x) {{
+  const a = DATA.axes[ai];
+  const t = (x - a.lo) / (a.hi - a.lo) * (a.n - 1);
+  const i = Math.max(0, Math.min(a.n - 2, Math.floor(t)));
+  return [i, Math.max(0, Math.min(1, t - i))];
+}}
+function at(grid, idx) {{ return idx.reduce((g, i) => g[i], grid); }}
+
+/* multilinear over however many axes there are */
+function interp(grid, coords) {{
+  const parts = coords.map((x, ai) => axisFrac(ai, x));
+  let total = 0;
+  const n = coords.length;
+  for (let mask = 0; mask < (1 << n); mask++) {{
+    let weight = 1, idx = [];
+    for (let ai = 0; ai < n; ai++) {{
+      const [i, f] = parts[ai];
+      const up = (mask >> ai) & 1;
+      weight *= up ? f : 1 - f;
+      idx.push(i + up);
+    }}
+    if (weight > 0) total += weight * at(grid, idx);
+  }}
+  return total;
+}}
+function coords() {{
+  return DATA.axes.map((a, i) => a.values[state[i]]);
+}}
+function fmt(v) {{
+  if (!isFinite(v)) return "--";
+  const m = Math.abs(v);
+  if (m !== 0 && (m < 1e-3 || m >= 1e5)) return v.toExponential(3);
+  return v.toFixed(m >= 100 ? 1 : m >= 1 ? 3 : 4);
+}}
+
+/* ---- controls ----------------------------------------------------- */
+const sliders = document.getElementById("sliders");
+DATA.axes.forEach((a, i) => {{
+  const wrap = document.createElement("div");
+  wrap.className = "control";
+  wrap.innerHTML =
+    '<label for="ax' + i + '"><span>' + a.label + '</span>' +
+    '<span class="value" id="val' + i + '"></span></label>' +
+    '<input type="range" id="ax' + i + '" min="0" max="' + (a.n - 1) +
+    '" step="1" value="' + state[i] + '">';
+  sliders.appendChild(wrap);
+  wrap.querySelector("input").addEventListener("input", e => {{
+    state[i] = +e.target.value;
+    render();
+  }});
+}});
+
+const pick = document.getElementById("output-pick");
+DATA.outputs.forEach((o, i) => {{
+  const opt = document.createElement("option");
+  opt.value = i;
+  opt.textContent = o.name + (o.units ? " (" + o.units + ")" : "");
+  pick.appendChild(opt);
+}});
+pick.addEventListener("change", render);
+
+/* ---- chart -------------------------------------------------------- */
+function drawChart(outIndex) {{
+  const svg = document.getElementById("chart");
+  const W = 640, H = 300, L = 64, R = 16, T = 16, B = 46;
+  const axis = DATA.axes[0], out = DATA.outputs[outIndex];
+  const here = coords();
+
+  const xs = axis.values;
+  const ys = xs.map(x => interp(out.values, [x, ...here.slice(1)]));
+  const yMin = Math.min(...ys), yMax = Math.max(...ys);
+  const pad = (yMax - yMin) * 0.08 || Math.abs(yMax) * 0.08 || 1;
+  const lo = yMin - pad, hi = yMax + pad;
+
+  const sx = x => L + (x - axis.lo) / (axis.hi - axis.lo) * (W - L - R);
+  const sy = y => H - B - (y - lo) / (hi - lo) * (H - T - B);
+
+  let parts = [];
+  /* grid + y labels, recessive */
+  for (let k = 0; k <= 4; k++) {{
+    const v = lo + (hi - lo) * k / 4, y = sy(v);
+    parts.push('<line x1="' + L + '" y1="' + y + '" x2="' + (W - R) +
+      '" y2="' + y + '" stroke="' + C.grid + '" stroke-width="1"/>');
+    parts.push('<text x="' + (L - 8) + '" y="' + (y + 4) +
+      '" text-anchor="end" font-size="11" fill="' + C.ink_soft + '">' +
+      fmt(v) + '</text>');
+  }}
+  /* x labels at the ends and middle */
+  [0, 0.5, 1].forEach(f => {{
+    const v = axis.lo + (axis.hi - axis.lo) * f;
+    parts.push('<text x="' + sx(v) + '" y="' + (H - B + 20) +
+      '" text-anchor="middle" font-size="11" fill="' + C.ink_soft + '">' +
+      fmt(v) + '</text>');
+  }});
+  parts.push('<text x="' + ((L + W - R) / 2) + '" y="' + (H - 8) +
+    '" text-anchor="middle" font-size="12" fill="' + C.ink_soft + '">' +
+    axis.label + (axis.units ? " (" + axis.units + ")" : "") + '</text>');
+
+  const d = xs.map((x, i) => (i ? "L" : "M") + sx(x) + " " + sy(ys[i])).join(" ");
+  parts.push('<path d="' + d + '" fill="none" stroke="' + C.series +
+    '" stroke-width="2" stroke-linejoin="round"/>');
+
+  /* where the sliders currently sit */
+  const cx = sx(here[0]), cy = sy(interp(out.values, here));
+  parts.push('<line x1="' + cx + '" y1="' + T + '" x2="' + cx + '" y2="' +
+    (H - B) + '" stroke="' + C.line + '" stroke-width="1" ' +
+    'stroke-dasharray="4 3"/>');
+  parts.push('<circle cx="' + cx + '" cy="' + cy + '" r="5" fill="' +
+    C.series + '" stroke="' + C.surface + '" stroke-width="2"/>');
+
+  svg.innerHTML = parts.join("");
+}}
+
+/* ---- readout ------------------------------------------------------ */
+function render() {{
+  const here = coords();
+  DATA.axes.forEach((a, i) => {{
+    document.getElementById("val" + i).textContent =
+      fmt(here[i]) + (a.units ? " " + a.units : "");
+  }});
+
+  const rows = DATA.outputs.map(o => {{
+    const v = interp(o.values, here);
+    const gKey = DATA.axes[0].key;
+    const g = o.gradients && o.gradients[gKey]
+      ? interp(o.gradients[gKey], here) : null;
+    return "<tr><td>" + o.name + "</td><td class='num'>" + fmt(v) +
+      (o.units ? " <span style='color:" + C.ink_soft + "'>" + o.units +
+        "</span>" : "") +
+      "</td><td class='sens'>" + (g === null ? "--" : fmt(g)) + "</td></tr>";
+  }});
+  document.getElementById("readout").innerHTML = rows.join("");
+  drawChart(+pick.value);
+}}
+render();
+</script>
+</body>
+</html>
+"""

--- a/src/difflow/serialize.py
+++ b/src/difflow/serialize.py
@@ -251,6 +251,31 @@ def _decode_stream(data: dict) -> dict:
 # ---------------------------------------------------------------------
 
 
+def _takes_params_first(sig) -> bool:
+    """Whether a constructor's leading argument is its ``Params`` object.
+
+    Most units are built as ``Unit(Params(...), thermo)``, but a
+    substantial minority --- ``Mixer``, ``Splitter``, ``GasPipe``,
+    ``Compressor`` and the rest of the gas plugin --- take a plain
+    argument there instead. Assuming the first argument is always the
+    ``Params`` silently drops a *required* one, and the unit then fails
+    to rebuild.
+    """
+    import dataclasses
+    import inspect
+
+    for name, param in sig.parameters.items():
+        if name == "self":
+            continue
+        annotation = param.annotation
+        return (
+            name == "params"
+            or dataclasses.is_dataclass(annotation)
+            or (isinstance(annotation, str) and annotation.endswith("Params"))
+        )
+    return False
+
+
 def constructor_extras(cls: type) -> list[str]:
     """Constructor arguments a class requires besides its ``Params``.
 
@@ -258,6 +283,15 @@ def constructor_extras(cls: type) -> list[str]:
     is an object rather than data. They are read off the instance by
     attribute of the same name, and either written (when the kind is
     supported) or supplied on load via ``extras=``.
+
+    Units that take no ``Params`` at all --- ``Mixer(species_order)``,
+    ``GasPipe(beta)`` --- report every required argument, since all of
+    them have to be written for the unit to be rebuilt.
+
+    Only *required* arguments are reported, so an optional constructor
+    object left at its default --- ``Mixer``'s ``thermo``, ``Flash``'s
+    ``eos`` --- is not carried by either format. Pass it back on load
+    with ``extras=`` when it matters.
     """
     import inspect
 
@@ -271,7 +305,9 @@ def constructor_extras(cls: type) -> list[str]:
         and p.default is inspect.Parameter.empty
         and p.kind not in (p.VAR_POSITIONAL, p.VAR_KEYWORD)
     ]
-    return required[1:]          # the first is the Params object
+    if required and _takes_params_first(sig):
+        return required[1:]
+    return required
 
 
 def _encode_extras(operation: Any, unit_name: str) -> dict:

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -1,0 +1,346 @@
+"""Tests for difflow.gui.
+
+The editor is a thin shell over serialize, codegen and catalog, so the
+tests exercise the shell: that every route answers, that an edit made in
+the browser reaches the model and changes the answer, and that a bad
+edit is reported rather than taking the server down.
+
+The two load-bearing tests are `test_an_edit_changes_the_solution` --- an
+editor whose edits do not reach the model is worse than none --- and
+`TestNonFiniteFloats`, because `mass_action_kinetics` puts `inf` in
+`K_eq` for every irreversible reaction and Python's `json` writes that
+as `Infinity`, which the browser refuses to parse.
+"""
+
+import json
+import threading
+import urllib.error
+import urllib.request
+
+import jax
+import pytest
+
+jax.config.update("jax_enable_x64", True)
+
+from difflow import (
+    CSTR,
+    CSTRParams,
+    Flash,
+    FlashParams,
+    Flowsheet,
+    Heater,
+    HeaterParams,
+    IdealThermo,
+    Mixer,
+    Unit,
+    get_species_data,
+    gui,
+    make_stream,
+    mass_action_kinetics,
+    serialize,
+)
+from difflow.gui import FlowsheetSession, _json_restore, _json_safe, make_server
+
+SPECIES = ["water", "ethanol"]
+
+
+@pytest.fixture(scope="module")
+def thermo():
+    return IdealThermo({n: get_species_data(n) for n in SPECIES})
+
+
+def build_flowsheet(thermo, V=1.0):
+    """A reactor with a data-built rate law, then a flash."""
+    kin = mass_action_kinetics([{
+        "equation": "water -> ethanol",
+        "reactants": {"water": 1.0}, "products": {"ethanol": 1.0},
+        "rate_params": {"A": 1.0e3, "Ea": 40_000.0, "n": 0.0},
+    }], SPECIES)
+    fs = Flowsheet(species_order=SPECIES)
+    fs.add_feed("feed", make_stream(
+        {"water": 1.0, "ethanol": 0.1}, T=350.0, P=101325.0
+    ))
+    fs.add_unit(Unit("reactor", CSTR(CSTRParams(
+        V=V, molar_density=1000.0, **kin.params_kwargs()
+    )), ["feed"], ["rx"]))
+    fs.add_unit(Unit("flash", Flash(FlashParams(species_order=SPECIES), thermo),
+                     ["rx"], ["liq", "vap"]))
+    return fs
+
+
+class Client:
+    """A live server on an ephemeral port, plus the two verbs it takes."""
+
+    def __init__(self, session):
+        self.session = session
+        self.server = make_server(session, port=0)
+        self.base = f"http://{gui.HOST}:{self.server.server_address[1]}"
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.thread.start()
+
+    def close(self):
+        self.server.shutdown()
+        self.server.server_close()
+
+    def get(self, path):
+        try:
+            with urllib.request.urlopen(self.base + path) as response:
+                return response.status, response.read()
+        except urllib.error.HTTPError as exc:
+            return exc.code, exc.read()
+
+    def get_json(self, path):
+        status, body = self.get(path)
+        return status, json.loads(body)
+
+    def post(self, path, body=None):
+        request = urllib.request.Request(
+            self.base + path, data=json.dumps(body or {}).encode(),
+            headers={"Content-Type": "application/json"}, method="POST",
+        )
+        try:
+            with urllib.request.urlopen(request) as response:
+                return response.status, json.loads(response.read())
+        except urllib.error.HTTPError as exc:
+            return exc.code, json.loads(exc.read())
+
+
+@pytest.fixture
+def client(thermo):
+    live = Client(FlowsheetSession(build_flowsheet(thermo)))
+    yield live
+    live.close()
+
+
+# =============================================================================
+# Routes
+# =============================================================================
+
+
+class TestRoutes:
+    def test_the_page_is_served(self, client):
+        status, body = client.get("/")
+        assert status == 200
+        assert b"<title>difflow editor</title>" in body
+
+    def test_the_catalog_lists_registered_operations(self, client):
+        status, catalog = client.get_json("/api/catalog")
+        assert status == 200
+        assert "CSTR" in catalog and "Flash" in catalog
+        assert catalog["Flash"]["ports"]["n_outlets"] == 2, (
+            "the palette needs port arity to draw anything"
+        )
+
+    def test_the_flowsheet_is_served_as_the_serialize_document(self, client):
+        status, doc = client.get_json("/api/flowsheet")
+        assert status == 200
+        assert [u["name"] for u in doc["flowsheet"]["units"]] == ["reactor", "flash"]
+        assert doc["flowsheet"]["format_version"] == serialize.FORMAT_VERSION
+
+    def test_the_python_export_is_served(self, client):
+        status, payload = client.get_json("/api/code")
+        assert status == 200
+        assert payload["error"] is None
+        assert "mass_action_kinetics" in payload["source"]
+
+    def test_solve_returns_every_stream(self, client):
+        status, payload = client.post("/api/solve")
+        assert status == 200 and payload["ok"]
+        assert set(payload["streams"]) == {"feed", "rx", "liq", "vap"}
+        assert isinstance(payload["streams"]["rx"]["F_ethanol"], float)
+
+    def test_favicon_is_answered(self, client):
+        """Otherwise every page load logs a 404 in the console."""
+        assert client.get("/favicon.ico")[0] == 200
+
+    def test_an_unknown_route_is_a_404(self, client):
+        assert client.get("/api/nope")[0] == 404
+        assert client.post("/api/nope")[0] == 404
+
+
+# =============================================================================
+# Editing
+# =============================================================================
+
+
+class TestEditing:
+    def test_an_edit_changes_the_solution(self, client):
+        """An editor whose edits do not reach the model is worse than none."""
+        _, before = client.post("/api/solve")
+        _, doc = client.get_json("/api/flowsheet")
+
+        doc["flowsheet"]["units"][0]["params"]["V"] = 5.0
+        status, payload = client.post("/api/flowsheet", doc["flowsheet"])
+        assert status == 200 and payload["ok"]
+
+        _, after = client.post("/api/solve")
+        assert after["ok"]
+        assert after["streams"]["rx"]["F_ethanol"] > before["streams"]["rx"]["F_ethanol"], (
+            "a five-fold larger reactor must convert more"
+        )
+
+    def test_the_edited_flowsheet_is_what_the_session_holds(self, client):
+        _, doc = client.get_json("/api/flowsheet")
+        doc["flowsheet"]["units"][0]["params"]["V"] = 3.0
+        client.post("/api/flowsheet", doc["flowsheet"])
+        assert float(client.session.flowsheet.units[0].operation.params.V) == 3.0
+
+    def test_a_bad_edit_is_reported_and_the_server_survives(self, client):
+        status, payload = client.post("/api/flowsheet", {"units": "not a flowsheet"})
+        assert status == 400 and not payload["ok"]
+        assert "error" in payload
+        # the previous model is untouched and still solvable
+        assert client.post("/api/solve")[1]["ok"]
+
+    def test_malformed_json_is_reported(self, client):
+        request = urllib.request.Request(
+            client.base + "/api/flowsheet", data=b"{not json",
+            headers={"Content-Type": "application/json"}, method="POST",
+        )
+        with pytest.raises(urllib.error.HTTPError) as excinfo:
+            urllib.request.urlopen(request)
+        assert excinfo.value.code == 400
+        assert "bad JSON" in json.loads(excinfo.value.read())["error"]
+
+
+# =============================================================================
+# Non-finite floats
+# =============================================================================
+
+
+class TestNonFiniteFloats:
+    """JSON has no literal for these, and the browser rejects Python's."""
+
+    def test_the_document_parses_under_browser_rules(self, client):
+        """`JSON.parse` has no Infinity; Python's `json.loads` allows it."""
+        def reject(token):
+            raise AssertionError(f"bare {token} would break JSON.parse")
+
+        status, body = client.get("/api/flowsheet")
+        assert status == 200
+        json.loads(body, parse_constant=reject)
+
+    def test_an_irreversible_reaction_puts_inf_in_the_document(self, client):
+        """Guards the premise: without inf present the test above is vacuous."""
+        _, doc = client.get_json("/api/flowsheet")
+        rate_params = doc["flowsheet"]["units"][0]["params"]["rate_params"]
+        assert rate_params["K_eq"]["$array"] == ["Infinity"]
+
+    def test_the_round_trip_restores_the_value(self, client):
+        _, doc = client.get_json("/api/flowsheet")
+        status, payload = client.post("/api/flowsheet", doc["flowsheet"])
+        assert status == 200 and payload["ok"]
+        rate_params = client.session.flowsheet.units[0].operation.params.rate_params
+        assert float(rate_params["K_eq"][0]) == float("inf")
+
+    def test_json_safe_and_restore_are_inverse(self):
+        value = {"a": [1.0, float("inf"), -float("inf")], "b": {"c": 2.0}}
+        assert _json_safe(value) == {"a": [1.0, "Infinity", "-Infinity"],
+                                     "b": {"c": 2.0}}
+        assert _json_restore(_json_safe(value)) == value
+
+    def test_nan_survives_the_round_trip(self):
+        restored = _json_restore(_json_safe({"x": float("nan")}))
+        assert restored["x"] != restored["x"]
+
+    def test_ordinary_strings_are_left_alone(self):
+        assert _json_restore({"phase": "vapor"}) == {"phase": "vapor"}
+
+
+# =============================================================================
+# Files
+# =============================================================================
+
+
+class TestFiles:
+    def test_a_session_loads_a_flowsheet_from_a_path(self, thermo, tmp_path):
+        path = tmp_path / "plant.json"
+        serialize.save(build_flowsheet(thermo), path)
+
+        session = FlowsheetSession(path=path)
+        assert [u.name for u in session.flowsheet.units] == ["reactor", "flash"]
+
+    def test_save_writes_a_readable_file(self, thermo, tmp_path):
+        path = tmp_path / "plant.json"
+        session = FlowsheetSession(build_flowsheet(thermo), path)
+        assert session.save()["ok"]
+        assert [u.name for u in serialize.load(path).units] == ["reactor", "flash"]
+
+    def test_save_without_a_path_is_refused_not_raised(self, thermo):
+        session = FlowsheetSession(build_flowsheet(thermo))
+        result = session.save()
+        assert not result["ok"] and "path" in result["error"]
+
+    def test_an_empty_session_reports_rather_than_raises(self):
+        session = FlowsheetSession()
+        assert session.document()["flowsheet"] is None
+        assert not session.solve()["ok"]
+        assert session.code()["error"]
+
+
+# =============================================================================
+# Failures the browser has to be told about
+# =============================================================================
+
+
+class TestFailureReporting:
+    def test_a_failing_solve_is_reported_not_raised(self, thermo):
+        """The browser needs the message; a traceback at the socket is useless."""
+        fs = Flowsheet(species_order=SPECIES)
+        fs.add_feed("feed", make_stream({"water": 1.0}, T=350.0, P=101325.0))
+        # a Heater takes one inlet; two is a modelling error, not a crash
+        fs.add_unit(Unit("heat", Heater(HeaterParams(T_out=360.0)),
+                         ["feed", "recycle"], ["hot"]))
+        fs.add_unit(Unit("flash", Flash(FlashParams(species_order=SPECIES), thermo),
+                         ["hot"], ["liq", "vap"]))
+        fs.add_recycle("liq", "recycle")
+
+        result = FlowsheetSession(fs).solve()
+        assert not result["ok"]
+        assert result["error"], "a failure must carry a message"
+
+    def test_an_unregistered_unit_makes_the_code_panel_report(self, thermo):
+        class HomeMadeUnit:
+            params = None
+
+        fs = build_flowsheet(thermo)
+        fs.add_unit(Unit("mystery", HomeMadeUnit(), ["rx"], ["out"]))
+        assert "registry" in FlowsheetSession(fs).code()["error"]
+
+
+# =============================================================================
+# Recycles
+# =============================================================================
+
+
+class TestRecycles:
+    def test_a_recycle_flowsheet_serves_edits_and_solves(self, thermo):
+        """The diagram draws recycles, so the document has to carry them."""
+        fs = Flowsheet(species_order=SPECIES)
+        fs.add_feed("feed", make_stream({"water": 1.0, "ethanol": 0.1},
+                                        T=350.0, P=101325.0))
+        fs.add_unit(Unit("mix", Mixer(SPECIES, thermo),
+                         ["feed", "recycle"], ["mixed"]))
+        fs.add_unit(Unit("heat", Heater(HeaterParams(T_out=360.0)),
+                         ["mixed"], ["hot"]))
+        fs.add_unit(Unit("flash", Flash(FlashParams(species_order=SPECIES), thermo),
+                         ["hot"], ["liq", "vap"]))
+        fs.add_recycle("vap", "recycle")
+
+        live = Client(FlowsheetSession(fs))
+        try:
+            _, doc = live.get_json("/api/flowsheet")
+            assert doc["flowsheet"]["recycles"] == {"vap": "recycle"}
+
+            doc["flowsheet"]["units"][1]["params"]["T_out"] = 365.0
+            assert live.post("/api/flowsheet", doc["flowsheet"])[1]["ok"]
+
+            _, solved = live.post("/api/solve")
+            assert solved["ok"]
+            assert solved["streams"]["hot"]["T"] == pytest.approx(365.0, abs=1e-9)
+        finally:
+            live.close()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -1,0 +1,222 @@
+"""Tests for difflow.publish.
+
+A published page is precomputed, so the thing to check is that the grid
+it carries is the flowsheet's real answer -- the page can only be as
+right as the numbers baked into it.
+"""
+
+import json
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+jax.config.update("jax_enable_x64", True)
+
+from difflow import (
+    CSTR,
+    CSTRParams,
+    Flowsheet,
+    SweepAxis,
+    Unit,
+    get_flows,
+    make_stream,
+    mass_action_kinetics,
+)
+from difflow.publish import publish, sweep, to_html
+
+SPECIES = ["A", "B"]
+
+
+@pytest.fixture(scope="module")
+def flowsheet():
+    kin = mass_action_kinetics([{
+        "equation": "A -> B",
+        "reactants": {"A": 1.0}, "products": {"B": 1.0},
+        "rate_params": {"A": 1.0e6, "Ea": 50_000.0, "n": 0.0},
+    }], SPECIES)
+    fs = Flowsheet(species_order=SPECIES)
+    fs.add_feed("feed", make_stream({"A": 1.0, "B": 0.0}, T=350.0, P=101325.0))
+    fs.add_unit(Unit("reactor", CSTR(CSTRParams(
+        V=1.0, molar_density=1000.0, **kin.params_kwargs()
+    )), ["feed"], ["out"]))
+    return fs
+
+
+def product(streams):
+    return get_flows(streams["out"])["B"]
+
+
+# =============================================================================
+# The sweep
+# =============================================================================
+
+
+class TestSweep:
+    def test_grid_matches_direct_evaluation(self, flowsheet):
+        """The page can only be as right as the numbers baked into it."""
+        axis = SweepAxis("reactor.V", 0.5, 3.0, n=6)
+        result = sweep(flowsheet, [axis], {"product": product})
+
+        objective = flowsheet.make_objective_fn(product)
+        for i, v in enumerate(axis.values()):
+            expected = float(objective({"reactor.V": float(v)}))
+            assert float(result.values["product"][i]) == pytest.approx(
+                expected, rel=1e-12
+            )
+
+    def test_gradients_are_the_real_derivatives(self, flowsheet):
+        axis = SweepAxis("reactor.V", 0.5, 3.0, n=4)
+        result = sweep(flowsheet, [axis], {"product": product})
+
+        objective = flowsheet.make_objective_fn(product)
+        for i, v in enumerate(axis.values()):
+            expected = float(
+                jax.grad(objective)({"reactor.V": float(v)})["reactor.V"]
+            )
+            got = float(result.gradients["product"]["reactor.V"][i])
+            assert got == pytest.approx(expected, rel=1e-9)
+
+    def test_two_axes_give_a_two_dimensional_grid(self, flowsheet):
+        result = sweep(
+            flowsheet,
+            [SweepAxis("reactor.V", 0.5, 3.0, n=5),
+             SweepAxis("reactor.T_damping", 0.2, 0.6, n=3)],
+            {"product": product},
+        )
+        assert result.shape == (5, 3)
+        assert result.n_points == 15
+        assert jnp.asarray(result.values["product"]).shape == (5, 3)
+
+    def test_the_loop_fallback_agrees_with_vmap(self, flowsheet):
+        axis = SweepAxis("reactor.V", 0.5, 3.0, n=4)
+        batched = sweep(flowsheet, [axis], {"product": product}, batch=True)
+        looped = sweep(flowsheet, [axis], {"product": product}, batch=False)
+        np.testing.assert_allclose(
+            np.asarray(batched.values["product"]),
+            np.asarray(looped.values["product"]),
+            rtol=1e-12,
+        )
+
+    def test_gradients_can_be_skipped(self, flowsheet):
+        result = sweep(
+            flowsheet, [SweepAxis("reactor.V", 0.5, 3.0, n=3)],
+            {"product": product}, gradients=False,
+        )
+        assert result.gradients == {}
+
+    def test_multiple_outputs(self, flowsheet):
+        result = sweep(
+            flowsheet, [SweepAxis("reactor.V", 0.5, 3.0, n=3)],
+            {"B": product, "A": lambda s: get_flows(s["out"])["A"]},
+        )
+        assert set(result.values) == {"A", "B"}
+        # a first-order conversion: what leaves as B did not leave as A
+        total = (jnp.asarray(result.values["A"])
+                 + jnp.asarray(result.values["B"]))
+        np.testing.assert_allclose(np.asarray(total), 1.0, rtol=1e-9)
+
+    def test_a_bigger_volume_converts_more(self, flowsheet):
+        result = sweep(
+            flowsheet, [SweepAxis("reactor.V", 0.5, 5.0, n=8)],
+            {"product": product},
+        )
+        values = np.asarray(result.values["product"])
+        assert np.all(np.diff(values) > 0), "conversion must rise with volume"
+
+
+class TestSweepValidation:
+    def test_no_axes_is_refused(self, flowsheet):
+        with pytest.raises(ValueError, match="at least one axis"):
+            sweep(flowsheet, [], {"product": product})
+
+    def test_no_outputs_is_refused(self, flowsheet):
+        with pytest.raises(ValueError, match="at least one output"):
+            sweep(flowsheet, [SweepAxis("reactor.V", 1.0, 2.0)], {})
+
+    def test_a_degenerate_axis_is_refused(self):
+        with pytest.raises(ValueError, match="at least 2 points"):
+            SweepAxis("reactor.V", 1.0, 2.0, n=1)
+        with pytest.raises(ValueError, match="hi must exceed lo"):
+            SweepAxis("reactor.V", 2.0, 1.0)
+
+
+# =============================================================================
+# The page
+# =============================================================================
+
+
+@pytest.fixture(scope="module")
+def page(flowsheet):
+    result = sweep(
+        flowsheet,
+        [SweepAxis("reactor.V", 0.5, 3.0, n=5, label="Volume", units="m^3")],
+        {"Product": product}, units={"Product": "mol/s"},
+    )
+    return to_html(result, title="Test model", description="A description.")
+
+
+class TestPage:
+    def test_is_self_contained(self, page):
+        """No network at run time: nothing to rot next to a paper."""
+        for pattern in ("http://", "https://", "<script src", "<link "):
+            assert pattern not in page, f"page reaches out via {pattern!r}"
+
+    def test_carries_the_grid(self, page):
+        assert '"Product"' in page
+        assert "Volume" in page
+        assert "m^3" in page
+
+    def test_has_the_interactive_pieces(self, page):
+        assert 'id="sliders"' in page
+        assert 'id="chart"' in page
+        assert 'id="readout"' in page
+        assert "function interp" in page
+
+    def test_title_and_description_are_escaped(self, flowsheet):
+        result = sweep(
+            flowsheet, [SweepAxis("reactor.V", 0.5, 3.0, n=3)],
+            {"p": product},
+        )
+        page = to_html(result, title="<script>x</script>", description="a & b")
+        assert "<script>x</script>" not in page.split("<style>")[0]
+        assert "&amp;" in page
+
+    def test_paints_its_own_background(self, page):
+        """A standalone page cannot inherit a host's colours."""
+        assert "background: var(--surface)" in page
+        assert "--surface:" in page
+
+    def test_records_provenance(self, page):
+        assert "Precomputed with difflow" in page
+        assert "solved operating" in page   # wraps in the template
+
+
+class TestPublish:
+    def test_writes_a_file(self, flowsheet, tmp_path):
+        path = publish(
+            flowsheet,
+            [SweepAxis("reactor.V", 0.5, 3.0, n=4)],
+            {"Product": product},
+            tmp_path / "model.html",
+            title="Reactor",
+        )
+        assert path.exists()
+        text = path.read_text()
+        assert text.startswith("<!doctype html>")
+        assert "Reactor" in text
+
+    def test_the_payload_is_valid_json(self, flowsheet):
+        result = sweep(
+            flowsheet, [SweepAxis("reactor.V", 0.5, 3.0, n=4)],
+            {"Product": product},
+        )
+        payload = result.to_dict()
+        restored = json.loads(json.dumps(payload))
+        assert restored["axes"][0]["n"] == 4
+        assert len(restored["outputs"][0]["values"]) == 4
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
The two user-facing halves of #174, on top of #180. Neither replaces writing Python; both remove a reason not to.

Stacked on `claude/declarative-roundtrip` — review #177 → #178 → #179 → #180 first, or read this one's diff alone (`git diff claude/declarative-roundtrip..claude/publish-and-gui`).

## `difflow.publish` — a model that opens with nothing installed

```python
publish(fs,
        axes=[SweepAxis("reactor.V", 0.5, 5.0, n=21, label="Reactor volume", units="m³"),
              SweepAxis("heater.T_out", 320.0, 400.0, n=9, label="Inlet temperature", units="K")],
        outputs={"conversion": lambda s: 1 - s["out"]["F_A"] / 1.0},
        path="model.html", title="Reactor sizing")
```

One self-contained HTML file — no Python, no server, no network, no CDN.

jaxlib has no WebAssembly build, so a browser cannot run the solver. But a *published* model does not need a general one: its topology is fixed and a couple of numbers vary. `sweep` evaluates the grid with `jax.vmap`, records exact derivatives with `jax.grad`, and the page interpolates between the points. The 189-point example above takes a few seconds and produces a 21 KB page.

That trade is stated on the page itself rather than left for the reader to discover — the footer says how many operating points were solved and that values between them are interpolated. It is exact *at* the grid points, only as good as the grid between them, and can vary only what the axes name.

`sweep` is usable on its own when you want the grid as data (`result.values`, `result.gradients`) rather than as a page.

## `difflow.gui` — a local editor

```bash
python -m difflow.gui plant.json
```

A single page on `127.0.0.1` with the installed package doing the solving: a palette of all 75 registered operations with port arity, a topology diagram (recycles dashed, routed under the row), editable parameter fields, **Solve**, **Save**, and a panel showing the generated Python.

Everything is derived from `catalog()`, so plugin units appear with no extra work, and a field the catalog reports as holding code is listed as *set in code* rather than given a text box that could only reject what you type.

Stdlib only (`http.server`) — making difflow depend on a web framework for a development tool would be a poor trade. A failed solve or a rejected edit comes back as `{"ok": false, "error": ...}`, so a bad edit from the browser cannot take the server down. It binds to loopback and is not hardened for network exposure; that is in the module docstring and the docs.

## Two bugs this found in the code it was built against

**`constructor_extras` dropped the first required argument of every constructor**, assuming it was always the `Params` object. It is for 55 registered units — but not for the other 20. `Mixer(species_order)`, `Splitter(species_order)`, `GasPipe(beta)`, `Compressor(ratio)`, `LLEEquilibrium(solutes, aqueous_carrier, organic_carrier)` and the rest of the gas plugin all lost a required argument and could not be rebuilt from their own JSON. It now drops that argument only when it really is the `Params`, decided from the parameter's name and annotation rather than its position.

While fixing it I confirmed the adjacent limitation is real but separate, and documented it rather than widening the change: only *required* constructor arguments are carried, so an optional object left at its default (`Mixer`'s `thermo`, `Flash`'s `eos`) is not written by either format. Pass it back with `extras=` when it matters.

**Non-finite floats broke the editor on the common case.** Python's `json` writes `inf` as the bare token `Infinity`, which `JSON.parse` refuses outright — and `mass_action_kinetics` puts `inf` in `K_eq` for *every irreversible reaction*, so the very first flowsheet I opened failed to load. Those values now travel as the strings `"Infinity"` / `"-Infinity"` / `"NaN"` and are restored on the way back, with `allow_nan=False` on the writer so a future leak fails loudly at the server instead of silently in the browser.

## Verification

- `tests/test_publish.py` — 18 tests; `tests/test_gui.py` — 24 tests. Both green.
- Full suite green: 1050 core + 499 plugin tests, no regressions from the `constructor_extras` fix. (The suite aborts partway when run as one process — an XLA OOM in `test_heat_exchanger.py`, which passes on its own; it is a container memory limit, not a regression, so it was run in six chunks.)
- Both pages rendered in headless Chromium: zero console errors, sliders and Solve both drive their readouts, the diagram draws the recycle as a dashed loop, and the Python panel shows the hoisted `mass_action_kinetics` call.
- The docs example was executed exactly as written; conversion rises monotonically in both volume and temperature.

Docs: two sections in `docs/streams-and-flowsheets.md`, and `CLAUDE.md` updated.

---
_Generated by [Claude Code](https://claude.ai/code/session_0115wVXe4gdrijT1yvb6YjcM)_