### PR TITLE
ci: one interpreter on pull requests, cancel superseded runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,16 +6,43 @@ on:
   pull_request:
     branches: [main, master]
 
+# Superseded pull-request runs are cancelled; pushes to main are not. Pushing
+# three times to a branch used to leave three full matrices running, and only
+# the last one's answer was ever read. Main is left alone so its history has a
+# result for every commit.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   # Fast suite: everything except the `slow` (compile-bound) tests. Those run
   # in the `slow-tests` job below, concurrently, so total coverage is unchanged
   # and wall-clock is max(fast, slow) rather than the sum.
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        # One interpreter on a pull request, all three on main.
+        #
+        # The three jobs run concurrently, so this does not make a pull
+        # request finish sooner -- it costs the same wall-clock as one job.
+        # What it saves is job-minutes, and this being a public repository
+        # those are free. The reason to do it anyway is contention: the three
+        # jobs draw on the same runner pool as every other repository on the
+        # account, and two of them have almost never been the ones to fail.
+        #
+        # Almost, not never, and the exception is the cost of this change.
+        # Over 134 full-matrix runs, three had 3.10 fail while 3.11 passed
+        # (all on main, 2026-07-17/18). Under this split that break would
+        # reach main before anything noticed, because a pull request no
+        # longer runs 3.10 -- merges still run all three, so it is caught one
+        # commit later rather than not at all. If that trade stops being
+        # worth it, delete the condition and keep the list.
+        python-version: >-
+          ${{ fromJSON(github.event_name == 'pull_request'
+              && '["3.11"]' || '["3.10", "3.11", "3.12"]') }}
 
     steps:
       - uses: actions/checkout@v4
@@ -46,6 +73,7 @@ jobs:
   slow-tests:
     name: Slow (compile-bound) tests
     runs-on: ubuntu-latest
+    timeout-minutes: 45
 
     steps:
       - uses: actions/checkout@v4
@@ -71,6 +99,7 @@ jobs:
   test-minimal:
     name: Test minimal install
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Fourth of four. **This one saves no minutes** — `differentiable-flowsheets` is public, so its standard runners bill nothing against the 3,000. It buys runner contention, a cancellation policy, and a cap on a failure mode. Merge it on those grounds or not at all.

## Where the 3,000 actually goes

Measured across all 20 private repos over 31 days, execution time per job rounded up to the whole minute (how GitHub bills) times the runner multiplier:

```
repo                          jobs  fractional  rounded-up
tep-rust                       252        1077        1432
openoptsim                      48         195         280
pounce-lean                      8          27          27
----------------------------------------------------------
TOTAL (private, 31 days)                  1295        1739   = 58% of 3000

differentiable-flowsheets      432         928           0   <- public, free
```

The three PRs alongside this one (tep-rust#1, tep-rust#2, openoptsim#3) take roughly 700 rounded minutes off that. This one takes off zero.

## What is in here

**Pull requests run 3.11 only; main runs all three.** The matrix jobs run concurrently, so a PR does not finish sooner — it occupies one runner instead of three, and those runners are shared with every other repo on the account.

The cost is measured, not assumed. Over 134 full-matrix runs, **three had 3.10 fail while 3.11 passed** (all on main, 2026-07-17/18). So a 3.10-specific break would now reach main before anything noticed; the full matrix on main catches it one commit later rather than not at all. That is the trade. The comment in the file states it and says how to undo it — delete the condition, keep the list.

**Superseded PR runs are cancelled.** Pushing three times to a branch left three full matrices running and only the last answer was ever read. Main is exempt, so its history keeps a result for every commit.

**Every job gets `timeout-minutes`** — 30, 45 and 15, against observed maxima of 8.5, 5.1 and 1.5 minutes. Ceilings against a hang, not budgets. The default was six hours.

## One number I cannot close

My reconstruction says 1,739 of 3,000, about 58%. You said 90%. The gap is roughly 960 minutes I cannot see, and the likely places are: repos in one of your 16 orgs billed to you rather than the org, a billing month that does not line up with my 31-day window, or Codespaces counted in the same figure. `/repos/.../timing` returns zeros for this token, so the reconstruction is a floor. `gh auth refresh -h github.com -s user` would let me read the real counter and say which.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NDFhkZkSJmSPDWxzm9HQfz
