### PR TITLE
feat(gui): add units from the palette and edit stream names

### DIFF
--- a/src/difflow/catalog.py
+++ b/src/difflow/catalog.py
@@ -130,6 +130,9 @@ class OperationSchema(ParamsMixin):
         ports: stream connectivity.
         parameters: the ``Params`` fields.
         params_class: name of the ``Params`` dataclass, if one was found.
+        constructor_extras: constructor arguments the class requires
+            besides its ``Params`` --- a ``thermo``, an ``eos``. These
+            are objects, so a front end cannot supply them.
     """
 
     name: str
@@ -142,11 +145,26 @@ class OperationSchema(ParamsMixin):
     ports: PortSpec = field(default_factory=PortSpec)
     parameters: list[ParameterSpec] = field(default_factory=list)
     params_class: str | None = None
+    constructor_extras: list[str] = field(default_factory=list)
 
     @property
     def is_declarative(self) -> bool:
         """Whether every parameter is data a form could supply."""
         return not any(p.is_callable for p in self.parameters)
+
+    @property
+    def is_buildable(self) -> bool:
+        """Whether a form could construct this operation unaided.
+
+        Weaker than :attr:`is_declarative`, and deliberately so: an
+        *optional* callable left at its default is no obstacle to
+        building the unit, only to filling that one field. What blocks
+        a form is a required callable, or a constructor argument that
+        is an object rather than data.
+        """
+        return not self.constructor_extras and not any(
+            p.required and p.is_callable for p in self.parameters
+        )
 
     @property
     def callable_parameters(self) -> list[str]:
@@ -168,6 +186,8 @@ class OperationSchema(ParamsMixin):
             "equations": list(self.equations),
             "params_class": self.params_class,
             "declarative": self.is_declarative,
+            "constructor_extras": list(self.constructor_extras),
+            "buildable": self.is_buildable,
             "ports": {
                 "inlets": list(self.ports.inlets),
                 "n_inlets": self.ports.n_inlets,
@@ -338,6 +358,8 @@ def describe_class(
     Works on any class, registered or not, which is what makes it
     usable on a plugin's units before they are wired in.
     """
+    from difflow.serialize import constructor_extras
+
     params_cls = _params_class(cls)
     doc = (description or cls.__doc__ or "").strip()
     return OperationSchema(
@@ -351,6 +373,7 @@ def describe_class(
         ports=_ports(cls),
         parameters=_parameters(params_cls),
         params_class=params_cls.__name__ if params_cls else None,
+        constructor_extras=constructor_extras(cls),
     )
 
 

--- a/src/difflow/gui.py
+++ b/src/difflow/gui.py
@@ -14,6 +14,17 @@ leaving the door open: the editor exports the model as a script
 (:mod:`difflow.codegen`) or as JSON (:mod:`difflow.serialize`), and
 reads JSON back. An editor you can only enter is worse than none.
 
+Units are added by clicking the palette, and streams are wired by
+naming them: an outlet names a stream, and an inlet chooses one that
+something already produces. Renaming a stream follows it to every
+consumer, so the wiring survives the edit.
+
+What the palette cannot add, it says so about rather than failing
+later. Roughly half the catalog needs something no form can supply ---
+a ``thermo`` object, a rate law --- and those entries are dimmed with
+the reason (:attr:`~difflow.catalog.OperationSchema.is_buildable`).
+For them the route is still Python, then JSON, then here.
+
 Everything comes from :mod:`difflow.catalog`, so the palette lists
 whatever is registered, plugins included, with the ports and parameter
 schema each unit actually declares.
@@ -345,6 +356,29 @@ _PAGE = """<!doctype html>
   .unit td:first-child { width:14rem; }
   .unit .units { color:var(--ink-soft); font-size:.72rem; }
   .code-fields { margin:.5rem 0 0; }
+  .op.add { cursor:pointer; width:100%; text-align:left; border:none;
+    background:none; font:inherit; font-size:.82rem; }
+  .op.add:hover { background:var(--panel); }
+  .op.blocked { opacity:.45; }
+  .wiring { display:grid; grid-template-columns:auto 1fr; gap:.3rem .5rem;
+    align-items:start; margin:.4rem 0 .6rem; font-size:.78rem; }
+  .wiring .lbl { color:var(--ink-soft); padding-top:.2rem; }
+  .row { display:flex; flex-wrap:wrap; gap:.3rem; align-items:center; }
+  select { font:inherit; font-size:.78rem; padding:.15rem .3rem;
+    border:1px solid var(--line); border-radius:4px; background:var(--surface);
+    color:var(--ink); }
+  select.bad, input.bad { border-color:var(--bad); background:#fbeeee; }
+  input.sname { width:8.5rem; font-size:.78rem; }
+  input.uname { font:inherit; font-size:.88rem; font-weight:650; width:12rem;
+    border:1px solid transparent; background:none; padding:.1rem .2rem;
+    border-radius:4px; }
+  input.uname:hover, input.uname:focus { border-color:var(--line);
+    background:var(--surface); }
+  .unit .rm { float:right; font-size:.72rem; padding:.1rem .45rem; }
+  .tiny { font-size:.72rem; padding:.1rem .4rem; }
+  .status.warn { background:#fdf6e8; color:#8a6100; border:1px solid #f0e2c2; }
+  .status ul { margin:.3rem 0 0; padding-left:1.1rem; }
+  .feeds { margin-bottom:.8rem; }
   .status { font-size:.8rem; padding:.4rem .6rem; border-radius:6px;
     margin-bottom:.7rem; }
   .status.err { background:#fbeeee; color:var(--bad);
@@ -379,6 +413,7 @@ _PAGE = """<!doctype html>
     <div id="status"></div>
     <svg id="diagram" viewBox="0 0 600 220" width="100%"
          role="img" aria-label="Flowsheet topology"></svg>
+    <div class="feeds" id="feeds"></div>
     <div id="units"></div>
   </section>
 
@@ -390,6 +425,8 @@ _PAGE = """<!doctype html>
 
 <script>
 let DOC = null, CATALOG = {};
+/* whether the server holds the flowsheet now on screen */
+let SYNCED = true, LAST_ERROR = "";
 
 const api = {
   get: p => fetch(p).then(r => r.json()),
@@ -407,41 +444,220 @@ function status(msg, kind) {
     msg ? '<div class="status ' + kind + '">' + msg + '</div>' : "";
 }
 
+/* ---- the document, as the browser holds it ------------------------ */
+/* Two kinds of name live in a flowsheet and they behave differently. A
+   *unit* name only labels a box. A *stream* name is the wiring: it is
+   how an outlet reaches the inlet that consumes it. So renaming a
+   stream has to travel -- to every consumer and to any recycle that
+   mentions it -- or the rename quietly disconnects the flowsheet. */
+function fsheet() { return DOC && DOC.flowsheet; }
+
+function esc(s) {
+  return String(s).replace(/[&<>"]/g, c =>
+    ({"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;"}[c]));
+}
+
+/* stream name -> a phrase naming whatever produces it */
+function producers() {
+  const f = fsheet(), out = {};
+  if (!f) return out;
+  Object.keys(f.feeds).forEach(n => out[n] = "feed " + n);
+  f.units.forEach(u => u.outlets.forEach(o => out[o] = "unit " + u.name));
+  /* a recycle republishes a stream under a second name, so the
+     destination is produced even though no outlet is called that */
+  Object.entries(f.recycles || {}).forEach(([src, dest]) => {
+    if (out[src] !== undefined) out[dest] = out[src];
+  });
+  return out;
+}
+function streamNames() { return Object.keys(producers()); }
+
+function renameStream(from, to) {
+  const f = fsheet();
+  if (!f || !to || from === to) return false;
+  if (streamNames().includes(to)) return false;
+  /* rebuilt, not mutated: the key order of feeds is the display order */
+  const feeds = {};
+  Object.entries(f.feeds).forEach(([k, v]) => feeds[k === from ? to : k] = v);
+  f.feeds = feeds;
+  f.units.forEach(u => {
+    u.inlets = u.inlets.map(s => s === from ? to : s);
+    u.outlets = u.outlets.map(s => s === from ? to : s);
+  });
+  const rec = {};
+  Object.entries(f.recycles || {}).forEach(([src, dest]) =>
+    rec[src === from ? to : src] = (dest === from ? to : dest));
+  f.recycles = rec;
+  return true;
+}
+
+/* ---- adding a unit ------------------------------------------------ */
+/* The catalog reports required fields but renders their defaults as
+   strings, so a seed is chosen from the declared type instead. It only
+   has to be the right *kind* of thing -- the point is a unit that
+   constructs, with the numbers left visibly wrong for editing. */
+function seedValue(p) {
+  const t = (p.type || "").toLowerCase();
+  if (p.name === "species_order") return (fsheet().species_order || []).slice();
+  if (p.is_callable) return null;
+  if (t.includes("list") || t.includes("tuple") || t.includes("sequence")) return [];
+  if (t.includes("dict") || t.includes("mapping")) return {};
+  if (t.includes("bool")) return false;
+  if (t.includes("float") || t.includes("int")) return 1.0;
+  if (t.includes("str")) return "";
+  return null;                       /* an Array, or something unread */
+}
+function seedParams(spec) {
+  const out = {};
+  (spec.parameters || []).forEach(p => { if (p.required) out[p.name] = seedValue(p); });
+  return out;                        /* optional fields: let the dataclass decide */
+}
+
+function uniqueUnitName(base) {
+  const taken = new Set(fsheet().units.map(u => u.name));
+  if (!taken.has(base)) return base;
+  for (let i = 2; ; i++) if (!taken.has(base + i)) return base + i;
+}
+
+/* the last stream nothing reads yet -- bolting a unit onto the end of
+   the flowsheet is the common case, and it should need no wiring */
+function freeStream() {
+  const consumed = new Set();
+  fsheet().units.forEach(u => u.inlets.forEach(s => consumed.add(s)));
+  const free = streamNames().filter(s => !consumed.has(s));
+  return free.length ? free[free.length - 1] : "";
+}
+
+function newUnit(opName) {
+  const spec = CATALOG[opName], ports = spec.ports || {};
+  const name = uniqueUnitName(opName.toLowerCase());
+  const nOut = ports.n_outlets === null || ports.n_outlets === undefined
+    ? 1 : ports.n_outlets;
+  const outlets = nOut === 1 ? [name + "_out"]
+    : Array.from({length: nOut}, (unused, i) => name + "_out" + (i + 1));
+  const nIn = ports.variadic ? 1 : (ports.n_inlets || 1);
+  const inlets = Array.from({length: nIn}, (unused, i) => i === 0 ? freeStream() : "");
+  return {name: name, operation: opName, params: seedParams(spec),
+          constructor: {}, extra_params: {}, inlets: inlets, outlets: outlets};
+}
+
+async function addUnit(opName) {
+  if (!fsheet()) { status("No flowsheet loaded.", "err"); return; }
+  fsheet().units.push(newUnit(opName));
+  /* on success reload: the server writes back every default the Params
+     dataclass filled in, which is what makes them editable here */
+  if (await push()) await reload();
+  render();
+}
+
+async function removeUnit(ui) {
+  fsheet().units.splice(ui, 1);
+  await push();
+  render();
+}
+
+async function renameUnit(ui, name) {
+  const f = fsheet();
+  name = name.trim();
+  if (name && !f.units.some((u, i) => i !== ui && u.name === name)) {
+    f.units[ui].name = name;
+    await push();
+  }
+  render();
+}
+
+/* ---- what is wrong with it ---------------------------------------- */
+/* Faults the server cannot see. It rebuilds a flowsheet with a dangling
+   inlet quite happily; only the solve fails, as a bare KeyError naming
+   a stream. Saying so before Solve is pressed is cheaper. */
+function problems() {
+  const f = fsheet();
+  if (!f) return [];
+  const out = [], known = streamNames(), seen = {}, named = new Set();
+  Object.keys(f.feeds).forEach(n => seen[n] = "feed " + n);
+  f.units.forEach(u => {
+    if (named.has(u.name)) out.push("two units are named " + u.name);
+    named.add(u.name);
+    u.inlets.forEach(s => {
+      if (!s) out.push(u.name + " has an inlet connected to nothing");
+      else if (!known.includes(s))
+        out.push(u.name + " reads " + s + ", which nothing produces");
+    });
+    u.outlets.forEach(s => {
+      if (!s) out.push(u.name + " has an unnamed outlet");
+      else if (seen[s])
+        out.push(s + " is produced by both " + seen[s] + " and unit " + u.name);
+      else seen[s] = "unit " + u.name;
+    });
+  });
+  return out;
+}
+
+function showProblems() {
+  if (!SYNCED) {
+    status("The model rejected that edit, and is still running the " +
+           "previous version: " + esc(LAST_ERROR), "err");
+    return;
+  }
+  const ps = problems();
+  status(ps.length ? "<strong>Not ready to solve</strong><ul>" +
+    ps.map(p => "<li>" + esc(p) + "</li>").join("") + "</ul>" : "", "warn");
+}
+
 /* ---- palette ------------------------------------------------------ */
+function blockedReason(s) {
+  const extras = s.constructor_extras || [];
+  const calls = (s.parameters || [])
+    .filter(p => p.required && p.is_callable).map(p => p.name);
+  const parts = [];
+  if (extras.length) parts.push(
+    (extras.length > 1 ? "the objects " : "the object ") + extras.join(", "));
+  if (calls.length) parts.push("code for " + calls.join(", "));
+  return s.name + " cannot be built from a form: it needs " +
+    parts.join(" and ") + ". Build it in Python, save the JSON, open it here.";
+}
+
 function renderPalette() {
   const groups = {};
   Object.values(CATALOG).forEach(s => (groups[s.category] ||= []).push(s));
   const el = document.getElementById("palette");
-  el.innerHTML = Object.keys(groups).sort().map(cat =>
-    '<div class="cat"><div class="cat-name">' + cat.replace(/_/g, " ") + '</div>' +
-    groups[cat].sort((a,b)=>a.name.localeCompare(b.name)).map(s => {
-      const p = s.ports;
-      const arity = (p.variadic ? "n" : p.n_inlets) + "&rarr;" +
-                    (p.n_outlets === null ? "?" : p.n_outlets);
-      return '<div class="op" title="' + (s.description || "").replace(/"/g,"") +
-             '"><span class="nm">' + s.name + '</span>' +
-             '<span class="ports">' + arity + '</span></div>';
-    }).join("") + '</div>'
-  ).join("");
+  el.innerHTML =
+    '<div class="hint">Click to add. Dimmed units need an object or a ' +
+    'function that only Python can supply.</div>' +
+    Object.keys(groups).sort().map(cat =>
+      '<div class="cat"><div class="cat-name">' + cat.replace(/_/g, " ") + '</div>' +
+      groups[cat].sort((a, b) => a.name.localeCompare(b.name)).map(s => {
+        const p = s.ports;
+        const arity = (p.variadic ? "n" : p.n_inlets) + "&rarr;" +
+                      (p.n_outlets === null ? "?" : p.n_outlets);
+        return '<button class="op add' + (s.buildable ? "" : " blocked") + '"' +
+               (s.buildable ? "" : " disabled") +
+               ' data-op="' + esc(s.name) + '" title="' +
+               esc(s.buildable ? (s.description || s.name) : blockedReason(s)) +
+               '"><span class="nm">' + esc(s.name) + '</span>' +
+               '<span class="ports">' + arity + '</span></button>';
+      }).join("") + '</div>'
+    ).join("");
+  el.querySelectorAll("button.add:not(.blocked)").forEach(b =>
+    b.addEventListener("click", () => addUnit(b.dataset.op)));
 }
 
 /* ---- diagram ------------------------------------------------------ */
 function renderDiagram() {
   const svg = document.getElementById("diagram");
-  if (!DOC || !DOC.flowsheet) { svg.innerHTML = ""; return; }
-  const fsheet = DOC.flowsheet;
-  const units = fsheet.units, feeds = Object.keys(fsheet.feeds);
-  const nodes = feeds.map(f => ({id:f, kind:"feed", label:f}))
-    .concat(units.map(u => ({id:u.name, kind:"unit", label:u.name, op:u.operation})));
+  const f = fsheet();
+  if (!f) { svg.innerHTML = ""; return; }
+  const units = f.units, feeds = Object.keys(f.feeds);
+  const nodes = feeds.map(n => ({id: n, kind: "feed", label: n}))
+    .concat(units.map(u => ({id: u.name, kind: "unit", label: u.name, op: u.operation})));
 
   /* A unit's inlets name *streams*, not nodes. Resolve each to whoever
      produces it -- a feed of the same name, or the unit that lists it
      as an outlet -- or the edge is silently dropped. */
   const producer = {};
-  feeds.forEach(f => producer[f] = f);
+  feeds.forEach(n => producer[n] = n);
   units.forEach(u => u.outlets.forEach(o => producer[o] = u.name));
-  /* a recycle maps a source stream onto the destination stream name */
-  const recycles = fsheet.recycles || {};
+  const recycles = f.recycles || {};
   Object.entries(recycles).forEach(([src, dest]) => {
     if (producer[src] !== undefined) producer[dest] = producer[src];
   });
@@ -487,69 +703,187 @@ function renderDiagram() {
       '" height="32" rx="7" fill="' + (feed ? "#2a78d6" : "#fcfcfb") +
       '" stroke="' + (feed ? "#2a78d6" : "#52514e") + '" stroke-width="1.2"/>');
     out.push('<text x="' + x + '" y="' + (y+4) + '" text-anchor="middle" fill="' +
-      (feed ? "#fff" : "#0b0b0b") + '">' + n.label + '</text>');
+      (feed ? "#fff" : "#0b0b0b") + '">' + esc(n.label) + '</text>');
     if (n.op) out.push('<text x="' + x + '" y="' + (y+28) +
-      '" text-anchor="middle" fill="#52514e" font-size="10">' + n.op + '</text>');
+      '" text-anchor="middle" fill="#52514e" font-size="10">' + esc(n.op) + '</text>');
   });
   svg.innerHTML = out.join("");
 }
 
-/* ---- units + editable parameters ---------------------------------- */
+/* ---- feeds --------------------------------------------------------- */
+/* Only the names are editable here. A feed's composition is a stream,
+   which the right-hand table already shows; renaming is what the
+   wiring needs, because a feed name *is* a stream name. */
+function renderFeeds() {
+  const f = fsheet(), el = document.getElementById("feeds");
+  if (!f) { el.innerHTML = ""; return; }
+  const names = Object.keys(f.feeds);
+  el.innerHTML = '<h2>Feed streams</h2>' + (names.length
+    ? '<div class="row">' + names.map(n =>
+        '<input class="sname" data-feed="' + esc(n) + '" value="' + esc(n) + '">'
+      ).join("") + '</div>'
+    : '<div class="hint">none; add one in Python</div>');
+  el.querySelectorAll("input[data-feed]").forEach(inp =>
+    inp.addEventListener("change", async e => {
+      if (renameStream(e.target.dataset.feed, e.target.value.trim())) await push();
+      render();
+    }));
+}
+
+/* ---- units: wiring and parameters ---------------------------------- */
 function renderUnits() {
   const el = document.getElementById("units");
-  if (!DOC || !DOC.flowsheet) { el.innerHTML = "<p>No flowsheet loaded.</p>"; return; }
-  el.innerHTML = DOC.flowsheet.units.map((u, ui) => {
+  const f = fsheet();
+  if (!f) { el.innerHTML = "<p>No flowsheet loaded.</p>"; return; }
+  const known = streamNames();
+
+  el.innerHTML = f.units.map((u, ui) => {
     const spec = CATALOG[u.operation] || {};
+    const ports = spec.ports || {};
     /* Fields the catalog reports as callable hold code, not data. An
        empty text box beside one invites typing a value that could only
        be rejected, so they are listed as read-only instead. */
     const byName = {};
     (spec.parameters || []).forEach(p => byName[p.name] = p);
+    const scalar = v => v === null || ["number","string","boolean"].includes(typeof v);
+    const flatList = v => Array.isArray(v) && v.every(scalar);
     const editable = ([k, v]) => !(byName[k] || {}).is_callable &&
-      (v === null || ["number","string","boolean"].includes(typeof v));
+      (scalar(v) || flatList(v));
 
     const rows = Object.entries(u.params).filter(editable).map(([k, v]) => {
-      const units = (byName[k] || {}).units;
-      return '<tr><td>' + k + (units ? ' <span class="units">' + units +
-        '</span>' : "") + '</td><td><input type="text" data-unit="' + ui +
-        '" data-key="' + k + '" value="' + (v === null ? "" : v) + '"></td></tr>';
+      const meta = byName[k] || {};
+      const shown = Array.isArray(v) ? v.join(", ") : (v === null ? "" : v);
+      const blank = shown === "" || (Array.isArray(v) && !v.length);
+      return '<tr><td>' + esc(k) + (meta.units ? ' <span class="units">' +
+        esc(meta.units) + '</span>' : "") + '</td><td><input type="text"' +
+        (meta.required && blank ? ' class="bad"' : "") +
+        ' data-unit="' + ui + '" data-key="' + esc(k) + '"' +
+        (Array.isArray(v) ? ' data-list="1"' : "") +
+        ' value="' + esc(shown) + '"></td></tr>';
     }).join("");
 
+    const inlets = u.inlets.map((s, i) => {
+      const bad = !known.includes(s);
+      const opts = ['<option value="">(not connected)</option>'].concat(
+        known.filter(n => !u.outlets.includes(n)).map(n =>
+          '<option value="' + esc(n) + '"' + (n === s ? " selected" : "") + '>' +
+          esc(n) + '</option>'));
+      if (s && bad) opts.push('<option value="' + esc(s) + '" selected>' +
+        esc(s) + ' (missing)</option>');
+      return '<select data-unit="' + ui + '" data-inlet="' + i + '"' +
+        (bad ? ' class="bad"' : "") + '>' + opts.join("") + '</select>';
+    }).join("");
+
+    const variadic = ports.variadic
+      ? '<button class="tiny" data-addin="' + ui + '" title="another inlet">+</button>' +
+        (u.inlets.length > 1
+          ? '<button class="tiny" data-delin="' + ui + '">&minus;</button>' : "")
+      : "";
+
+    const outlets = u.outlets.map((s, i) =>
+      '<input class="sname' + (s ? "" : " bad") + '" data-unit="' + ui +
+      '" data-outlet="' + i + '" value="' + esc(s) + '">').join("");
+
     const code = Object.keys(u.params).filter(k => (byName[k] || {}).is_callable);
-    return '<div class="unit"><h3>' + u.name + '</h3>' +
-      '<div class="meta">' + u.operation +
-      ' &nbsp;·&nbsp; ' + u.inlets.join(", ") + ' &rarr; ' + u.outlets.join(", ") +
-      (spec.description ? ' &nbsp;·&nbsp; ' + spec.description : "") + '</div>' +
+    return '<div class="unit">' +
+      '<button class="rm" data-rm="' + ui + '">Remove</button>' +
+      '<h3><input class="uname" data-uname="' + ui + '" value="' + esc(u.name) +
+      '" title="unit name"></h3>' +
+      '<div class="meta">' + esc(u.operation) +
+      (spec.description ? ' &nbsp;·&nbsp; ' + esc(spec.description) : "") + '</div>' +
+      '<div class="wiring">' +
+      '<span class="lbl">in</span><span class="row">' +
+      (inlets || '<span class="hint">none</span>') + variadic + '</span>' +
+      '<span class="lbl">out</span><span class="row">' +
+      (outlets || '<span class="hint">none</span>') + '</span></div>' +
       (rows ? '<table><tbody>' + rows + '</tbody></table>'
             : '<div class="meta">no editable parameters</div>') +
       (code.length ? '<div class="meta code-fields">set in code: ' +
-        code.join(", ") + '</div>' : "") + '</div>';
+        esc(code.join(", ")) + '</div>' : "") + '</div>';
   }).join("");
 
   el.querySelectorAll("input[data-key]").forEach(inp =>
-    inp.addEventListener("change", e => {
-      const u = DOC.flowsheet.units[+e.target.dataset.unit];
+    inp.addEventListener("change", async e => {
+      const u = f.units[+e.target.dataset.unit];
       const raw = e.target.value.trim();
-      const n = Number(raw);
-      /* isFinite, not !isNaN: JSON.stringify writes Infinity as null,
-         so a non-finite value has to travel back as the string the
-         server sent, which it knows how to restore. */
-      u.params[e.target.dataset.key] =
-        raw === "" ? null : (isFinite(n) && raw !== "" ? n : raw);
-      push();
+      if (e.target.dataset.list) {
+        const parts = raw === "" ? [] : raw.split(",").map(x => x.trim());
+        const nums = parts.map(Number);
+        /* a list of numbers must not arrive as a list of strings */
+        u.params[e.target.dataset.key] =
+          parts.length && nums.every(n => isFinite(n)) ? nums : parts;
+      } else {
+        const n = Number(raw);
+        /* isFinite, not !isNaN: JSON.stringify writes Infinity as null,
+           so a non-finite value has to travel back as the string the
+           server sent, which it knows how to restore. */
+        u.params[e.target.dataset.key] =
+          raw === "" ? null : (isFinite(n) && raw !== "" ? n : raw);
+      }
+      await push();
+      render();
+    }));
+
+  el.querySelectorAll("select[data-inlet]").forEach(sel =>
+    sel.addEventListener("change", async e => {
+      f.units[+e.target.dataset.unit].inlets[+e.target.dataset.inlet] = e.target.value;
+      await push();
+      render();
+    }));
+
+  el.querySelectorAll("input[data-outlet]").forEach(inp =>
+    inp.addEventListener("change", async e => {
+      const u = f.units[+e.target.dataset.unit];
+      if (renameStream(u.outlets[+e.target.dataset.outlet], e.target.value.trim()))
+        await push();
+      render();
+    }));
+
+  el.querySelectorAll("input[data-uname]").forEach(inp =>
+    inp.addEventListener("change", e => renameUnit(+e.target.dataset.uname, e.target.value)));
+
+  el.querySelectorAll("button[data-rm]").forEach(b =>
+    b.addEventListener("click", () => removeUnit(+b.dataset.rm)));
+
+  el.querySelectorAll("button[data-addin]").forEach(b =>
+    b.addEventListener("click", async () => {
+      f.units[+b.dataset.addin].inlets.push("");
+      await push();
+      render();
+    }));
+
+  el.querySelectorAll("button[data-delin]").forEach(b =>
+    b.addEventListener("click", async () => {
+      f.units[+b.dataset.delin].inlets.pop();
+      await push();
+      render();
     }));
 }
 
+function render() { renderDiagram(); renderFeeds(); renderUnits(); showProblems(); }
+
+/* ---- talking to the model ------------------------------------------ */
+/* A rejected edit leaves the server running the *previous* flowsheet
+   while the browser shows the new one. Solving then would report
+   numbers for a model that is not on screen, so the flag gates it. */
 async function push() {
-  const r = await api.post("/api/flowsheet", DOC.flowsheet);
-  status(r.ok ? "" : (r.error || "rejected"), "err");
+  const r = await api.post("/api/flowsheet", fsheet());
+  SYNCED = !!r.ok;
+  LAST_ERROR = r.ok ? "" : (r.error || "rejected");
+  return SYNCED;
+}
+
+async function reload() {
+  DOC = await api.get("/api/flowsheet");
+  document.getElementById("path").textContent = DOC.path || "(unsaved)";
 }
 
 /* ---- right panel --------------------------------------------------- */
 async function showStreams() {
+  if (!SYNCED || problems().length) { showProblems(); return; }
   document.getElementById("rightTitle").textContent = "Streams";
   const r = await api.post("/api/solve");
-  if (!r.ok) { status(r.error, "err"); document.getElementById("right").innerHTML = "";
+  if (!r.ok) { status(esc(r.error), "err"); document.getElementById("right").innerHTML = "";
                return; }
   status("Solved" + (r.iterations != null ? " in " + r.iterations + " iterations" : ""), "ok");
   const names = Object.keys(r.streams);
@@ -569,7 +903,7 @@ async function showCode() {
   document.getElementById("rightTitle").textContent = "Python";
   const r = await api.get("/api/code");
   document.getElementById("right").innerHTML = r.error
-    ? '<div class="status err">' + r.error + '</div>'
+    ? '<div class="status err">' + esc(r.error) + '</div>'
     : "<pre>" + r.source.replace(/[&<>]/g, c =>
         ({"&":"&amp;","<":"&lt;",">":"&gt;"}[c])) + "</pre>";
 }
@@ -579,14 +913,14 @@ document.getElementById("solve").addEventListener("click", showStreams);
 document.getElementById("showcode").addEventListener("click", showCode);
 document.getElementById("save").addEventListener("click", async () => {
   const r = await api.post("/api/save");
-  status(r.ok ? "Saved to " + r.path : r.error, r.ok ? "ok" : "err");
+  status(r.ok ? "Saved to " + esc(r.path) : esc(r.error), r.ok ? "ok" : "err");
 });
 
 (async function start() {
   CATALOG = await api.get("/api/catalog");
-  DOC = await api.get("/api/flowsheet");
-  document.getElementById("path").textContent = DOC.path || "(unsaved)";
-  renderPalette(); renderDiagram(); renderUnits();
+  await reload();
+  renderPalette();
+  render();
 })();
 </script>
 </body>

--- a/src/difflow/serialize.py
+++ b/src/difflow/serialize.py
@@ -478,16 +478,27 @@ def _build_operation(cls: type, encoded_params: dict, unit_name: str,
             f"on load, e.g. extras={{{unit_name!r}: {{{missing[0]!r}: ...}}}}."
         )
 
+    params_cls = _params_class(cls)
+
     if not encoded_params:
         try:
+            # units that take no Params at all: Mixer, GasPipe
             return cls(**extras)
         except TypeError as exc:
+            # A Params class whose fields all carry defaults is still
+            # constructible from nothing, and "no parameters written"
+            # means exactly that -- which is the state a unit is in the
+            # moment difflow.gui adds it to a flowsheet.
+            if params_cls is not None:
+                try:
+                    return cls(params_cls(), **extras)
+                except TypeError:
+                    pass
             raise SerializationError(
                 f"unit {unit_name!r}: {cls.__name__} needs parameters, but "
                 f"none were written ({exc})."
             ) from exc
 
-    params_cls = _params_class(cls)
     if params_cls is None:
         raise SerializationError(
             f"unit {unit_name!r}: cannot find the Params class for "

--- a/tests/js/checks.js
+++ b/tests/js/checks.js
@@ -1,0 +1,104 @@
+/* Assertions over the editor's model functions. See harness.js. */
+require(process.env.HARNESS);
+const T = globalThis.T;
+let fails = 0;
+const eq = (label, got, want) => {
+  const a = JSON.stringify(got), b = JSON.stringify(want);
+  if (a !== b) { console.log("FAIL " + label + "\n  got  " + a + "\n  want " + b); fails++; }
+  else console.log("ok   " + label);
+};
+
+const doc = () => ({flowsheet: {
+  species_order: ["water", "ethanol"],
+  feeds: {feed: {F_water: 1.0, T: 350.0}},
+  units: [
+    {name:"reactor", operation:"CSTR", params:{}, inlets:["feed"], outlets:["rx"]},
+    {name:"flash", operation:"Flash", params:{}, inlets:["rx"], outlets:["liq","vap"]},
+  ],
+  recycles: {},
+}});
+T.setCAT({
+  Heater: {name:"Heater", ports:{inlets:["s"], n_inlets:1, n_outlets:1, variadic:false},
+           parameters:[{name:"T_out", type:"jax.Array | float | None", required:false}]},
+  Mixer:  {name:"Mixer", ports:{inlets:[], n_inlets:null, n_outlets:1, variadic:true},
+           parameters:[{name:"species_order", type:"list[str]", required:true}]},
+  PSAUnit:{name:"PSAUnit", ports:{inlets:["s"], n_inlets:1, n_outlets:2, variadic:false},
+           parameters:[{name:"adsorbent", type:"str", required:true},
+                       {name:"n_beds", type:"int", required:true},
+                       {name:"elements", type:"list[str]", required:true},
+                       {name:"tol", type:"float", required:false}]},
+});
+
+/* --- producers and stream names --- */
+T.setDOC(doc());
+eq("streams are feeds plus outlets", T.streamNames(), ["feed","rx","liq","vap"]);
+eq("free stream is the last thing nothing reads", T.freeStream(), "vap");
+
+/* --- renaming a stream travels to its consumer --- */
+let d = doc(); T.setDOC(d);
+eq("rename returns true", T.renameStream("rx", "crude"), true);
+eq("outlet renamed", d.flowsheet.units[0].outlets, ["crude"]);
+eq("consumer follows", d.flowsheet.units[1].inlets, ["crude"]);
+
+/* --- renaming a feed keeps it a feed, and the consumer follows --- */
+d = doc(); T.setDOC(d);
+T.renameStream("feed", "charge");
+eq("feed key renamed", Object.keys(d.flowsheet.feeds), ["charge"]);
+eq("feed values kept", d.flowsheet.feeds.charge.F_water, 1.0);
+eq("consumer of the feed follows", d.flowsheet.units[0].inlets, ["charge"]);
+
+/* --- a rename onto an existing name is refused, and changes nothing --- */
+d = doc(); T.setDOC(d);
+eq("collision refused", T.renameStream("rx", "liq"), false);
+eq("nothing moved", d.flowsheet.units[0].outlets, ["rx"]);
+eq("empty name refused", T.renameStream("rx", ""), false);
+
+/* --- a recycle follows the rename too --- */
+d = doc(); d.flowsheet.recycles = {vap: "rx"}; T.setDOC(d);
+T.renameStream("vap", "overhead");
+eq("recycle source follows", d.flowsheet.recycles, {overhead: "rx"});
+d = doc(); d.flowsheet.recycles = {vap: "rx"}; T.setDOC(d);
+T.renameStream("rx", "crude");
+eq("recycle destination follows", d.flowsheet.recycles, {vap: "crude"});
+eq("a recycle destination counts as produced",
+   T.streamNames().includes("crude"), true);
+
+/* --- adding a unit --- */
+d = doc(); T.setDOC(d);
+eq("new unit is wired to the free stream", T.newUnit("Heater"),
+   {name:"heater", operation:"Heater", params:{}, constructor:{},
+    extra_params:{}, inlets:["vap"], outlets:["heater_out"]});
+d.flowsheet.units.push(T.newUnit("Heater"));
+eq("second one gets a distinct name", T.newUnit("Heater").name, "heater2");
+eq("and its own outlet name", T.newUnit("Heater").outlets, ["heater2_out"]);
+
+d = doc(); T.setDOC(d);
+eq("two outlets are numbered", T.newUnit("PSAUnit").outlets,
+   ["psaunit_out1", "psaunit_out2"]);
+eq("required params are seeded by type", T.newUnit("PSAUnit").params,
+   {adsorbent: "", n_beds: 1.0, elements: []});
+eq("a variadic unit starts with one inlet", T.newUnit("Mixer").inlets, ["vap"]);
+eq("species_order is seeded from the flowsheet", T.newUnit("Mixer").params,
+   {species_order: ["water", "ethanol"]});
+
+/* --- problems --- */
+d = doc(); T.setDOC(d);
+eq("a sound flowsheet has no problems", T.problems(), []);
+d = doc(); d.flowsheet.units[1].inlets = ["ghost"]; T.setDOC(d);
+eq("a dangling inlet is named", T.problems(),
+   ["flash reads ghost, which nothing produces"]);
+d = doc(); d.flowsheet.units[1].inlets = [""]; T.setDOC(d);
+eq("an unconnected inlet is named", T.problems(),
+   ["flash has an inlet connected to nothing"]);
+d = doc(); d.flowsheet.units[1].outlets = ["rx", "vap"]; T.setDOC(d);
+eq("two producers of one stream is a problem", T.problems(),
+   ["rx is produced by both unit reactor and unit flash"]);
+d = doc(); d.flowsheet.units[1].name = "reactor"; T.setDOC(d);
+eq("a duplicate unit name is a problem", T.problems()[0],
+   "two units are named reactor");
+
+/* --- escaping --- */
+eq("attribute values are escaped", T.esc('a"b<c&d'), "a&quot;b&lt;c&amp;d");
+
+console.log(fails ? "\n" + fails + " FAILED" : "\nall passed");
+process.exit(fails ? 1 : 0);

--- a/tests/js/harness.js
+++ b/tests/js/harness.js
@@ -1,0 +1,26 @@
+/* Loads difflow.gui's page script with just enough of a browser under
+   it to exercise the pure model functions -- naming, wiring, seeding.
+   Run by tests/test_gui.py, which extracts the script from _PAGE and
+   passes it in PAGE_JS. The rendering is left to the browser; what is
+   checked here is the bookkeeping that would silently disconnect a
+   flowsheet if it were wrong.
+
+   Nothing in difflow needs node. The test that drives this skips when
+   node is not installed.
+*/
+const vm = require("vm");
+const src = require("fs").readFileSync(process.env.PAGE_JS, "utf8");
+
+const noElement = () => ({
+  addEventListener() {}, querySelectorAll: () => [],
+  set innerHTML(v) {}, get innerHTML() { return ""; },
+  textContent: "", setAttribute() {},
+});
+globalThis.document = { getElementById: noElement };
+globalThis.fetch = async () => ({ json: async () => ({ ok: true }) });
+
+vm.runInThisContext(src + `
+;globalThis.T = {renameStream, producers, streamNames, newUnit, problems,
+                 seedValue, seedParams, uniqueUnitName, freeStream, esc,
+                 setDOC: d => { DOC = d; }, setCAT: c => { CATALOG = c; }};
+`);

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -177,6 +177,54 @@ class TestParameters:
 
 
 # =============================================================================
+# Buildability
+# =============================================================================
+
+
+class TestBuildability:
+    """What a form --- difflow.gui's palette --- can construct unaided."""
+
+    def test_constructor_extras_are_reported(self, cat):
+        assert cat["Flash"].constructor_extras == ["thermo"]
+        assert cat["Mixer"].constructor_extras == ["species_order"]
+        assert cat["Heater"].constructor_extras == []
+
+    def test_an_object_argument_blocks_building(self, cat):
+        assert not cat["Flash"].is_buildable, "a thermo is not data"
+
+    def test_a_required_callable_blocks_building(self, cat):
+        assert not cat["CSTR"].is_buildable, "a rate law is not data"
+
+    def test_an_optional_callable_does_not_block_building(self, cat):
+        """Weaker than is_declarative, deliberately.
+
+        A field like Flash's optional ``eos`` is no obstacle to building
+        the unit --- only to filling that one field --- so it must not
+        cost the operation its place in the palette.
+        """
+        optional_only = [
+            n for n, s in cat.items()
+            if s.callable_parameters and s.is_buildable
+        ]
+        for name in optional_only:
+            spec = cat[name]
+            assert not [
+                p.name for p in spec.parameters if p.required and p.is_callable
+            ], name
+            assert not spec.is_declarative, name
+
+    def test_a_useful_number_of_operations_are_buildable(self, cat):
+        """A palette that could add almost nothing would not be worth one."""
+        buildable = [n for n, s in cat.items() if s.is_buildable]
+        assert len(buildable) > len(cat) // 2, f"only {len(buildable)} of {len(cat)}"
+
+    def test_buildability_is_in_the_json_payload(self, cat):
+        payload = cat["Flash"].to_dict()
+        assert payload["buildable"] is False
+        assert payload["constructor_extras"] == ["thermo"]
+
+
+# =============================================================================
 # Schema
 # =============================================================================
 

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -13,6 +13,11 @@ as `Infinity`, which the browser refuses to parse.
 """
 
 import json
+import os
+import pathlib
+import re
+import shutil
+import subprocess
 import threading
 import urllib.error
 import urllib.request
@@ -340,6 +345,143 @@ class TestRecycles:
             assert solved["streams"]["hot"]["T"] == pytest.approx(365.0, abs=1e-9)
         finally:
             live.close()
+
+
+# =============================================================================
+# Building: adding units from the palette, and naming streams
+# =============================================================================
+
+
+def heater_unit(name="heater", inlet="liq"):
+    """Exactly the document the page's ``newUnit`` builds for a Heater.
+
+    Written out rather than derived, so that a change to the page which
+    stopped producing this shape would fail here.
+    """
+    return {"name": name, "operation": "Heater", "params": {},
+            "constructor": {}, "extra_params": {},
+            "inlets": [inlet], "outlets": [name + "_out"]}
+
+
+class TestPalette:
+    def test_the_catalog_says_what_a_form_can_build(self, client):
+        """The palette dims what it cannot add; it needs to be told which."""
+        _, catalog = client.get_json("/api/catalog")
+        assert catalog["Heater"]["buildable"]
+        assert not catalog["Flash"]["buildable"], "Flash needs a thermo object"
+        assert catalog["Flash"]["constructor_extras"] == ["thermo"]
+        assert not catalog["CSTR"]["buildable"], "CSTR needs a rate law"
+        assert catalog["CSTR"]["constructor_extras"] == []
+
+    def test_every_buildable_operation_declares_its_ports(self, client):
+        """A unit whose arity is unknown cannot be given outlet names."""
+        _, catalog = client.get_json("/api/catalog")
+        for name, spec in catalog.items():
+            if not spec["buildable"]:
+                continue
+            ports = spec["ports"]
+            assert ports["variadic"] or ports["n_inlets"] is not None, name
+
+
+class TestBuilding:
+    def test_a_unit_added_from_the_palette_reaches_the_model(self, client):
+        _, doc = client.get_json("/api/flowsheet")
+        doc["flowsheet"]["units"].append(heater_unit())
+        status, payload = client.post("/api/flowsheet", doc["flowsheet"])
+        assert status == 200 and payload["ok"]
+        assert [u.name for u in client.session.flowsheet.units] == [
+            "reactor", "flash", "heater"
+        ]
+
+    def test_the_defaults_come_back_so_they_can_be_edited(self, client):
+        """The page reloads after adding; that is where the fields come from.
+
+        A unit is added with no parameters at all, and the Params
+        dataclass fills them in. If they were not written back the new
+        unit would show an empty card and be uneditable.
+        """
+        _, doc = client.get_json("/api/flowsheet")
+        doc["flowsheet"]["units"].append(heater_unit())
+        client.post("/api/flowsheet", doc["flowsheet"])
+
+        _, after = client.get_json("/api/flowsheet")
+        assert set(after["flowsheet"]["units"][-1]["params"]) == {
+            "duty", "T_out", "UA", "T_utility", "Cp"
+        }
+
+    def test_the_added_unit_then_solves(self, client):
+        _, doc = client.get_json("/api/flowsheet")
+        doc["flowsheet"]["units"].append(heater_unit())
+        client.post("/api/flowsheet", doc["flowsheet"])
+
+        _, doc = client.get_json("/api/flowsheet")
+        doc["flowsheet"]["units"][-1]["params"]["T_out"] = 400.0
+        assert client.post("/api/flowsheet", doc["flowsheet"])[1]["ok"]
+
+        _, solved = client.post("/api/solve")
+        assert solved["ok"]
+        assert solved["streams"]["heater_out"]["T"] == pytest.approx(400.0)
+
+    def test_renamed_streams_rewire_the_model(self, client):
+        """What the page's renameStream produces has to solve unchanged."""
+        _, before = client.post("/api/solve")
+        _, doc = client.get_json("/api/flowsheet")
+        units = doc["flowsheet"]["units"]
+        units[0]["outlets"] = ["crude"]        # was rx
+        units[1]["inlets"] = ["crude"]         # the consumer followed
+        assert client.post("/api/flowsheet", doc["flowsheet"])[1]["ok"]
+
+        _, after = client.post("/api/solve")
+        assert after["ok"]
+        assert "rx" not in after["streams"] and "crude" in after["streams"]
+        assert after["streams"]["crude"]["F_ethanol"] == pytest.approx(
+            before["streams"]["rx"]["F_ethanol"]
+        )
+
+    def test_a_dangling_inlet_is_reported_rather_than_raised(self, client):
+        """The page catches this first, but the socket must survive it."""
+        _, doc = client.get_json("/api/flowsheet")
+        doc["flowsheet"]["units"][1]["inlets"] = ["ghost"]
+        assert client.post("/api/flowsheet", doc["flowsheet"])[1]["ok"]
+
+        status, solved = client.post("/api/solve")
+        assert status == 200 and not solved["ok"]
+        assert "ghost" in solved["error"]
+
+
+# =============================================================================
+# The page's own logic
+# =============================================================================
+
+
+class TestPageLogic:
+    """Run the editor's model functions under node.
+
+    Renaming a stream, seeding a new unit and spotting a dangling inlet
+    all happen in the browser, and all of them would break the wiring
+    silently if they were wrong --- the one thing the Python tests
+    above cannot see. node is not a difflow dependency, so this skips
+    when it is absent.
+    """
+
+    def test_the_pages_model_functions_behave(self, tmp_path):
+        node = shutil.which("node")
+        if node is None:
+            pytest.skip("node is not installed")
+
+        script = re.search(r"<script>(.*)</script>", gui._PAGE, re.S)
+        assert script, "the page must carry its script inline"
+        page_js = tmp_path / "page.js"
+        page_js.write_text(script.group(1))
+
+        here = pathlib.Path(__file__).parent / "js"
+        result = subprocess.run(
+            [node, str(here / "checks.js")],
+            env={**os.environ, "HARNESS": str(here / "harness.js"),
+                 "PAGE_JS": str(page_js)},
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why

`difflow.gui` could inspect a flowsheet and retune it, but not build one. The palette was a read-only reference (no click handler), and nothing in the page could add a unit or change how streams were wired. Launched without a file it showed an empty screen with nothing to do, and `Save` returned *"no path was given on startup"*.

## What changed

**Adding units**

- Palette entries are buttons. A click appends a unit with a unique name (`heater`, `heater2`), auto-named outlets (`heater_out`), and its first inlet wired to the last stream nothing consumes — bolting a unit onto the end needs no wiring. The page then reloads, so the defaults the `Params` dataclass filled in are on screen and editable.
- 25 of 60 operations need something no form can supply. Those are dimmed and say which, rather than failing when the edit is pushed:
  > Flash cannot be built from a form: it needs the object thermo. Build it in Python, save the JSON, open it here.

**Wiring**

- Unit name, inlets (a `<select>` over the streams something produces, its own outlets excluded) and outlet names are editable, with `+`/`−` for variadic units like `Mixer` and a Remove button. Feed names too — a feed name *is* a stream name.
- Renaming a stream follows it to every consumer and to any recycle that mentions it. A rename that did not travel would silently disconnect the flowsheet, which is the whole hazard of the feature.
- Wiring faults the server cannot see — a dangling inlet, two units producing one name, duplicate unit names — are reported before Solve rather than arriving as a bare `KeyError` from the solver.

**Three fixes underneath**

1. `catalog.py` — `OperationSchema` gains `constructor_extras` and `is_buildable`. `is_buildable` is deliberately weaker than the existing `is_declarative`: an *optional* callable (the `eos` on Flash) blocks filling one field, not building the unit, and should not cost an operation its place in the palette.
2. `serialize.py:_build_operation` — a unit added with nothing set writes `"params": {}`, which took the "takes no `Params` at all" branch (there for `Mixer`, `GasPipe`) and raised `Heater() missing 1 required argument`. It now falls back to `cls(params_cls(), **extras)` when every field carries a default. Any hand-written JSON with empty params loads too.
3. `gui.py` — a rejected edit left the server running the *previous* flowsheet while the browser showed the new one, so Solve reported numbers for a model that was not on screen. A sync flag gates it.

## Tests

`1657 passed` on the full suite.

- 11 new Python tests: `TestPalette` and `TestBuilding` in `test_gui.py`, `TestBuildability` in `test_catalog.py`.
- The renaming, seeding and fault-finding happen in the browser, and all of them break the wiring silently when wrong — the one thing the Python tests cannot see. `tests/js/` runs 27 assertions over those functions under node, skipped when node is absent. This is a new mechanism for the repo; say if you would rather not carry it.

Chrome automation was not available in this session (extension not connected), so rendering was verified by running the page script under a DOM stub against the live catalog: 60 palette buttons / 25 blocked, cards, selects and diagram all as expected.

## Not in scope

Feeds and `species_order` still have no UI, so `python -m difflow.gui newfile.json` on a path that does not exist remains a dead end — you need an existing JSON to open. Add-feed plus a new-flowsheet form is the remaining piece.

## Unrelated, pre-existing

`tests/test_catalog.py::TestCoreRegistration` has 2 failures on `main`: `difflow_gas` is missing from the installed entry-point metadata although `pyproject.toml:114` declares it, so the editable install is stale. Not touched here; deselected for the full run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NDFhkZkSJmSPDWxzm9HQfz
