### PR TITLE
fix(ree): correct extraction loading, capacity, mechanism and activity models (#189-#195)

### DIFF
--- a/docs/unit-operations-ree.md
+++ b/docs/unit-operations-ree.md
@@ -90,6 +90,29 @@ print(f"Reference concentration: {d2ehpa.reference_concentration} M")
 | Cyanex272 | Bis(2,4,4-trimethylpentyl)phosphinic acid | Heavy REE, Co/Ni |
 | TBP | Tri-n-butyl phosphate | Ce separation, nuclear |
 
+Every extractant record declares a normalized **extraction mechanism**, and it
+is the mechanism that decides which correlation drives `D` (#195):
+
+| Mechanism | `type` values | Driving variable | Coefficient block |
+|-----------|---------------|------------------|-------------------|
+| `cation_exchange` | `acidic_phosphoric`, `acidic_phosphonic`, `acidic_phosphinic`, `acidic_carboxylic` | pH | `ph_coefficients` |
+| `solvating` | `solvating_neutral` | nitrate concentration | `nitrate_coefficients` |
+
+A record carries only the block its mechanism needs. TBP has **no**
+`ph_coefficients` block (it was deleted — see below), so
+`Extractant.ph_coefficients` is `dict | None`, and asking for TBP with
+`mechanism="cation_exchange"` raises.
+
+```python
+from difflow_ree import get_extractant, normalize_mechanism
+
+print(get_extractant("D2EHPA").mechanism)  # 'cation_exchange'
+print(get_extractant("TBP").mechanism)     # 'solvating'
+print(get_extractant("TBP").requires_nitrate, get_extractant("TBP").reference_nitrate)
+# True 3.0
+print(normalize_mechanism("acidic_phosphonic"))  # 'cation_exchange'
+```
+
 ---
 
 ## Equilibrium Models
@@ -97,7 +120,11 @@ print(f"Reference concentration: {d2ehpa.reference_concentration} M")
 (distribution-coefficients)=
 ### Distribution Coefficients
 
-The distribution coefficient D = [REE]_org / [REE]_aq is modeled as a function of pH, temperature, and extractant concentration:
+The distribution coefficient D = [REE]_org / [REE]_aq is modeled as a function of the
+mechanism's driving variable, temperature, and extractant concentration.
+
+For a **cation-exchange** extractant (D2EHPA, PC88A, Cyanex272), the driving
+variable is pH:
 
 $$\log_{10}(D) = a + b \cdot pH + c \cdot pH^2 + \frac{\Delta H}{R \ln(10)} \left(\frac{1}{T} - \frac{1}{T_{ref}}\right)$$
 
@@ -120,6 +147,338 @@ D_all = dist.get_D_all(pH=3.0)
 for elem, D in D_all.items():
     print(f"D({elem}): {D:.2f}")
 ```
+
+(solvating-extractants)=
+#### Solvating extractants (TBP)
+
+A neutral extractant releases no protons; it extracts the neutral nitrate
+complex, so its `D` rises with nitrate concentration and is comparatively flat
+in pH. The correlation is referenced to `reference_nitrate` (3 M for TBP), so
+`a` is $\log_{10}(D)$ **at** that concentration and `b` is the nitrate slope
+$\mathrm{d}\log_{10}(D)/\mathrm{d}\log_{10}[\mathrm{NO_3^-}]$:
+
+$$s = \log_{10}\!\left(\frac{[\mathrm{NO_3^-}]}{[\mathrm{NO_3^-}]_{ref}}\right),
+\qquad \log_{10}(D) = a + b\,s + c\,s^2 + \frac{\Delta H}{R \ln(10)}\left(\frac{1}{T}-\frac{1}{T_{ref}}\right)$$
+
+```python
+tbp = REEDistribution(
+    extractant="TBP", elements=("Nd",), nitrate_conc=3.0, concentration=1.1
+)
+print(float(tbp.get_D("Nd")))                    # at 3 M nitrate
+print(float(tbp.get_D("Nd", nitrate_conc=6.0)))  # rises with nitrate
+```
+
+```{note}
+**TBP's nitrate coefficients are refitted from primary literature (and are the
+only literature-derived numbers in the extractant database).** D2EHPA, PC88A
+and Cyanex272 remain **hand-tuned with no recorded source** — do not mistake one
+for the other.
+
+**Fit basis.** Kraikaew, Srinuttrakul & Chayavadhanakur (2005), "Solvent
+Extraction Study of Rare Earths from Nitrate Medium by the Mixtures of TBP and
+D2EHPA in Kerosene", *J. Metals, Materials and Minerals* **15**(2), 89-95
+([S1](https://jmmm.material.chula.ac.th/index.php/jmmm/article/view/1345), no
+DOI), Table 1 — 1.0 M TBP in kerosene, 0.2001 N free acidity, 35 ± 1 °C —
+corrected to the record's reference (3.0 M NO₃⁻, 1.0 M TBP, 298.15 K) by
+
+$$a = \log_{10}D_\mathrm{meas} + 3\log_{10}\!\frac{3.0}{6.06}
+      - 2300\left(\frac{1}{308.15}-\frac{1}{298.15}\right)
+    = \log_{10}D_\mathrm{meas} - 0.6658$$
+
+The **6.06 M nitrate is derived, not reported**: it was computed from S1's ppm
+feed table (RE nitrates plus 0.2 N free acid). That is the single largest
+uncertainty — a 10% error in it shifts every `a` by 0.13 log units *in common*,
+so relative selectivity survives but the absolute level does not.
+
+**What this fixed.** Three defects in the previous, unsourced block:
+
+| | Old (unsourced) | New (measured) |
+|---|---|---|
+| $D_\mathrm{Dy}/D_\mathrm{La}$ at the reference | 100 | **10.2** |
+| $D_\mathrm{Dy}$ at the reference | 3.16 | **0.24** |
+| Temperature coefficient `d` | negative (⇒ endothermic) | **+2300 K (⇒ exothermic)** |
+
+At the reference the record now gives $D_\mathrm{La}=0.023$,
+$D_\mathrm{Ce}=0.032$, $D_\mathrm{Pr}=0.060$, $D_\mathrm{Nd}=0.072$,
+$D_\mathrm{Sm}=0.120$, $D_\mathrm{Eu}=0.138$, $D_\mathrm{Gd}=0.174$,
+$D_\mathrm{Tb}=0.204$, $D_\mathrm{Dy}=0.240$, $D_\mathrm{Y}=0.214$ — every
+value below 1, mean adjacent-pair separation factor 1.29 per unit atomic
+number (La(57) -> Dy(66) is 9 steps, Pm included), which is why a TBP
+separation needs very many stages.
+
+**Per-element provenance.** La, Ce, Pr, Nd, Sm, Eu, Gd, Dy, Y are **derived**
+from S1 Table 1. **Tb is interpolated** (log-linear in atomic number between Gd
+and Dy) — no TBP-nitrate `D` for Tb exists in any retrieved source. **Y is a
+special case**: its effective position slides from Ho-like at high acidity to
+La-like at very low acidity (Poos & Wilhelm, ISC-695, 1954), so a single $a_Y$
+is a fiction; the value recorded is the ~6 M, low-free-acid one.
+
+**`b = 3.0` is stoichiometric, not fitted.** It is the 3 of RE(NO₃)₃ + 3 TBP.
+No measured $\mathrm{d}\log D/\mathrm{d}\log[\mathrm{NO_3^-}]$ in a
+neutral-salt system was found; the only corroboration is indirect — Ganesh &
+Pandey (2019) measured the *TBP* order as 2.81 ($R^2 = 0.992$). The old
+per-element 2.50–2.85 trend had no support and is removed.
+
+**`d = +2300 K`: one measurement, nine assumptions.** From
+$\Delta H_\mathrm{Sm} = -43.3$ kJ/mol (Ganesh & Pandey, *J. Rad. Nucl. Appl.*
+**4**(2), 109-115 (2019); the DOI printed in the PDF, 10.18576/jrna/040205, is
+**not registered in Crossref** — cite the [retrieved
+PDF](https://www.naturalspublishing.com/files/published/q86xt25u4iq5o9.pdf))
+via $d = -\Delta H/(2.303R)$. **Sm is measured; the other nine elements are
+assumed equal to Sm and are no data.** That paper's Table 1 appears to have its
+$\Delta H$ and slope columns transposed between its two rows, so
+$\Delta H_\mathrm{TBP}$ is either −43.3 or −61.2 kJ/mol, i.e. $d = +2261$ or
+$+3197$ K — a ±40% ambiguity that cannot be resolved from the paper. The
+defensible range is **+2260 to +3200 K**. The *sign* is solid, and is
+independently corroborated by Jorjani & Shahbazi, *Arab. J. Chem.* **9**,
+S1532-S1539 (2016), [doi:10.1016/j.arabjc.2012.04.002](https://doi.org/10.1016/j.arabjc.2012.04.002),
+whose extraction fell as T went 25 → 55 °C.
+
+**Known gap — the highest-value follow-up.** Fidelis, "Temperature effect on the
+extraction of lanthanides in the TBP-HNO₃ system", *J. Inorg. Nucl. Chem.*
+**32**, 997-1003 (1970),
+[doi:10.1016/0022-1902(70)80079-3](https://doi.org/10.1016/0022-1902(70)80079-3),
+measured the whole series at 10/17/25/40 °C — exactly the per-element
+$\Delta H$ assumed constant above. It is paywalled with no open-access copy and
+was **not** used. Obtaining it would replace nine assumed `d` values with nine
+measured ones.
+```
+
+```{warning}
+**Validity window: `b = 3.0` holds only for nitrate supplied by a neutral
+salt.** NH₄NO₃ / LiNO₃ / Ca(NO₃)₂ / Mg(NO₃)₂ / Al(NO₃)₃, **≤ 0.5 M free acid,
+1–6 M NO₃⁻, 283–326 K.**
+
+One `b` cannot cover more, and both counter-cases are measured:
+
+* In **neat TBP with concentrated HNO₃** the slope is **~6**, not 3 (Topp &
+  Weaver, ORNL-1811, 1954,
+  [doi:10.2172/4398970](https://doi.org/10.2172/4398970), Tables II/IV,
+  8.5–17.4 N).
+* At **1.1 M TBP in HNO₃**, `D` actually *falls* with acidity, because the acid
+  consumes the extractant as the TBP·HNO₃ adduct and starves the RE complex of
+  free TBP — effective slope **~0 or negative** (Ganesh & Pandey, Fig. 4).
+
+Two further caveats on the *level* (not the shape): the model's extractant term
+uses **total** [TBP] while the measured cube law holds in **free** TBP; and S1's
+solvent was at or over saturation (0.35 M organic loading needs 1.05 M TBP of
+the 1.0 M available), so these are **loading-suppressed process** `D` values,
+not trace `D`.
+
+**Use for:** relative REE selectivity; why TBP needs many stages; trend and
+sensitivity studies; the *direction* of the temperature and nitrate
+dependences.
+
+**Do not use for:** stage counts; solvent inventories; absolute recoveries;
+HNO₃-supplied nitrate; loaded solvent; free acidity above ~0.5 M; regressing
+equilibrium constants; or Y at any acidity other than S1's 0.2 N.
+```
+
+```{warning}
+**`extractant_conc = 0.5` is meaningless for TBP.** Every Params class in
+difflow_ree defaults to 0.5 M, which is a cation-exchange default. TBP's
+`reference_concentration` is 1.0 M and its `concentration_exponent` is 3.0, so
+0.5 M multiplies every `D` by $(0.5/1.0)^3 = 0.125$ — an 8x reduction, giving
+$D_\mathrm{La} = 0.0029$ and $D_\mathrm{Nd} = 0.0091$. TBP is normally run at
+~30% v/v, which for the recorded density (0.979 g/mL) and molecular weight
+(266.31 g/mol) is **1.10 M** (neat TBP is 3.68 M). Pass
+`concentration=1.1` / `extractant_conc=1.1` explicitly whenever you use TBP.
+```
+
+```{warning}
+**Behaviour change (#195).** `REEDistribution(extractant="TBP", ...)` without a
+`nitrate_conc` now **raises**. Before, it silently used TBP's `ph_coefficients`
+block and modelled TBP as a weak cation exchanger, which gets the qualitative
+dependence backwards. `nitrate_conc=0.0` raises for the same reason.
+
+**TBP's `ph_coefficients` block has since been deleted**, so the opt-in that
+used to reach it now **raises** as well:
+
+    REEDistribution(extractant="TBP", elements=(...), mechanism="cation_exchange")
+    # ValueError: ... 'TBP' ... carries no 'ph_coefficients' block ...
+
+The block was removed because it was mechanistically indefensible, not merely
+uncalibrated: it modelled TBP as a weak cation exchanger, but TBP's own record
+has `pKa: null` and `stoichiometry.protons_released: 0` — there is *no proton to
+exchange*. No retrieved source reports a pH-slope correlation for TBP, and the
+block carried the same refuted 100× La-to-Dy spread as the old nitrate block.
+
+The error message names TBP, says the block was deleted as mechanistically
+unsupported, and points at the nitrate path. There is **no silent fall-back**
+and no `AttributeError`/`KeyError` leaking out of a later `get_D`.
+
+TBP in HNO₃ is a real system, but this database has no coefficients fitted for
+it — and per the validity window above, `b = 3` would be wrong for it anyway
+(ORNL-1811 measured ~6; Ganesh & Pandey measured ~0 or negative). Supply your
+own via `create_custom_extractant()` rather than reaching for a deleted block.
+
+Consequently `Extractant.ph_coefficients` is now `dict[str, PHCoefficients] |
+None`. Any consumer must handle `None`; there is no empty-dict stand-in.
+`ExtractantDatabase.add_element_to_extractant()` raises for a record with no
+pH block rather than lazily creating one.
+```
+
+##### What "a medium its coefficients do not cover" actually means
+
+Issue #195 asked for a raise when an extractant is used in a medium its
+coefficients do not cover. There are **two distinct checks**, and it is worth
+being precise about which is which, because only the second is a medium check:
+
+1. **Driving-ion check (always on).** A `solvating` extractant's correlation is
+   a function of `[NO3-]`, so that concentration must exist and be positive.
+   `nitrate_conc=None` and `nitrate_conc=0.0` raise. A concrete array is checked
+   at its minimum, so a per-stage profile containing a zero raises too.
+2. **Medium check (only when you state a medium).** `REEDistribution` takes an
+   optional `medium`, one of `AQUEOUS_MEDIA` (`"sulfate"`, `"chloride"`,
+   `"nitrate"`, `"mixed"`). The extractant records carry exactly **one** medium
+   constraint, `stoichiometry.requires_nitrate`, so exactly one thing is
+   detected: a nitrate-requiring extractant declared to be operating in a
+   medium that supplies no nitrate.
+
+```python
+from difflow_ree import REEDistribution
+
+# Detected: TBP requires nitrate, chloride supplies none.
+REEDistribution(extractant="TBP", elements=("Nd",),
+                nitrate_conc=3.0, medium="chloride")   # ValueError
+
+REEDistribution(extractant="TBP", elements=("Nd",),
+                nitrate_conc=3.0, medium="nitrate")    # fine
+```
+
+Nothing in `data/extractants.yaml` declares a chloride or sulfate
+*incompatibility* for the acidic extractants, so **no other medium combination
+is rejected** — D2EHPA is accepted in every medium. `medium=None` (the default)
+leaves the medium unstated and is not guessed at. If you want more than this,
+the records have to carry more than `requires_nitrate`.
+
+##### Which Params classes carry these fields
+
+| Params class | `nitrate_conc` | `mechanism` |
+|---|---|---|
+| `REEExtractorParams` | yes | **no** |
+| `MixerSettlerParams` | yes | **no** |
+| `ScrubberParams` | yes | yes |
+| `StripperParams` | yes | yes |
+| `ExtractStripParams` | yes | yes |
+| `SplitShellParams` | yes | yes |
+| `ExtractScrubStripParams` | yes | yes |
+| `SeparationTrainParams` | yes | yes |
+
+`REEExtractorParams` and `MixerSettlerParams` each own a `REEDistribution` but
+have **no** `mechanism` field, so the mechanism-override cannot reach an
+extraction section: it takes the mechanism from the extractant record. The
+flowsheets that contain an extraction section (`ExtractStripParams`,
+`ExtractScrubStripParams`, `SeparationTrainParams`) therefore apply `mechanism`
+to their scrubbing and stripping sections only. Adding a `mechanism` field to
+`REEExtractorParams` and `MixerSettlerParams` would close the gap.
+
+(activity-corrections)=
+#### pH scale and activity corrections
+
+`pH` is on the **concentration** scale, $pH = -\log_{10}[\mathrm{H^+}]$, matching
+the header of `data/extractants.yaml`.
+
+The tabulated correlations are *conditional constants*: their coefficients were
+fitted at the ionic strength of their source experiments and already absorb the
+activity coefficients there. So **`ionic_strength=None` (the default) is a
+first-class option, not a fallback** — for a 2 to 4 M chloride leach liquor, a
+conditional constant used at the liquor's own ionic strength is the standard and
+defensible treatment, and every implemented activity model is out of range there.
+
+Supplying `ionic_strength` requests a correction *to a different ionic strength*.
+Because the $b \cdot pH$ term already carries the $[\mathrm{H^+}]^{-p}$ dependence
+on the concentration scale, what remains is (#194)
+
+$$D_\text{corr} = D \cdot \frac{\gamma_{\mathrm{RE^{3+}}}}{\gamma_{\mathrm{H^+}}^{\,p}},
+\qquad p = \texttt{Extractant.stoichiometry\_protons}$$
+
+not $\gamma_{\mathrm{RE^{3+}}}$ alone. For a solvating extractant $p = 0$ and
+there is no proton term; its real ionic-strength dependence is a nitrate salting
+effect on the *anion*, which an aqueous-cation model does not represent, so
+difflow_ree says so rather than reusing the cation-exchange form silently.
+
+```python
+# Implemented activity models and their declared validity ranges
+from difflow_ree import ACTIVITY_MODELS
+print({k: v["max_ionic_strength"] for k, v in ACTIVITY_MODELS.items()})
+# {'davies': 0.5, 'none': inf}
+
+dist = REEDistribution(extractant="D2EHPA", elements=("Nd",))
+dist.get_D("Nd", pH=3.0, ionic_strength=0.3)   # in range, silent
+dist.get_D("Nd", pH=3.0, ionic_strength=3.0)   # UserWarning: outside Davies range
+
+# Escalate to an error, or silence it, at construction time
+REEDistribution(extractant="D2EHPA", elements=("Nd",), on_out_of_range="raise")
+REEDistribution(extractant="D2EHPA", elements=("Nd",), on_out_of_range="ignore")
+
+# Or state explicitly that no correction is wanted
+REEDistribution(extractant="D2EHPA", elements=("Nd",), activity_model="none")
+```
+
+Bromley and SIT are deliberately **not** offered — difflow_ree does not carry
+their ion-interaction parameters and will not invent them.
+
+(davies-sign-inversion)=
+##### Davies does not just lose accuracy above 0.5 M — it changes sign
+
+```{danger}
+Davies writes $\log_{10}\gamma = -A z^2 f(I)$ with
+$f(I) = \sqrt{I}/(1+\sqrt{I}) - 0.3\,I$. That bracket is **not monotone**: it
+peaks near $I = 0.4$ M and crosses zero at
+
+$$I = 1.940363884733242\ \mathrm{M}$$
+
+the root of $0.3 I + 0.3\sqrt{I} - 1 = 0$
+(`speciation.DAVIES_SIGN_CHANGE_IONIC_STRENGTH`). Above it every Davies
+$\gamma$ exceeds 1 and the correction
+$\gamma_{\mathrm{RE}}/\gamma_{\mathrm{H}}^3 = 10^{-6Af}$ **inverts**:
+
+| $I$ (M) | 0.1 | 1.0 | 1.9404 | 3.0 | 4.0 |
+|---|---|---|---|---|---|
+| $D_\text{corr}/D$ | 0.228 | 0.245 | 1.000 | **6.49** | **42.5** |
+
+That is exactly the 2 to 4 M chloride regime #194 was filed about: raw Davies
+does not merely extrapolate there, it multiplies `D` by 6.5.
+```
+
+The guard is therefore **arithmetic, not a warning**. The ionic strength handed
+to the activity model is clamped at that model's `max_ionic_strength` (0.5 M for
+Davies), so beyond the documented range the correction **saturates at its
+end-of-range value instead of reversing**, and $\mathrm{d}D/\mathrm{d}I$ is
+exactly zero there — the honest statement that the model carries no information
+about that regime. Values inside the range are untouched.
+
+```python
+d = REEDistribution(extractant="D2EHPA", elements=("Nd",), on_out_of_range="ignore")
+D0 = float(d.get_D("Nd", pH=3.0))
+[float(d.get_D("Nd", pH=3.0, ionic_strength=I)) / D0 for I in (0.1, 1.0, 3.0)]
+# [0.2280, 0.1560, 0.1560]   <- never above 1
+
+# Raw, possibly inverted Davies is still available, but only on request:
+e = REEDistribution(extractant="D2EHPA", elements=("Nd",),
+                    on_out_of_range="ignore", extrapolate_activity_model=True)
+float(e.get_D("Nd", pH=3.0, ionic_strength=3.0)) / D0     # 6.49
+```
+
+Why the clamp rather than refusing to trace, or an opt-in flag for traced
+values: under `jit`, `grad` and `vmap` the ionic strength is an abstract tracer,
+and **no** Python-level check can inspect it. Refusing to trace would break
+gradient-based design studies outright; a per-tracer opt-in would leave the
+inverted branch reachable by anyone who set the flag for an in-range sweep. A
+clamp is arithmetic, so it holds identically for scalars, concrete arrays and
+tracers. An inverted `D` is reachable only through
+`extrapolate_activity_model=True`.
+
+The reporting layer is separate from the guard, runs at the Python level, and
+reports once per instance per condition, so it neither spams a stage loop nor
+breaks `jit`/`grad`:
+
+* a **concrete scalar or array** is inspected (arrays at their maximum) and
+  reported against the model's range;
+* an **abstract tracer** cannot be inspected, and that is itself reported —
+  `on_out_of_range="raise"` raises on a traced ionic strength rather than
+  silently skipping the check, which is what it used to do.
 
 #### pH Dependence
 
@@ -184,7 +543,9 @@ class REEExtractorParams:
     elements: tuple[str, ...]  # REE elements to track
     pH: float = 3.0            # Operating pH
     extractant_conc: float = 0.5  # Extractant concentration (M)
-    include_loading: bool = True  # Account for extractant loading
+    nitrate_conc: float | None = None  # M; required for solvating extractants
+    include_loading: bool = True  # Account for extractant loading capacity
+    capacity_sharpness: int = 8   # Sharpness of the smooth loading limiters
     include_speciation: bool = False  # Account for aqueous speciation
 ```
 
@@ -203,9 +564,12 @@ params = REEExtractorParams(
 )
 extractor = REEExtractor(params)
 
-# Create feed and solvent streams
+# Create feed and solvent streams.
+# The solvent must name the extractant and/or the diluent the extractor is
+# configured with: those two species are the organic phase, everything else
+# in a stream is aqueous. A stream carrying neither raises (#192).
 feed = make_stream({"H2O": 1.0, "La": 0.1, "Ce": 0.2, "Nd": 0.15, "Dy": 0.05}, T=298.15, P=101325.0)
-solvent = make_stream({"Organic": 1.0}, T=298.15, P=101325.0)
+solvent = make_stream({"D2EHPA": 0.2, "kerosene": 1.0}, T=298.15, P=101325.0)
 
 # Run extraction
 raffinate, extract, info = extractor(feed, solvent, T=298.15, pH=3.0)
@@ -213,6 +577,11 @@ raffinate, extract, info = extractor(feed, solvent, T=298.15, pH=3.0)
 # Check recoveries
 for elem, data in info["profiles"].items():
     print(f"{elem}: Recovery = {data['recovery']:.1%}")
+
+# With include_loading=True, info also reports the capacity condition
+print(info["theta_total"])                # organic loading, 1.0 = saturated
+print(info["capacity"])                   # F_extractant / m, a molar flow
+print(info["capacity_clamped_fraction"])  # how much the limiter removed
 ```
 
 #### Governing Equations
@@ -227,6 +596,111 @@ Where:
 - $S/F$ is the solvent-to-feed ratio
 - $N$ is the number of stages
 
+#### Phases, loading and capacity
+
+The organic phase of any stream is the extractant plus the diluent; every
+other species (water, acid, dissolved REE, spectators) is aqueous. `REEExtractor`
+and `REEMixerSettler` share this one definition, so a single Kremser stage and
+one 100%-efficient mixer-settler give the same recovery. A stream missing the
+phase a unit needs raises a `ValueError` naming the species that were present,
+rather than silently defaulting that phase's flow to 1.0.
+
+Loading is always a **dimensionless fraction**,
+
+$$\theta = \frac{m \, n_{\mathrm{REE,org}}}{n_{\mathrm{HA}}}$$
+
+with $m$ the extractant monomer equivalents bound per REE, read from the
+extraction mechanism declared in `data/extractants.yaml`
+(`Extractant.monomers_per_ree`). It is 6 for the acidic organophosphorus
+extractants, which are declared as three dimers, and 3 for TBP. The capacity is
+$1/m$ mol REE per mol extractant, and the free-extractant exponent in
+`LoadingIsotherm.apparent_D` is the same $m$, so the two cannot disagree.
+
+:::{warning}
+This changed exported API. `LoadingIsotherm.max_loading` was a constructor
+field defaulting to 0.33; it is now a read-only property equal to $1/m$, so
+`LoadingIsotherm(max_loading=0.33)` raises `TypeError` — pass `m=3.0` instead,
+and note that the acidic organophosphorus extractants now derive $m=6$, halving
+the capacity the old literal claimed. The `"stoichiometry"` and `"max_loading"`
+keys were removed from the public `EXTRACTANT_CAPACITIES` dict (read
+`get_extractant(name).monomers_per_ree` instead), and `loading_correction()`
+now raises the free fraction to `isotherm.m` rather than a literal 3 against a
+halved capacity, which moves its output by a factor of ~25 for D2EHPA.
+:::
+
+Free-extractant depletion, $D \propto [\mathrm{HA}]_\mathrm{free}^n$, is applied
+in exactly one place: the concentration term inside `REEDistribution.get_D`.
+`LoadingIsotherm.apparent_D` implements the same physics and is available for
+callers holding a $D$ that does not already carry that term, but it is not
+applied in the stage path, which would double the correction.
+
+What the stage does enforce is finite capacity. The Kremser closed form can
+predict extraction beyond what the extractant can physically hold, so the newly
+extracted total is multiplied by the smooth saturation
+
+$$s = \left[1 + \left(\frac{n_\mathrm{extracted}}{n_\mathrm{HA}/m}\right)^{k}\right]^{-1/k}$$
+
+with $k$ = `capacity_sharpness`. Because the capacity is a flow of
+extractant, a solvent stream that does not declare one raises when
+`include_loading=True`, rather than silently returning zero recovery. This is
+$C^\infty$, so `jax.grad`
+is continuous at the capacity constraint an economic optimum sits on, unlike
+the hard clamp it replaces. `info` reports `theta_total`, `theta_solvent`,
+`free_fraction_in`, `capacity`, `uncapped_extracted`, `capacity_scale`,
+`capacity_clamped_fraction` and `capacity_sharpness` so a converged design can
+be told apart from one pinned against the capacity wall.
+
+The **same** smoothing, driven by the same $k$, is applied to the free fraction
+of the *entering* solvent, which multiplies $E$ when a partly loaded solvent is
+recycled from the strip section:
+
+$$f_\mathrm{free} = 1 - \theta_\mathrm{solvent}\left[1 + \theta_\mathrm{solvent}^{\,k}\right]^{-1/k}$$
+
+A hard $\max(1-\theta, 0)$ here is worse than a kink: beyond $\theta = 1$ it is
+identically zero, so $E$ is zero, so the derivative of every downstream
+quantity with respect to the solvent loading is *exactly* zero and the lever is
+dead — the vanishing-column failure `difflow.planning.health` reports. The
+smooth form behaves as $1-\theta$ below saturation, equals $1 - 2^{-1/k}$ at
+$\theta = 1$, and decays as $\theta^{-k}/k$ beyond it, so the gradient is
+small but never zero. (It is evaluated as $-\mathrm{expm1}(-\mathrm{log1p}
+(\theta^{-k})/k)$ above $\theta = 1$; the literal expression cancels to exactly
+0 in float64 around $\theta \approx 100$, which would resurrect the dead lever.)
+
+**Choosing $k$.** The smoothing costs a small unconditional haircut below
+capacity where a hard clamp cost nothing:
+
+| $n_\mathrm{extracted}/n_\mathrm{capacity}$ | $k=4$ | $k=8$ (default) | $k=16$ |
+|---|---|---|---|
+| 0.50 | 0.98496 | 0.99951 | 0.9999990 |
+| 0.75 | 0.93358 | 0.98814 | 0.99938 |
+| 1.00 | 0.84090 | 0.91700 | 0.95760 |
+
+The log-log slope $\mathrm{d}\ln s/\mathrm{d}\ln r$ is bounded in $[-1, 0]$ for
+every $k$, so $k$ does not change first-derivative magnitudes; what grows is
+the curvature, $|\mathrm{d}^2\ln s/\mathrm{d}(\ln r)^2| = k/4$ at the crossing.
+The default is 8: since `include_loading` defaults to `True`, every default
+result carries this haircut, and 0.05% at half capacity is below the
+uncertainty in the correlations themselves, where $k=4$ cost 1.5%. Raise it to
+16 or 32 to approach `min()` once a solve has converged; lower it to 2–4 when
+an optimizer is far away and needs a gentler surface.
+
+The REE flowsheet Params (`ExtractStripParams` and friends) do not yet expose
+`capacity_sharpness`; reach it through the extractor they build:
+
+```python
+circuit._extractor.params = circuit._extractor.params.update(
+    capacity_sharpness=16)
+```
+
+**Zero-flow phases.** A phase whose species are present but whose flows sum to
+zero (`{"H2O": 0.0, "D2EHPA": 1.0, "kerosene": 5.0}`) raises: the phase ratio
+$D\,F_\mathrm{org}/F_\mathrm{aq}$ is undefined, and flooring it produced an
+extraction factor of order $10^{10}$. Non-zero denominators are guarded by a
+floor *relative* to the streams' own total flow rather than an absolute molar
+flow, so recoveries are invariant to the unit the flows are expressed in over
+the whole float64 range (an absolute $10^{-10}$ floor broke that below about
+$10^{-11}$ mol/s).
+
 (reemixersettler)=
 ### REEMixerSettler
 
@@ -239,10 +713,22 @@ class MixerSettlerParams:
     elements: tuple[str, ...]
     pH: float = 3.0
     extractant_conc: float = 0.5
+    nitrate_conc: float | None = None  # M; required for solvating extractants
     mixer_residence_time: float = 120.0  # seconds
     settler_residence_time: float = 300.0  # seconds
     stage_efficiency: float = 0.95
+    third_phase_loading_limit: float | None = None  # mol REE / mol extractant
 ```
+
+When `third_phase_loading_limit` is set, the organic inlet must declare a flow
+of the extractant — the loading is mol REE per mol extractant, and dividing by
+a missing flow reported loadings of order $10^{29}$ and called them converged.
+`info` then carries `organic_loading`, the
+boolean `third_phase_formed`, and `third_phase_margin` = `limit - loading`. The
+margin is smooth and signed (positive is feasible), so third-phase onset can be
+posed as an inequality constraint in an optimization rather than only read as a
+diagnostic; the boolean has no gradient, so an optimizer would otherwise walk
+straight through the boundary because crossing it is profitable in the model.
 
 (reescrubber)=
 ### REEScrubber

--- a/examples/09_ree_ndfeb_magnet.ipynb
+++ b/examples/09_ree_ndfeb_magnet.ipynb
@@ -38,40 +38,13 @@
    "id": "cell-1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-03-01T12:50:59.542444Z",
-     "iopub.status.busy": "2026-03-01T12:50:59.542170Z",
-     "iopub.status.idle": "2026-03-01T12:51:00.964044Z",
-     "shell.execute_reply": "2026-03-01T12:51:00.963440Z"
+     "iopub.execute_input": "2026-09-04T15:34:34.561957Z",
+     "iopub.status.busy": "2026-09-04T15:34:34.561729Z",
+     "iopub.status.idle": "2026-09-04T15:34:35.263351Z",
+     "shell.execute_reply": "2026-09-04T15:34:35.262938Z"
     }
    },
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING:2026-03-01 07:50:59,902:jax._src.xla_bridge:905: Platform 'METAL' is experimental and not all JAX functionality may be correctly supported!\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING: All log messages before absl::InitializeLog() is called are written to STDERR\n",
-      "W0000 00:00:1772369459.902908 12638768 mps_client.cc:510] WARNING: JAX Apple GPU support is experimental and not all JAX functionality is correctly supported!\n",
-      "I0000 00:00:1772369459.913545 12638768 service.cc:145] XLA service 0x893080500 initialized for platform METAL (this does not guarantee that XLA will be used). Devices:\n",
-      "I0000 00:00:1772369459.913553 12638768 service.cc:153]   StreamExecutor device (0): Metal, <undefined>\n",
-      "I0000 00:00:1772369459.914775 12638768 mps_client.cc:406] Using Simple allocator.\n",
-      "I0000 00:00:1772369459.914787 12638768 mps_client.cc:384] XLA backend will use up to 55662313472 bytes on device 0 for SimpleAllocator.\n",
-      "WARNING:2026-03-01 07:50:59,915:jax._src.xla_bridge:905: Platform 'mps' is experimental and not all JAX functionality may be correctly supported!\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Metal device set to: Apple M4 Pro\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -123,10 +96,10 @@
    "id": "cell-3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-03-01T12:51:00.965740Z",
-     "iopub.status.busy": "2026-03-01T12:51:00.965501Z",
-     "iopub.status.idle": "2026-03-01T12:51:00.968175Z",
-     "shell.execute_reply": "2026-03-01T12:51:00.967778Z"
+     "iopub.execute_input": "2026-09-04T15:34:35.264617Z",
+     "iopub.status.busy": "2026-09-04T15:34:35.264515Z",
+     "iopub.status.idle": "2026-09-04T15:34:35.266780Z",
+     "shell.execute_reply": "2026-09-04T15:34:35.266354Z"
     }
    },
    "outputs": [
@@ -186,10 +159,10 @@
    "id": "cell-5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-03-01T12:51:00.969583Z",
-     "iopub.status.busy": "2026-03-01T12:51:00.969472Z",
-     "iopub.status.idle": "2026-03-01T12:51:01.107844Z",
-     "shell.execute_reply": "2026-03-01T12:51:01.107370Z"
+     "iopub.execute_input": "2026-09-04T15:34:35.267779Z",
+     "iopub.status.busy": "2026-09-04T15:34:35.267716Z",
+     "iopub.status.idle": "2026-09-04T15:34:35.393317Z",
+     "shell.execute_reply": "2026-09-04T15:34:35.392903Z"
     }
    },
    "outputs": [
@@ -258,10 +231,10 @@
    "id": "cell-7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-03-01T12:51:01.109218Z",
-     "iopub.status.busy": "2026-03-01T12:51:01.109119Z",
-     "iopub.status.idle": "2026-03-01T12:51:01.405736Z",
-     "shell.execute_reply": "2026-03-01T12:51:01.405153Z"
+     "iopub.execute_input": "2026-09-04T15:34:35.394614Z",
+     "iopub.status.busy": "2026-09-04T15:34:35.394537Z",
+     "iopub.status.idle": "2026-09-04T15:34:35.609652Z",
+     "shell.execute_reply": "2026-09-04T15:34:35.609171Z"
     }
    },
    "outputs": [
@@ -328,10 +301,10 @@
    "id": "cell-9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-03-01T12:51:01.407013Z",
-     "iopub.status.busy": "2026-03-01T12:51:01.406933Z",
-     "iopub.status.idle": "2026-03-01T12:51:01.692186Z",
-     "shell.execute_reply": "2026-03-01T12:51:01.691582Z"
+     "iopub.execute_input": "2026-09-04T15:34:35.610864Z",
+     "iopub.status.busy": "2026-09-04T15:34:35.610783Z",
+     "iopub.status.idle": "2026-09-04T15:34:35.855432Z",
+     "shell.execute_reply": "2026-09-04T15:34:35.855079Z"
     }
    },
    "outputs": [
@@ -394,10 +367,10 @@
    "id": "cell-10",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-03-01T12:51:01.693633Z",
-     "iopub.status.busy": "2026-03-01T12:51:01.693526Z",
-     "iopub.status.idle": "2026-03-01T12:51:01.722654Z",
-     "shell.execute_reply": "2026-03-01T12:51:01.722126Z"
+     "iopub.execute_input": "2026-09-04T15:34:35.856546Z",
+     "iopub.status.busy": "2026-09-04T15:34:35.856477Z",
+     "iopub.status.idle": "2026-09-04T15:34:35.877006Z",
+     "shell.execute_reply": "2026-09-04T15:34:35.876663Z"
     }
    },
    "outputs": [
@@ -461,10 +434,10 @@
    "id": "cell-12",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-03-01T12:51:01.724027Z",
-     "iopub.status.busy": "2026-03-01T12:51:01.723943Z",
-     "iopub.status.idle": "2026-03-01T12:51:02.323608Z",
-     "shell.execute_reply": "2026-03-01T12:51:02.323126Z"
+     "iopub.execute_input": "2026-09-04T15:34:35.878276Z",
+     "iopub.status.busy": "2026-09-04T15:34:35.878213Z",
+     "iopub.status.idle": "2026-09-04T15:34:36.338031Z",
+     "shell.execute_reply": "2026-09-04T15:34:36.337532Z"
     }
    },
    "outputs": [
@@ -476,21 +449,21 @@
       "==================================================\n",
       "\n",
       "Base case: pH=3.0, N=3, S/F=0.5\n",
-      "Recovery: 46.9%\n",
+      "Recovery: 48.3%\n",
       "\n",
-      "∂(recovery)/∂(pH) = 2.3565\n",
-      "  → +0.5 pH unit: +117.83% change\n",
+      "∂(recovery)/∂(pH) = 2.3919\n",
+      "  → +0.5 pH unit: +119.59% change\n",
       "\n",
-      "∂(recovery)/∂(S/F) = 0.8131\n",
-      "  → +20% solvent: +16.26% change\n",
+      "∂(recovery)/∂(S/F) = 0.7963\n",
+      "  → +20% solvent: +15.93% change\n",
       "\n",
       "Effect of stages (discrete parameter):\n",
-      "  3 stages: 46.9%\n",
-      "  5 stages: 49.5%\n",
-      "  Δ(recovery) / Δ(stages) ≈ 1.29% per stage\n",
+      "  3 stages: 48.3%\n",
+      "  5 stages: 51.2%\n",
+      "  Δ(recovery) / Δ(stages) ≈ 1.42% per stage\n",
       "\n",
-      "Gradient verification (finite difference): 2.3861\n",
-      "Gradient verification (autodiff):          2.3565\n"
+      "Gradient verification (finite difference): 2.4187\n",
+      "Gradient verification (autodiff):          2.3919\n"
      ]
     }
    ],
@@ -515,9 +488,23 @@
     "        flows={\"H2O\": 10.0, \"La\": 0.015, \"Nd\": 0.02, \"Dy\": 0.001},\n",
     "        T=298.15, P=101325.0,\n",
     "    )\n",
-    "    # Use explicit extractant + diluent keys (required since fix #52)\n",
+    "    # The solvent must name the extractant and the diluent as species, and it\n",
+    "    # must carry a real extractant flow: the loading capacity of the organic\n",
+    "    # phase is F_extractant / m (#191), so the PC88A flow of 0.0 used here\n",
+    "    # previously meant zero capacity and hence zero extraction. A stream whose\n",
+    "    # carrier is neither the extractant nor the diluent now raises instead of\n",
+    "    # silently defaulting the organic flow to 1.0 (#192).\n",
+    "    #\n",
+    "    # 0.5 M PC88A in kerosene is roughly 10 mol% extractant (kerosene is\n",
+    "    # ~0.75 g/mL and ~170 g/mol, so ~4.4 mol/L of diluent against 0.5 mol/L of\n",
+    "    # extractant). The total organic flow is unchanged at 10.0 * SF_ratio; it\n",
+    "    # is just split 10% PC88A / 90% kerosene.\n",
     "    solvent = make_stream(\n",
-    "        flows={\"PC88A\": 0.0, \"kerosene\": 10.0 * SF_ratio, \"La\": 0.0, \"Nd\": 0.0, \"Dy\": 0.0},\n",
+    "        flows={\n",
+    "            \"PC88A\": 1.0 * SF_ratio,\n",
+    "            \"kerosene\": 9.0 * SF_ratio,\n",
+    "            \"La\": 0.0, \"Nd\": 0.0, \"Dy\": 0.0,\n",
+    "        },\n",
     "        T=298.15, P=101325.0,\n",
     "    )\n",
     "    \n",
@@ -581,10 +568,10 @@
    "id": "cell-14",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-03-01T12:51:02.324889Z",
-     "iopub.status.busy": "2026-03-01T12:51:02.324800Z",
-     "iopub.status.idle": "2026-03-01T12:51:02.327157Z",
-     "shell.execute_reply": "2026-03-01T12:51:02.326623Z"
+     "iopub.execute_input": "2026-09-04T15:34:36.339234Z",
+     "iopub.status.busy": "2026-09-04T15:34:36.339155Z",
+     "iopub.status.idle": "2026-09-04T15:34:36.341339Z",
+     "shell.execute_reply": "2026-09-04T15:34:36.340944Z"
     }
    },
    "outputs": [
@@ -637,10 +624,10 @@
    "id": "cell-15",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-03-01T12:51:02.328584Z",
-     "iopub.status.busy": "2026-03-01T12:51:02.328474Z",
-     "iopub.status.idle": "2026-03-01T12:51:02.331108Z",
-     "shell.execute_reply": "2026-03-01T12:51:02.330477Z"
+     "iopub.execute_input": "2026-09-04T15:34:36.342275Z",
+     "iopub.status.busy": "2026-09-04T15:34:36.342204Z",
+     "iopub.status.idle": "2026-09-04T15:34:36.344126Z",
+     "shell.execute_reply": "2026-09-04T15:34:36.343812Z"
     }
    },
    "outputs": [
@@ -685,10 +672,10 @@
    "id": "cell-16",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-03-01T12:51:02.332315Z",
-     "iopub.status.busy": "2026-03-01T12:51:02.332218Z",
-     "iopub.status.idle": "2026-03-01T12:51:02.334751Z",
-     "shell.execute_reply": "2026-03-01T12:51:02.334446Z"
+     "iopub.execute_input": "2026-09-04T15:34:36.344989Z",
+     "iopub.status.busy": "2026-09-04T15:34:36.344922Z",
+     "iopub.status.idle": "2026-09-04T15:34:36.347114Z",
+     "shell.execute_reply": "2026-09-04T15:34:36.346863Z"
     }
    },
    "outputs": [
@@ -735,10 +722,10 @@
    "id": "cell-17",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-03-01T12:51:02.335877Z",
-     "iopub.status.busy": "2026-03-01T12:51:02.335784Z",
-     "iopub.status.idle": "2026-03-01T12:51:02.338176Z",
-     "shell.execute_reply": "2026-03-01T12:51:02.337740Z"
+     "iopub.execute_input": "2026-09-04T15:34:36.348058Z",
+     "iopub.status.busy": "2026-09-04T15:34:36.348001Z",
+     "iopub.status.idle": "2026-09-04T15:34:36.349914Z",
+     "shell.execute_reply": "2026-09-04T15:34:36.349688Z"
     }
    },
    "outputs": [
@@ -823,7 +810,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.11"
+   "version": "3.13.5"
   }
  },
  "nbformat": 4,

--- a/examples/20_ree_extraction_basics.ipynb
+++ b/examples/20_ree_extraction_basics.ipynb
@@ -33,47 +33,13 @@
    "id": "imports",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-03-01T12:52:17.033802Z",
-     "iopub.status.busy": "2026-03-01T12:52:17.033674Z",
-     "iopub.status.idle": "2026-03-01T12:52:18.351205Z",
-     "shell.execute_reply": "2026-03-01T12:52:18.350528Z"
+     "iopub.execute_input": "2026-09-04T15:37:20.198054Z",
+     "iopub.status.busy": "2026-09-04T15:37:20.197659Z",
+     "iopub.status.idle": "2026-09-04T15:37:21.562035Z",
+     "shell.execute_reply": "2026-09-04T15:37:21.561622Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING:2026-03-01 07:52:17,376:jax._src.xla_bridge:905: Platform 'mps' is experimental and not all JAX functionality may be correctly supported!\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING:2026-03-01 07:52:17,406:jax._src.xla_bridge:905: Platform 'METAL' is experimental and not all JAX functionality may be correctly supported!\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING: All log messages before absl::InitializeLog() is called are written to STDERR\n",
-      "W0000 00:00:1772369537.407043 12641069 mps_client.cc:510] WARNING: JAX Apple GPU support is experimental and not all JAX functionality is correctly supported!\n",
-      "I0000 00:00:1772369537.407290 12641069 service.cc:145] XLA service 0xabbce4400 initialized for platform METAL (this does not guarantee that XLA will be used). Devices:\n",
-      "I0000 00:00:1772369537.407295 12641069 service.cc:153]   StreamExecutor device (0): Metal, <undefined>\n",
-      "I0000 00:00:1772369537.407892 12641069 mps_client.cc:406] Using Simple allocator.\n",
-      "I0000 00:00:1772369537.407900 12641069 mps_client.cc:384] XLA backend will use up to 55662313472 bytes on device 0 for SimpleAllocator.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Metal device set to: Apple M4 Pro\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import jax\n",
     "import jax.numpy as jnp\n",
@@ -116,10 +82,10 @@
    "id": "list-elements",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-03-01T12:52:18.352697Z",
-     "iopub.status.busy": "2026-03-01T12:52:18.352517Z",
-     "iopub.status.idle": "2026-03-01T12:52:18.358657Z",
-     "shell.execute_reply": "2026-03-01T12:52:18.358169Z"
+     "iopub.execute_input": "2026-09-04T15:37:21.563429Z",
+     "iopub.status.busy": "2026-09-04T15:37:21.563327Z",
+     "iopub.status.idle": "2026-09-04T15:37:21.568991Z",
+     "shell.execute_reply": "2026-09-04T15:37:21.568611Z"
     }
    },
    "outputs": [
@@ -174,10 +140,10 @@
    "id": "list-extractants",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-03-01T12:52:18.359790Z",
-     "iopub.status.busy": "2026-03-01T12:52:18.359721Z",
-     "iopub.status.idle": "2026-03-01T12:52:18.371062Z",
-     "shell.execute_reply": "2026-03-01T12:52:18.370669Z"
+     "iopub.execute_input": "2026-09-04T15:37:21.570085Z",
+     "iopub.status.busy": "2026-09-04T15:37:21.570022Z",
+     "iopub.status.idle": "2026-09-04T15:37:21.582296Z",
+     "shell.execute_reply": "2026-09-04T15:37:21.581930Z"
     }
    },
    "outputs": [
@@ -246,10 +212,10 @@
    "id": "calc-d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-03-01T12:52:18.372166Z",
-     "iopub.status.busy": "2026-03-01T12:52:18.372081Z",
-     "iopub.status.idle": "2026-03-01T12:52:18.492742Z",
-     "shell.execute_reply": "2026-03-01T12:52:18.492387Z"
+     "iopub.execute_input": "2026-09-04T15:37:21.583237Z",
+     "iopub.status.busy": "2026-09-04T15:37:21.583180Z",
+     "iopub.status.idle": "2026-09-04T15:37:21.698614Z",
+     "shell.execute_reply": "2026-09-04T15:37:21.698252Z"
     }
    },
    "outputs": [
@@ -313,10 +279,10 @@
    "id": "ph-sweep",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-03-01T12:52:18.494171Z",
-     "iopub.status.busy": "2026-03-01T12:52:18.494090Z",
-     "iopub.status.idle": "2026-03-01T12:52:18.498576Z",
-     "shell.execute_reply": "2026-03-01T12:52:18.498236Z"
+     "iopub.execute_input": "2026-09-04T15:37:21.699788Z",
+     "iopub.status.busy": "2026-09-04T15:37:21.699720Z",
+     "iopub.status.idle": "2026-09-04T15:37:21.703773Z",
+     "shell.execute_reply": "2026-09-04T15:37:21.703464Z"
     }
    },
    "outputs": [
@@ -361,7 +327,9 @@
    "source": [
     "## 5. Multi-Stage Extraction Unit\n",
     "\n",
-    "Simulate a counter-current extraction cascade."
+    "Simulate a counter-current extraction cascade.\n",
+    "\n",
+    "The organic solvent stream names its carriers explicitly — the extractant (D2EHPA) and the diluent (kerosene) — rather than a generic `\"Organic\"` species. The extractant molar flow is what sets the loading capacity of the organic phase (#191), and a solvent that names neither carrier is now rejected instead of being silently assigned an organic flow of 1.0 (#192).\n"
    ]
   },
   {
@@ -370,10 +338,10 @@
    "id": "run-extraction",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-03-01T12:52:18.500304Z",
-     "iopub.status.busy": "2026-03-01T12:52:18.500211Z",
-     "iopub.status.idle": "2026-03-01T12:52:18.806093Z",
-     "shell.execute_reply": "2026-03-01T12:52:18.805694Z"
+     "iopub.execute_input": "2026-09-04T15:37:21.704824Z",
+     "iopub.status.busy": "2026-09-04T15:37:21.704747Z",
+     "iopub.status.idle": "2026-09-04T15:37:21.871414Z",
+     "shell.execute_reply": "2026-09-04T15:37:21.870951Z"
     }
    },
    "outputs": [
@@ -385,12 +353,12 @@
       "======================================================================\n",
       "Element    Feed         Raffinate    Extract      Recovery %  \n",
       "----------------------------------------------------------------------\n",
-      "La         0.0100       0.0100       0.0000       0.3         \n",
-      "Nd         0.0200       0.0191       0.0009       4.5         \n",
+      "La         0.0100       0.0098       0.0002       2.5         \n",
+      "Nd         0.0200       0.0113       0.0087       43.4        \n",
       "Dy         0.0100       0.0000       0.0100       100.0       \n",
       "\n",
       "Extract Composition:\n",
-      "  Nd purity (among REEs): 8.3%\n"
+      "  Nd purity (among REEs): 45.9%\n"
      ]
     }
    ],
@@ -418,9 +386,22 @@
     "    P=101325.0,\n",
     ")\n",
     "\n",
+    "# Organic solvent stream.\n",
+    "#\n",
+    "# The stream must name the *extractant* and the *diluent* as species. A\n",
+    "# solvent whose carrier matches neither now raises instead of silently\n",
+    "# defaulting the organic flow to 1.0 (#192), and when loading is enabled the\n",
+    "# extractant molar flow is what sets the capacity of the organic phase\n",
+    "# (capacity = F_extractant / m, #191).\n",
+    "#\n",
+    "# 0.5 M D2EHPA in kerosene is roughly 10 mol% extractant (kerosene is\n",
+    "# ~0.75 g/mL and ~170 g/mol, so ~4.4 mol/L of diluent against 0.5 mol/L of\n",
+    "# extractant). The total organic flow is unchanged at 8.0 mol/s; it is just\n",
+    "# split 0.8 D2EHPA / 7.2 kerosene.\n",
     "solvent = make_stream(\n",
     "    flows={\n",
-    "        \"Organic\": 8.0,\n",
+    "        \"D2EHPA\": 0.8,\n",
+    "        \"kerosene\": 7.2,\n",
     "        \"La\": 0.0,\n",
     "        \"Nd\": 0.0,\n",
     "        \"Dy\": 0.0,\n",
@@ -474,10 +455,10 @@
    "id": "gradients",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-03-01T12:52:18.807395Z",
-     "iopub.status.busy": "2026-03-01T12:52:18.807312Z",
-     "iopub.status.idle": "2026-03-01T12:52:19.010977Z",
-     "shell.execute_reply": "2026-03-01T12:52:19.010515Z"
+     "iopub.execute_input": "2026-09-04T15:37:21.872689Z",
+     "iopub.status.busy": "2026-09-04T15:37:21.872604Z",
+     "iopub.status.idle": "2026-09-04T15:37:22.036582Z",
+     "shell.execute_reply": "2026-09-04T15:37:22.036161Z"
     }
    },
    "outputs": [
@@ -549,10 +530,10 @@
    "id": "optimize",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-03-01T12:52:19.012197Z",
-     "iopub.status.busy": "2026-03-01T12:52:19.012106Z",
-     "iopub.status.idle": "2026-03-01T12:52:19.243304Z",
-     "shell.execute_reply": "2026-03-01T12:52:19.242856Z"
+     "iopub.execute_input": "2026-09-04T15:37:22.037759Z",
+     "iopub.status.busy": "2026-09-04T15:37:22.037684Z",
+     "iopub.status.idle": "2026-09-04T15:37:22.219516Z",
+     "shell.execute_reply": "2026-09-04T15:37:22.219105Z"
     }
    },
    "outputs": [
@@ -563,16 +544,16 @@
       "Optimization Progress:\n",
       "==================================================\n",
       "Iter     pH         Nd Purity %    \n",
-      "--------------------------------------------------\n",
-      "5        2.992      2.11           \n",
-      "10       2.983      2.12           \n",
-      "15       2.975      2.14           \n"
+      "--------------------------------------------------\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "5        2.992      2.11           \n",
+      "10       2.983      2.12           \n",
+      "15       2.975      2.14           \n",
       "20       2.967      2.15           \n",
       "\n",
       "✓ Optimal pH: 2.967\n",
@@ -646,10 +627,10 @@
    "id": "compare-extractants",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-03-01T12:52:19.244528Z",
-     "iopub.status.busy": "2026-03-01T12:52:19.244430Z",
-     "iopub.status.idle": "2026-03-01T12:52:19.248559Z",
-     "shell.execute_reply": "2026-03-01T12:52:19.248130Z"
+     "iopub.execute_input": "2026-09-04T15:37:22.220739Z",
+     "iopub.status.busy": "2026-09-04T15:37:22.220661Z",
+     "iopub.status.idle": "2026-09-04T15:37:22.224249Z",
+     "shell.execute_reply": "2026-09-04T15:37:22.223949Z"
     }
    },
    "outputs": [
@@ -741,7 +722,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.11"
+   "version": "3.13.5"
   }
  },
  "nbformat": 4,

--- a/examples/21_custom_extractants.ipynb
+++ b/examples/21_custom_extractants.ipynb
@@ -32,47 +32,13 @@
    "id": "imports",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-03-01T12:52:21.058670Z",
-     "iopub.status.busy": "2026-03-01T12:52:21.058587Z",
-     "iopub.status.idle": "2026-03-01T12:52:22.089479Z",
-     "shell.execute_reply": "2026-03-01T12:52:22.089083Z"
+     "iopub.execute_input": "2026-09-04T15:37:24.186725Z",
+     "iopub.status.busy": "2026-09-04T15:37:24.186624Z",
+     "iopub.status.idle": "2026-09-04T15:37:24.900002Z",
+     "shell.execute_reply": "2026-09-04T15:37:24.899568Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING:2026-03-01 07:52:21,307:jax._src.xla_bridge:905: Platform 'mps' is experimental and not all JAX functionality may be correctly supported!\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING:2026-03-01 07:52:21,336:jax._src.xla_bridge:905: Platform 'METAL' is experimental and not all JAX functionality may be correctly supported!\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING: All log messages before absl::InitializeLog() is called are written to STDERR\n",
-      "W0000 00:00:1772369541.336986 12641261 mps_client.cc:510] WARNING: JAX Apple GPU support is experimental and not all JAX functionality is correctly supported!\n",
-      "I0000 00:00:1772369541.337200 12641261 service.cc:145] XLA service 0xcab9eb200 initialized for platform METAL (this does not guarantee that XLA will be used). Devices:\n",
-      "I0000 00:00:1772369541.337205 12641261 service.cc:153]   StreamExecutor device (0): Metal, <undefined>\n",
-      "I0000 00:00:1772369541.337793 12641261 mps_client.cc:406] Using Simple allocator.\n",
-      "I0000 00:00:1772369541.337800 12641261 mps_client.cc:384] XLA backend will use up to 55662313472 bytes on device 0 for SimpleAllocator.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Metal device set to: Apple M4 Pro\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import jax\n",
     "import jax.numpy as jnp\n",
@@ -140,10 +106,10 @@
    "id": "simple-extractant",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-03-01T12:52:22.090938Z",
-     "iopub.status.busy": "2026-03-01T12:52:22.090796Z",
-     "iopub.status.idle": "2026-03-01T12:52:22.093728Z",
-     "shell.execute_reply": "2026-03-01T12:52:22.093207Z"
+     "iopub.execute_input": "2026-09-04T15:37:24.901557Z",
+     "iopub.status.busy": "2026-09-04T15:37:24.901445Z",
+     "iopub.status.idle": "2026-09-04T15:37:24.904146Z",
+     "shell.execute_reply": "2026-09-04T15:37:24.903681Z"
     }
    },
    "outputs": [
@@ -221,10 +187,10 @@
    "id": "register-extractant",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-03-01T12:52:22.094922Z",
-     "iopub.status.busy": "2026-03-01T12:52:22.094852Z",
-     "iopub.status.idle": "2026-03-01T12:52:22.105345Z",
-     "shell.execute_reply": "2026-03-01T12:52:22.104966Z"
+     "iopub.execute_input": "2026-09-04T15:37:24.905343Z",
+     "iopub.status.busy": "2026-09-04T15:37:24.905261Z",
+     "iopub.status.idle": "2026-09-04T15:37:24.918197Z",
+     "shell.execute_reply": "2026-09-04T15:37:24.917698Z"
     }
    },
    "outputs": [
@@ -277,10 +243,10 @@
    "id": "test-distribution",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-03-01T12:52:22.106506Z",
-     "iopub.status.busy": "2026-03-01T12:52:22.106438Z",
-     "iopub.status.idle": "2026-03-01T12:52:22.210194Z",
-     "shell.execute_reply": "2026-03-01T12:52:22.209736Z"
+     "iopub.execute_input": "2026-09-04T15:37:24.919266Z",
+     "iopub.status.busy": "2026-09-04T15:37:24.919185Z",
+     "iopub.status.idle": "2026-09-04T15:37:25.038644Z",
+     "shell.execute_reply": "2026-09-04T15:37:25.038187Z"
     }
    },
    "outputs": [
@@ -339,10 +305,10 @@
    "id": "comparison",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-03-01T12:52:22.211538Z",
-     "iopub.status.busy": "2026-03-01T12:52:22.211456Z",
-     "iopub.status.idle": "2026-03-01T12:52:22.225417Z",
-     "shell.execute_reply": "2026-03-01T12:52:22.224987Z"
+     "iopub.execute_input": "2026-09-04T15:37:25.039919Z",
+     "iopub.status.busy": "2026-09-04T15:37:25.039832Z",
+     "iopub.status.idle": "2026-09-04T15:37:25.054265Z",
+     "shell.execute_reply": "2026-09-04T15:37:25.053657Z"
     }
    },
    "outputs": [
@@ -410,10 +376,10 @@
    "id": "test-extractor",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-03-01T12:52:22.226627Z",
-     "iopub.status.busy": "2026-03-01T12:52:22.226560Z",
-     "iopub.status.idle": "2026-03-01T12:52:22.409252Z",
-     "shell.execute_reply": "2026-03-01T12:52:22.408781Z"
+     "iopub.execute_input": "2026-09-04T15:37:25.055673Z",
+     "iopub.status.busy": "2026-09-04T15:37:25.055572Z",
+     "iopub.status.idle": "2026-09-04T15:37:25.206480Z",
+     "shell.execute_reply": "2026-09-04T15:37:25.206031Z"
     }
    },
    "outputs": [
@@ -425,12 +391,12 @@
       "============================================================\n",
       "Element    Feed         Extract      Recovery %  \n",
       "------------------------------------------------------------\n",
-      "La         0.0100       0.0000       0.5         \n",
-      "Nd         0.0200       0.0010       5.1         \n",
-      "Dy         0.0100       0.0100       99.7        \n",
+      "La         0.0100       0.0004       3.6         \n",
+      "Nd         0.0200       0.0081       40.4        \n",
+      "Dy         0.0100       0.0100       100.0       \n",
       "\n",
       "Extract Quality:\n",
-      "  Nd purity: 9.2%\n"
+      "  Nd purity: 43.8%\n"
      ]
     }
    ],
@@ -453,8 +419,20 @@
     "    T=298.15, P=101325.0,\n",
     ")\n",
     "\n",
+    "# Organic solvent stream.\n",
+    "#\n",
+    "# The stream must name the *extractant* and the *diluent* as species. A\n",
+    "# solvent whose carrier matches neither now raises instead of silently\n",
+    "# defaulting the organic flow to 1.0 (#192), and when loading is enabled the\n",
+    "# extractant molar flow is what sets the capacity of the organic phase\n",
+    "# (capacity = F_extractant / m, #191).\n",
+    "#\n",
+    "# 0.5 M MyExtractant in kerosene is roughly 10 mol% extractant (kerosene is\n",
+    "# ~0.75 g/mL and ~170 g/mol, so ~4.4 mol/L of diluent against 0.5 mol/L of\n",
+    "# extractant). The total organic flow is unchanged at 8.0 mol/s; it is just\n",
+    "# split 0.8 MyExtractant / 7.2 kerosene.\n",
     "solvent = make_stream(\n",
-    "    flows={\"Organic\": 8.0, \"La\": 0.0, \"Nd\": 0.0, \"Dy\": 0.0},\n",
+    "    flows={\"MyExtractant\": 0.8, \"kerosene\": 7.2, \"La\": 0.0, \"Nd\": 0.0, \"Dy\": 0.0},\n",
     "    T=298.15, P=101325.0,\n",
     ")\n",
     "\n",
@@ -500,10 +478,10 @@
    "id": "calibration-example",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-03-01T12:52:22.410531Z",
-     "iopub.status.busy": "2026-03-01T12:52:22.410449Z",
-     "iopub.status.idle": "2026-03-01T12:52:23.820709Z",
-     "shell.execute_reply": "2026-03-01T12:52:23.820225Z"
+     "iopub.execute_input": "2026-09-04T15:37:25.207730Z",
+     "iopub.status.busy": "2026-09-04T15:37:25.207627Z",
+     "iopub.status.idle": "2026-09-04T15:37:26.395907Z",
+     "shell.execute_reply": "2026-09-04T15:37:26.395474Z"
     }
    },
    "outputs": [
@@ -521,13 +499,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "20       -9369.3534   -37433.2627  -149709.2314 21.438900   \n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "20       -9369.3534   -37433.2627  -149709.2314 21.438900   \n",
       "40       -9369.3534   -37433.2627  -149709.2314 21.438900   \n"
      ]
     },
@@ -535,13 +507,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "60       -9369.3534   -37433.2627  -149709.2314 21.438900   \n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "60       -9369.3534   -37433.2627  -149709.2314 21.438900   \n",
       "80       -9369.3534   -37433.2627  -149709.2314 21.438900   \n"
      ]
     },
@@ -646,10 +612,10 @@
    "id": "full-extractant",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-03-01T12:52:23.822002Z",
-     "iopub.status.busy": "2026-03-01T12:52:23.821915Z",
-     "iopub.status.idle": "2026-03-01T12:52:23.826067Z",
-     "shell.execute_reply": "2026-03-01T12:52:23.825763Z"
+     "iopub.execute_input": "2026-09-04T15:37:26.397018Z",
+     "iopub.status.busy": "2026-09-04T15:37:26.396931Z",
+     "iopub.status.idle": "2026-09-04T15:37:26.400907Z",
+     "shell.execute_reply": "2026-09-04T15:37:26.400536Z"
     }
    },
    "outputs": [
@@ -744,10 +710,10 @@
    "id": "cleanup-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-03-01T12:52:23.827070Z",
-     "iopub.status.busy": "2026-03-01T12:52:23.827005Z",
-     "iopub.status.idle": "2026-03-01T12:52:23.828777Z",
-     "shell.execute_reply": "2026-03-01T12:52:23.828434Z"
+     "iopub.execute_input": "2026-09-04T15:37:26.401834Z",
+     "iopub.status.busy": "2026-09-04T15:37:26.401779Z",
+     "iopub.status.idle": "2026-09-04T15:37:26.403241Z",
+     "shell.execute_reply": "2026-09-04T15:37:26.402975Z"
     }
    },
    "outputs": [
@@ -837,7 +803,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.11"
+   "version": "3.13.5"
   }
  },
  "nbformat": 4,

--- a/examples/24_custom_ree_elements.ipynb
+++ b/examples/24_custom_ree_elements.ipynb
@@ -3,148 +3,657 @@
   {
    "cell_type": "markdown",
    "id": "68834a80",
-   "source": "# Custom REE Elements: Adding New Elements to the Database\n\nThe built-in `difflow_ree` database covers 10 commercial REEs (La, Ce, Pr, Nd, Sm, Eu, Gd, Tb, Dy, Y) and 4 extractant systems. However, the lanthanide series contains 15 elements, and real separation processes often involve elements not in the default database (e.g., Ho, Er, Tm, Yb, Lu) or non-REE impurities that co-extract.\n\nThis notebook demonstrates how to add custom elements with your own literature data, so you can simulate separations involving any element.\n\n## What you will learn\n\n1. Register a new element with `create_custom_element` and `add_element`\n2. Add extraction coefficients for the new element to specific extractants with `add_element_to_extractant`\n3. Add separation factor data with `add_pair` and `add_separation_factors`\n4. Use the new element in distribution and extraction calculations\n5. Clean up custom data when done",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "# Custom REE Elements: Adding New Elements to the Database\n",
+    "\n",
+    "The built-in `difflow_ree` database covers 10 commercial REEs (La, Ce, Pr, Nd, Sm, Eu, Gd, Tb, Dy, Y) and 4 extractant systems. However, the lanthanide series contains 15 elements, and real separation processes often involve elements not in the default database (e.g., Ho, Er, Tm, Yb, Lu) or non-REE impurities that co-extract.\n",
+    "\n",
+    "This notebook demonstrates how to add custom elements with your own literature data, so you can simulate separations involving any element.\n",
+    "\n",
+    "## What you will learn\n",
+    "\n",
+    "1. Register a new element with `create_custom_element` and `add_element`\n",
+    "2. Add extraction coefficients for the new element to specific extractants with `add_element_to_extractant`\n",
+    "3. Add separation factor data with `add_pair` and `add_separation_factors`\n",
+    "4. Use the new element in distribution and extraction calculations\n",
+    "5. Clean up custom data when done"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 1,
    "id": "4a460adc",
-   "source": "import jax\nimport jax.numpy as jnp\n\njax.config.update(\"jax_enable_x64\", True)\n\nfrom difflow_ree import (\n    # Custom element creation\n    create_custom_element,\n    # Database singletons\n    get_ree_database,\n    get_extractant_database,\n    get_sf_database,\n    # Convenience functions\n    get_element,\n    list_ree_elements,\n    # Equilibrium\n    REEDistribution,\n    # Units\n    REEExtractor,\n    REEExtractorParams,\n)\nfrom difflow.streams import make_stream, get_flows",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-04T15:38:00.180755Z",
+     "iopub.status.busy": "2026-09-04T15:38:00.180356Z",
+     "iopub.status.idle": "2026-09-04T15:38:00.913353Z",
+     "shell.execute_reply": "2026-09-04T15:38:00.912891Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import jax\n",
+    "import jax.numpy as jnp\n",
+    "\n",
+    "jax.config.update(\"jax_enable_x64\", True)\n",
+    "\n",
+    "from difflow_ree import (\n",
+    "    # Custom element creation\n",
+    "    create_custom_element,\n",
+    "    # Database singletons\n",
+    "    get_ree_database,\n",
+    "    get_extractant_database,\n",
+    "    get_sf_database,\n",
+    "    # Convenience functions\n",
+    "    get_element,\n",
+    "    list_ree_elements,\n",
+    "    # Equilibrium\n",
+    "    REEDistribution,\n",
+    "    # Units\n",
+    "    REEExtractor,\n",
+    "    REEExtractorParams,\n",
+    ")\n",
+    "from difflow.streams import make_stream, get_flows"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "e85cf63d",
-   "source": "## 1. The built-in database\n\nBefore adding anything, let's see what is already available.",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "## 1. The built-in database\n",
+    "\n",
+    "Before adding anything, let's see what is already available."
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 2,
    "id": "2ca8da63",
-   "source": "ree_db = get_ree_database()\next_db = get_extractant_database()\nsf_db = get_sf_database()\n\nprint(\"Built-in elements:\", ree_db.list_elements())\nprint(\"Built-in extractants:\", ext_db.list_extractants())\nprint()\n\n# Show element groups\nfor group in (\"light\", \"middle\", \"heavy\"):\n    print(f\"  {group}: {ree_db.list_by_group(group)}\")",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-04T15:38:00.914652Z",
+     "iopub.status.busy": "2026-09-04T15:38:00.914556Z",
+     "iopub.status.idle": "2026-09-04T15:38:00.933178Z",
+     "shell.execute_reply": "2026-09-04T15:38:00.932788Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Built-in elements: ['La', 'Ce', 'Pr', 'Nd', 'Sm', 'Eu', 'Gd', 'Tb', 'Dy', 'Y']\n",
+      "Built-in extractants: ['D2EHPA', 'PC88A', 'Cyanex272', 'TBP']\n",
+      "\n",
+      "  light: ['La', 'Ce', 'Pr', 'Nd']\n",
+      "  middle: ['Sm', 'Eu', 'Gd']\n",
+      "  heavy: ['Tb', 'Dy', 'Y']\n"
+     ]
+    }
+   ],
+   "source": [
+    "ree_db = get_ree_database()\n",
+    "ext_db = get_extractant_database()\n",
+    "sf_db = get_sf_database()\n",
+    "\n",
+    "print(\"Built-in elements:\", ree_db.list_elements())\n",
+    "print(\"Built-in extractants:\", ext_db.list_extractants())\n",
+    "print()\n",
+    "\n",
+    "# Show element groups\n",
+    "for group in (\"light\", \"middle\", \"heavy\"):\n",
+    "    print(f\"  {group}: {ree_db.list_by_group(group)}\")"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "fdf46e2a",
-   "source": "## 2. Adding Holmium to the element database\n\nHolmium (Ho, Z=67) sits between Dysprosium and Erbium in the lanthanide series. Its physical properties are well-established constants from standard references.\n\n**Important:** The physical properties below (atomic weight, ionic radius, density, melting point) are standard reference values. The extraction coefficients in later cells are *placeholders* to demonstrate the API. In a real application, you should replace them with values from your own experimental data or published correlations for your specific system.",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "## 2. Adding Holmium to the element database\n",
+    "\n",
+    "Holmium (Ho, Z=67) sits between Dysprosium and Erbium in the lanthanide series. Its physical properties are well-established constants from standard references.\n",
+    "\n",
+    "**Important:** The physical properties below (atomic weight, ionic radius, density, melting point) are standard reference values. The extraction coefficients in later cells are *placeholders* to demonstrate the API. In a real application, you should replace them with values from your own experimental data or published correlations for your specific system."
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 3,
    "id": "090c66e2",
-   "source": "# Create Holmium from standard reference data\n# Sources: CRC Handbook (physical properties), Shannon 1976 (ionic radius)\nho = create_custom_element(\n    symbol=\"Ho\",\n    name=\"Holmium\",\n    atomic_number=67,\n    atomic_weight=164.930,   # g/mol\n    ionic_radius_pm=90.1,    # pm, CN=6, 3+ oxidation state (Shannon 1976)\n    density=8.795,           # g/cm3\n    melting_point=1734,      # K\n    group=\"heavy\",           # Ho behaves as a heavy REE\n    oxide_formula=\"Ho2O3\",\n    oxide_mw=377.86,         # g/mol\n    price_usd_kg=60.0,      # approximate market price, varies\n)\n\n# Register it\nree_db.add_element(\"Ho\", ho)\n\nprint(f\"Added: {ho.name} ({ho.symbol}), Z={ho.atomic_number}\")\nprint(f\"  Atomic weight: {ho.atomic_weight} g/mol\")\nprint(f\"  Ionic radius:  {ho.ionic_radius_pm} pm\")\nprint(f\"  Group:         {ho.group}\")\nprint()\nprint(\"Heavy REEs now:\", ree_db.list_by_group(\"heavy\"))",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-04T15:38:00.934413Z",
+     "iopub.status.busy": "2026-09-04T15:38:00.934337Z",
+     "iopub.status.idle": "2026-09-04T15:38:00.936581Z",
+     "shell.execute_reply": "2026-09-04T15:38:00.936179Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Added: Holmium (Ho), Z=67\n",
+      "  Atomic weight: 164.93 g/mol\n",
+      "  Ionic radius:  90.1 pm\n",
+      "  Group:         heavy\n",
+      "\n",
+      "Heavy REEs now: ['Tb', 'Dy', 'Y', 'Ho']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Create Holmium from standard reference data\n",
+    "# Sources: CRC Handbook (physical properties), Shannon 1976 (ionic radius)\n",
+    "ho = create_custom_element(\n",
+    "    symbol=\"Ho\",\n",
+    "    name=\"Holmium\",\n",
+    "    atomic_number=67,\n",
+    "    atomic_weight=164.930,   # g/mol\n",
+    "    ionic_radius_pm=90.1,    # pm, CN=6, 3+ oxidation state (Shannon 1976)\n",
+    "    density=8.795,           # g/cm3\n",
+    "    melting_point=1734,      # K\n",
+    "    group=\"heavy\",           # Ho behaves as a heavy REE\n",
+    "    oxide_formula=\"Ho2O3\",\n",
+    "    oxide_mw=377.86,         # g/mol\n",
+    "    price_usd_kg=60.0,      # approximate market price, varies\n",
+    ")\n",
+    "\n",
+    "# Register it\n",
+    "ree_db.add_element(\"Ho\", ho)\n",
+    "\n",
+    "print(f\"Added: {ho.name} ({ho.symbol}), Z={ho.atomic_number}\")\n",
+    "print(f\"  Atomic weight: {ho.atomic_weight} g/mol\")\n",
+    "print(f\"  Ionic radius:  {ho.ionic_radius_pm} pm\")\n",
+    "print(f\"  Group:         {ho.group}\")\n",
+    "print()\n",
+    "print(\"Heavy REEs now:\", ree_db.list_by_group(\"heavy\"))"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "cb3baa39",
-   "source": "## 3. Adding extraction coefficients for PC88A\n\nNow we need pH and temperature coefficients so the distribution model can compute D values for Ho. These are extractant-specific empirical correlations, so we add them only to the extractants we have data for.\n\nThe model is: `log10(D) = a + b*pH + c*pH^2`, with a temperature correction `d*(1/T - 1/T_ref)`.\n\n**The values below are illustrative placeholders.** In practice, you would obtain these by fitting published D vs. pH data for Ho with your extractant system (see notebook `21_custom_extractants.ipynb` for a calibration example).",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "## 3. Adding extraction coefficients for PC88A\n",
+    "\n",
+    "Now we need pH and temperature coefficients so the distribution model can compute D values for Ho. These are extractant-specific empirical correlations, so we add them only to the extractants we have data for.\n",
+    "\n",
+    "The model is: `log10(D) = a + b*pH + c*pH^2`, with a temperature correction `d*(1/T - 1/T_ref)`.\n",
+    "\n",
+    "**The values below are illustrative placeholders.** In practice, you would obtain these by fitting published D vs. pH data for Ho with your extractant system (see notebook `21_custom_extractants.ipynb` for a calibration example)."
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 4,
    "id": "479d1285",
-   "source": "# Add Ho coefficients to PC88A only\n# PLACEHOLDER VALUES - replace with your literature data!\n#\n# These follow the lanthanide contraction trend in the PC88A data:\n#   Tb: a=-6.52, b=2.82   Dy: a=-6.32, b=2.90\n# Ho (Z=67) should sit just above Dy, continuing the ~0.18/0.07 step:\next_db.add_element_to_extractant(\n    \"PC88A\",\n    \"Ho\",\n    ph_coefficients={\n        \"a\": -6.15,    # slightly less negative than Dy (-6.32)\n        \"b\": 2.95,     # slightly steeper than Dy (2.90)\n        \"c\": 0.010,    # same quadratic term as series\n    },\n    temperature_coefficient=-2350,  # K, continuing trend from Dy (-2300)\n)\n\n# Verify: Ho is now in PC88A but NOT in other extractants\npc88a = ext_db.get(\"PC88A\")\nprint(\"Ho in PC88A:\", \"Ho\" in pc88a.ph_coefficients)\nprint(\"Ho in D2EHPA:\", \"Ho\" in ext_db.get(\"D2EHPA\").ph_coefficients)\nprint()\nprint(f\"PC88A now covers: {sorted(pc88a.ph_coefficients.keys())}\")",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-04T15:38:00.937610Z",
+     "iopub.status.busy": "2026-09-04T15:38:00.937543Z",
+     "iopub.status.idle": "2026-09-04T15:38:00.939519Z",
+     "shell.execute_reply": "2026-09-04T15:38:00.939252Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Ho in PC88A: True\n",
+      "Ho in D2EHPA: False\n",
+      "\n",
+      "PC88A now covers: ['Ce', 'Dy', 'Eu', 'Gd', 'Ho', 'La', 'Nd', 'Pr', 'Sm', 'Tb', 'Y']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Add Ho coefficients to PC88A only\n",
+    "# PLACEHOLDER VALUES - replace with your literature data!\n",
+    "#\n",
+    "# These follow the lanthanide contraction trend in the PC88A data:\n",
+    "#   Tb: a=-6.52, b=2.82   Dy: a=-6.32, b=2.90\n",
+    "# Ho (Z=67) should sit just above Dy, continuing the ~0.18/0.07 step:\n",
+    "ext_db.add_element_to_extractant(\n",
+    "    \"PC88A\",\n",
+    "    \"Ho\",\n",
+    "    ph_coefficients={\n",
+    "        \"a\": -6.15,    # slightly less negative than Dy (-6.32)\n",
+    "        \"b\": 2.95,     # slightly steeper than Dy (2.90)\n",
+    "        \"c\": 0.010,    # same quadratic term as series\n",
+    "    },\n",
+    "    temperature_coefficient=-2350,  # K, continuing trend from Dy (-2300)\n",
+    ")\n",
+    "\n",
+    "# Verify: Ho is now in PC88A but NOT in other extractants\n",
+    "pc88a = ext_db.get(\"PC88A\")\n",
+    "print(\"Ho in PC88A:\", \"Ho\" in pc88a.ph_coefficients)\n",
+    "print(\"Ho in D2EHPA:\", \"Ho\" in ext_db.get(\"D2EHPA\").ph_coefficients)\n",
+    "print()\n",
+    "print(f\"PC88A now covers: {sorted(pc88a.ph_coefficients.keys())}\")"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "105effbd",
-   "source": "## 4. Adding separation factor data\n\nSeparation factors quantify how well two elements can be separated. You can add individual pairs to existing extractants, or create a complete entry for a new extractant.",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "## 4. Adding separation factor data\n",
+    "\n",
+    "Separation factors quantify how well two elements can be separated. You can add individual pairs to existing extractants, or create a complete entry for a new extractant."
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 5,
    "id": "c502b989",
-   "source": "# Add Ho separation factor pairs to PC88A\n# Convention: \"heavier_lighter\", SF = D_heavier / D_lighter\n# PLACEHOLDER VALUES - replace with your literature data!\nsf_db.add_pair(\"PC88A\", \"Ho_Dy\", 1.4, adjacent=True, stages_99=20)\nsf_db.add_pair(\"PC88A\", \"Y_Ho\", 0.9, adjacent=True)\n\n# Non-adjacent group pair\nsf_db.add_pair(\"PC88A\", \"Ho_Gd\", 2.8, adjacent=False)\n\n# Query the data back\nprint(\"SF(Ho/Dy) with PC88A:\", sf_db.get_sf(\"PC88A\", \"Ho_Dy\"))\nprint(\"SF(Y/Ho)  with PC88A:\", sf_db.get_sf(\"PC88A\", \"Y_Ho\"))\nprint(\"Stages for 99% Ho/Dy:\", sf_db.get_stages_needed(\"PC88A\", \"Ho_Dy\"))",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-04T15:38:00.940630Z",
+     "iopub.status.busy": "2026-09-04T15:38:00.940567Z",
+     "iopub.status.idle": "2026-09-04T15:38:00.942384Z",
+     "shell.execute_reply": "2026-09-04T15:38:00.942127Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "SF(Ho/Dy) with PC88A: 1.4\n",
+      "SF(Y/Ho)  with PC88A: 0.9\n",
+      "Stages for 99% Ho/Dy: 20\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Add Ho separation factor pairs to PC88A\n",
+    "# Convention: \"heavier_lighter\", SF = D_heavier / D_lighter\n",
+    "# PLACEHOLDER VALUES - replace with your literature data!\n",
+    "sf_db.add_pair(\"PC88A\", \"Ho_Dy\", 1.4, adjacent=True, stages_99=20)\n",
+    "sf_db.add_pair(\"PC88A\", \"Y_Ho\", 0.9, adjacent=True)\n",
+    "\n",
+    "# Non-adjacent group pair\n",
+    "sf_db.add_pair(\"PC88A\", \"Ho_Gd\", 2.8, adjacent=False)\n",
+    "\n",
+    "# Query the data back\n",
+    "print(\"SF(Ho/Dy) with PC88A:\", sf_db.get_sf(\"PC88A\", \"Ho_Dy\"))\n",
+    "print(\"SF(Y/Ho)  with PC88A:\", sf_db.get_sf(\"PC88A\", \"Y_Ho\"))\n",
+    "print(\"Stages for 99% Ho/Dy:\", sf_db.get_stages_needed(\"PC88A\", \"Ho_Dy\"))"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "b07fb341",
-   "source": "## 5. Using Ho in distribution calculations\n\nWith the element registered and extraction coefficients added, Ho works just like any built-in element in the distribution model.",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "## 5. Using Ho in distribution calculations\n",
+    "\n",
+    "With the element registered and extraction coefficients added, Ho works just like any built-in element in the distribution model."
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 6,
    "id": "9f8ef0d7",
-   "source": "# Create distribution model including Ho\ndist = REEDistribution(\n    extractant=\"PC88A\",\n    elements=(\"Gd\", \"Dy\", \"Ho\", \"Y\"),\n    concentration=0.5,\n)\n\n# D values at pH 2.0 (low enough to see meaningful differences)\nprint(\"Distribution coefficients with PC88A at pH 2.0, 25 C:\")\nprint(\"-\" * 50)\nD_all = dist.get_D_all(pH=2.0, T=298.15)\nfor elem, D in D_all.items():\n    print(f\"  D({elem:>2}) = {float(D):8.4f}\")\n\nprint()\n\n# Separation factors from D values\nD_Ho = float(D_all[\"Ho\"])\nD_Dy = float(D_all[\"Dy\"])\nD_Gd = float(D_all[\"Gd\"])\nD_Y  = float(D_all[\"Y\"])\nprint(\"Separation factors (should show Ho > Dy > Y > Gd):\")\nprint(f\"  SF(Ho/Dy) = D(Ho)/D(Dy) = {D_Ho/D_Dy:.2f}\")\nprint(f\"  SF(Ho/Gd) = D(Ho)/D(Gd) = {D_Ho/D_Gd:.2f}\")\nprint(f\"  SF(Y/Ho)  = D(Y)/D(Ho)  = {D_Y/D_Ho:.2f}\")",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-04T15:38:00.943337Z",
+     "iopub.status.busy": "2026-09-04T15:38:00.943272Z",
+     "iopub.status.idle": "2026-09-04T15:38:01.046881Z",
+     "shell.execute_reply": "2026-09-04T15:38:01.046429Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Distribution coefficients with PC88A at pH 2.0, 25 C:\n",
+      "--------------------------------------------------\n",
+      "  D(Gd) =   0.0617\n",
+      "  D(Dy) =   0.3311\n",
+      "  D(Ho) =   0.6166\n",
+      "  D( Y) =   0.0776\n",
+      "\n",
+      "Separation factors (should show Ho > Dy > Y > Gd):\n",
+      "  SF(Ho/Dy) = D(Ho)/D(Dy) = 1.86\n",
+      "  SF(Ho/Gd) = D(Ho)/D(Gd) = 10.00\n",
+      "  SF(Y/Ho)  = D(Y)/D(Ho)  = 0.13\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Create distribution model including Ho\n",
+    "dist = REEDistribution(\n",
+    "    extractant=\"PC88A\",\n",
+    "    elements=(\"Gd\", \"Dy\", \"Ho\", \"Y\"),\n",
+    "    concentration=0.5,\n",
+    ")\n",
+    "\n",
+    "# D values at pH 2.0 (low enough to see meaningful differences)\n",
+    "print(\"Distribution coefficients with PC88A at pH 2.0, 25 C:\")\n",
+    "print(\"-\" * 50)\n",
+    "D_all = dist.get_D_all(pH=2.0, T=298.15)\n",
+    "for elem, D in D_all.items():\n",
+    "    print(f\"  D({elem:>2}) = {float(D):8.4f}\")\n",
+    "\n",
+    "print()\n",
+    "\n",
+    "# Separation factors from D values\n",
+    "D_Ho = float(D_all[\"Ho\"])\n",
+    "D_Dy = float(D_all[\"Dy\"])\n",
+    "D_Gd = float(D_all[\"Gd\"])\n",
+    "D_Y  = float(D_all[\"Y\"])\n",
+    "print(\"Separation factors (should show Ho > Dy > Y > Gd):\")\n",
+    "print(f\"  SF(Ho/Dy) = D(Ho)/D(Dy) = {D_Ho/D_Dy:.2f}\")\n",
+    "print(f\"  SF(Ho/Gd) = D(Ho)/D(Gd) = {D_Ho/D_Gd:.2f}\")\n",
+    "print(f\"  SF(Y/Ho)  = D(Y)/D(Ho)  = {D_Y/D_Ho:.2f}\")"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "6999eb4e",
-   "source": "## 6. Using Ho in a multi-stage extraction unit\n\nCustom elements also work with the unit operation models. Here we run a 5-stage extraction of a Gd/Ho/Y mixture with PC88A.",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "## 6. Using Ho in a multi-stage extraction unit\n",
+    "\n",
+    "Custom elements also work with the unit operation models. Here we run a 5-stage extraction of a Gd/Ho/Y mixture with PC88A."
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 7,
    "id": "731b6d5d",
-   "source": "# Create extractor at pH 2.0 where there is meaningful selectivity\nparams = REEExtractorParams(\n    n_stages=5,\n    extractant=\"PC88A\",\n    elements=(\"Gd\", \"Ho\", \"Y\"),\n    pH=2.0,\n    include_loading=False,  # no loading isotherm data for Ho\n)\nextractor = REEExtractor(params)\n\n# Feed stream: mixed Gd/Ho/Y solution\nfeed = make_stream(\n    flows={\"H2O\": 10.0, \"Gd\": 0.02, \"Ho\": 0.01, \"Y\": 0.015},\n    T=298.15, P=101325.0,\n)\n\n# Organic solvent (S/F ~ 1.0 by volume)\nsolvent = make_stream(\n    flows={\"Organic\": 10.0, \"Gd\": 0.0, \"Ho\": 0.0, \"Y\": 0.0},\n    T=298.15, P=101325.0,\n)\n\n# Run extraction\nraffinate, extract, info = extractor(feed, solvent)\n\n# Results\nfeed_flows = get_flows(feed)\next_flows = get_flows(extract)\n\nprint(\"Extraction results (5 stages, PC88A, pH 2.0, S/F=1.0):\")\nprint(\"-\" * 55)\nprint(f\"{'Element':<10} {'Feed (mol/s)':<15} {'Extract':<15} {'Recovery %'}\")\nprint(\"-\" * 55)\nfor elem in [\"Gd\", \"Ho\", \"Y\"]:\n    f_val = float(feed_flows[elem])\n    e_val = float(ext_flows[elem])\n    rec = (e_val / f_val) * 100 if f_val > 0 else 0\n    print(f\"{elem:<10} {f_val:<15.4f} {e_val:<15.4f} {rec:.1f}\")",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-04T15:38:01.048024Z",
+     "iopub.status.busy": "2026-09-04T15:38:01.047947Z",
+     "iopub.status.idle": "2026-09-04T15:38:01.189345Z",
+     "shell.execute_reply": "2026-09-04T15:38:01.188896Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Extraction results (5 stages, PC88A, pH 2.0, S/F=1.0):\n",
+      "-------------------------------------------------------\n",
+      "Element    Feed (mol/s)    Extract         Recovery %\n",
+      "-------------------------------------------------------\n",
+      "Gd         0.0200          0.0012          6.1\n",
+      "Ho         0.0100          0.0059          59.2\n",
+      "Y          0.0150          0.0012          7.7\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Create extractor at pH 2.0 where there is meaningful selectivity\n",
+    "params = REEExtractorParams(\n",
+    "    n_stages=5,\n",
+    "    extractant=\"PC88A\",\n",
+    "    elements=(\"Gd\", \"Ho\", \"Y\"),\n",
+    "    pH=2.0,\n",
+    "    include_loading=False,  # no loading isotherm data for Ho\n",
+    ")\n",
+    "extractor = REEExtractor(params)\n",
+    "\n",
+    "# Feed stream: mixed Gd/Ho/Y solution\n",
+    "feed = make_stream(\n",
+    "    flows={\"H2O\": 10.0, \"Gd\": 0.02, \"Ho\": 0.01, \"Y\": 0.015},\n",
+    "    T=298.15, P=101325.0,\n",
+    ")\n",
+    "\n",
+    "# Organic solvent stream.\n",
+    "#\n",
+    "# The stream must name the *extractant* and the *diluent* as species. A\n",
+    "# solvent whose carrier matches neither now raises instead of silently\n",
+    "# defaulting the organic flow to 1.0 (#192), and when loading is enabled the\n",
+    "# extractant molar flow is what sets the capacity of the organic phase\n",
+    "# (capacity = F_extractant / m, #191).\n",
+    "#\n",
+    "# 0.5 M PC88A in kerosene is roughly 10 mol% extractant (kerosene is\n",
+    "# ~0.75 g/mL and ~170 g/mol, so ~4.4 mol/L of diluent against 0.5 mol/L of\n",
+    "# extractant). The total organic flow is unchanged at 10.0 mol/s\n",
+    "# (S/F ~ 1.0); it is just split 1.0 PC88A / 9.0 kerosene.\n",
+    "solvent = make_stream(\n",
+    "    flows={\"PC88A\": 1.0, \"kerosene\": 9.0, \"Gd\": 0.0, \"Ho\": 0.0, \"Y\": 0.0},\n",
+    "    T=298.15, P=101325.0,\n",
+    ")\n",
+    "\n",
+    "# Run extraction\n",
+    "raffinate, extract, info = extractor(feed, solvent)\n",
+    "\n",
+    "# Results\n",
+    "feed_flows = get_flows(feed)\n",
+    "ext_flows = get_flows(extract)\n",
+    "\n",
+    "print(\"Extraction results (5 stages, PC88A, pH 2.0, S/F=1.0):\")\n",
+    "print(\"-\" * 55)\n",
+    "print(f\"{'Element':<10} {'Feed (mol/s)':<15} {'Extract':<15} {'Recovery %'}\")\n",
+    "print(\"-\" * 55)\n",
+    "for elem in [\"Gd\", \"Ho\", \"Y\"]:\n",
+    "    f_val = float(feed_flows[elem])\n",
+    "    e_val = float(ext_flows[elem])\n",
+    "    rec = (e_val / f_val) * 100 if f_val > 0 else 0\n",
+    "    print(f\"{elem:<10} {f_val:<15.4f} {e_val:<15.4f} {rec:.1f}\")"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "4f1768f8",
-   "source": "## 7. Gradients work through custom elements\n\nBecause the custom element uses the same differentiable model, JAX automatic differentiation works as expected. Here we compute the gradient of Ho recovery with respect to pH.",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "## 7. Gradients work through custom elements\n",
+    "\n",
+    "Because the custom element uses the same differentiable model, JAX automatic differentiation works as expected. Here we compute the gradient of Ho recovery with respect to pH."
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 8,
    "id": "b2c9fe34",
-   "source": "from jax import grad\n\ndef ho_recovery(pH):\n    \"\"\"Compute Ho recovery as a function of extraction pH.\"\"\"\n    params = REEExtractorParams(\n        n_stages=5,\n        extractant=\"PC88A\",\n        elements=(\"Gd\", \"Ho\", \"Y\"),\n        pH=pH,\n        include_loading=False,\n    )\n    extractor = REEExtractor(params)\n\n    feed = make_stream(\n        flows={\"H2O\": 10.0, \"Gd\": 0.02, \"Ho\": 0.01, \"Y\": 0.015},\n        T=298.15, P=101325.0,\n    )\n    solvent = make_stream(\n        flows={\"Organic\": 10.0, \"Gd\": 0.0, \"Ho\": 0.0, \"Y\": 0.0},\n        T=298.15, P=101325.0,\n    )\n\n    _, extract, _ = extractor(feed, solvent)\n    ext_flows = get_flows(extract)\n    return ext_flows[\"Ho\"] / 0.01  # recovery fraction\n\n# Gradient of recovery w.r.t. pH\nd_recovery_d_pH = grad(ho_recovery)\n\npH_test = 2.0\nrec = float(ho_recovery(pH_test))\ndrec = float(d_recovery_d_pH(pH_test))\n\nprint(f\"At pH {pH_test}:\")\nprint(f\"  Ho recovery:     {rec:.4f} ({rec*100:.1f}%)\")\nprint(f\"  d(recovery)/dpH: {drec:.4f}\")\nprint(f\"  -> Increasing pH by 0.1 would change recovery by ~{drec*0.1*100:.1f}%\")",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-04T15:38:01.190526Z",
+     "iopub.status.busy": "2026-09-04T15:38:01.190444Z",
+     "iopub.status.idle": "2026-09-04T15:38:01.532346Z",
+     "shell.execute_reply": "2026-09-04T15:38:01.531849Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "At pH 2.0:\n",
+      "  Ho recovery:     0.5920 (59.2%)\n",
+      "  d(recovery)/dpH: 3.5124\n",
+      "  -> Increasing pH by 0.1 would change recovery by ~35.1%\n"
+     ]
+    }
+   ],
+   "source": [
+    "from jax import grad\n",
+    "\n",
+    "def ho_recovery(pH):\n",
+    "    \"\"\"Compute Ho recovery as a function of extraction pH.\"\"\"\n",
+    "    params = REEExtractorParams(\n",
+    "        n_stages=5,\n",
+    "        extractant=\"PC88A\",\n",
+    "        elements=(\"Gd\", \"Ho\", \"Y\"),\n",
+    "        pH=pH,\n",
+    "        include_loading=False,\n",
+    "    )\n",
+    "    extractor = REEExtractor(params)\n",
+    "\n",
+    "    feed = make_stream(\n",
+    "        flows={\"H2O\": 10.0, \"Gd\": 0.02, \"Ho\": 0.01, \"Y\": 0.015},\n",
+    "        T=298.15, P=101325.0,\n",
+    "    )\n",
+    "    # Same solvent as above: PC88A + kerosene, total organic flow 10.0 (#191/#192)\n",
+    "    solvent = make_stream(\n",
+    "        flows={\"PC88A\": 1.0, \"kerosene\": 9.0, \"Gd\": 0.0, \"Ho\": 0.0, \"Y\": 0.0},\n",
+    "        T=298.15, P=101325.0,\n",
+    "    )\n",
+    "\n",
+    "    _, extract, _ = extractor(feed, solvent)\n",
+    "    ext_flows = get_flows(extract)\n",
+    "    return ext_flows[\"Ho\"] / 0.01  # recovery fraction\n",
+    "\n",
+    "# Gradient of recovery w.r.t. pH\n",
+    "d_recovery_d_pH = grad(ho_recovery)\n",
+    "\n",
+    "pH_test = 2.0\n",
+    "rec = float(ho_recovery(pH_test))\n",
+    "drec = float(d_recovery_d_pH(pH_test))\n",
+    "\n",
+    "print(f\"At pH {pH_test}:\")\n",
+    "print(f\"  Ho recovery:     {rec:.4f} ({rec*100:.1f}%)\")\n",
+    "print(f\"  d(recovery)/dpH: {drec:.4f}\")\n",
+    "print(f\"  -> Increasing pH by 0.1 would change recovery by ~{drec*0.1*100:.1f}%\")"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "a3bdca23",
-   "source": "## 8. Correcting or removing custom data\n\nIf you need to update coefficients (e.g., after getting better literature data), remove and re-add. All custom data modifications are runtime-only and do not affect the YAML files on disk.",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "## 8. Correcting or removing custom data\n",
+    "\n",
+    "If you need to update coefficients (e.g., after getting better literature data), remove and re-add. All custom data modifications are runtime-only and do not affect the YAML files on disk."
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 9,
    "id": "481b683e",
-   "source": "# Update extraction coefficients: remove and re-add\next_db.remove_element_from_extractant(\"PC88A\", \"Ho\")\next_db.add_element_to_extractant(\n    \"PC88A\", \"Ho\",\n    ph_coefficients={\"a\": -6.18, \"b\": 2.96, \"c\": 0.011},  # revised values\n    temperature_coefficient=-2380,\n)\nprint(\"Updated Ho coefficients for PC88A\")\n\n# Update element properties (e.g., corrected price)\nupdated_ho = create_custom_element(\n    symbol=\"Ho\", name=\"Holmium\", atomic_number=67,\n    atomic_weight=164.930, ionic_radius_pm=90.1, density=8.795,\n    melting_point=1734, group=\"heavy\", oxide_formula=\"Ho2O3\",\n    oxide_mw=377.86, price_usd_kg=75.0,  # updated price\n)\nree_db.update_element(\"Ho\", updated_ho)\nprint(f\"Updated Ho price: ${ree_db.get('Ho').price_usd_kg}/kg\")\n\n# Remove separation factor pair and re-add\nsf_db.remove_pair(\"PC88A\", \"Ho_Dy\")\nsf_db.add_pair(\"PC88A\", \"Ho_Dy\", 1.5, stages_99=18)  # revised value\nprint(f\"Updated SF(Ho/Dy): {sf_db.get_sf('PC88A', 'Ho_Dy')}\")",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-04T15:38:01.533795Z",
+     "iopub.status.busy": "2026-09-04T15:38:01.533700Z",
+     "iopub.status.idle": "2026-09-04T15:38:01.535927Z",
+     "shell.execute_reply": "2026-09-04T15:38:01.535534Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Updated Ho coefficients for PC88A\n",
+      "Updated Ho price: $75.0/kg\n",
+      "Updated SF(Ho/Dy): 1.5\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Update extraction coefficients: remove and re-add\n",
+    "ext_db.remove_element_from_extractant(\"PC88A\", \"Ho\")\n",
+    "ext_db.add_element_to_extractant(\n",
+    "    \"PC88A\", \"Ho\",\n",
+    "    ph_coefficients={\"a\": -6.18, \"b\": 2.96, \"c\": 0.011},  # revised values\n",
+    "    temperature_coefficient=-2380,\n",
+    ")\n",
+    "print(\"Updated Ho coefficients for PC88A\")\n",
+    "\n",
+    "# Update element properties (e.g., corrected price)\n",
+    "updated_ho = create_custom_element(\n",
+    "    symbol=\"Ho\", name=\"Holmium\", atomic_number=67,\n",
+    "    atomic_weight=164.930, ionic_radius_pm=90.1, density=8.795,\n",
+    "    melting_point=1734, group=\"heavy\", oxide_formula=\"Ho2O3\",\n",
+    "    oxide_mw=377.86, price_usd_kg=75.0,  # updated price\n",
+    ")\n",
+    "ree_db.update_element(\"Ho\", updated_ho)\n",
+    "print(f\"Updated Ho price: ${ree_db.get('Ho').price_usd_kg}/kg\")\n",
+    "\n",
+    "# Remove separation factor pair and re-add\n",
+    "sf_db.remove_pair(\"PC88A\", \"Ho_Dy\")\n",
+    "sf_db.add_pair(\"PC88A\", \"Ho_Dy\", 1.5, stages_99=18)  # revised value\n",
+    "print(f\"Updated SF(Ho/Dy): {sf_db.get_sf('PC88A', 'Ho_Dy')}\")"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "6d155a51",
-   "source": "## 9. Cleanup\n\nRemove Ho from all databases to restore the original state. Since the databases are singletons, this matters if other code in your session relies on the default element list.",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "## 9. Cleanup\n",
+    "\n",
+    "Remove Ho from all databases to restore the original state. Since the databases are singletons, this matters if other code in your session relies on the default element list."
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 10,
    "id": "13cf5c03",
-   "source": "# Remove Ho from extractant coefficients\next_db.remove_element_from_extractant(\"PC88A\", \"Ho\")\n\n# Remove Ho separation factor pairs\nfor pair in [\"Ho_Dy\", \"Y_Ho\", \"Ho_Gd\"]:\n    try:\n        sf_db.remove_pair(\"PC88A\", pair)\n    except KeyError:\n        pass\n\n# Remove Ho from element database\nree_db.remove_element(\"Ho\")\n\nprint(\"Restored databases:\")\nprint(\"  Elements:\", ree_db.list_elements())\nprint(\"  Heavy REEs:\", ree_db.list_by_group(\"heavy\"))\nprint(\"  PC88A elements:\", sorted(ext_db.get(\"PC88A\").ph_coefficients.keys()))",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-04T15:38:01.536962Z",
+     "iopub.status.busy": "2026-09-04T15:38:01.536860Z",
+     "iopub.status.idle": "2026-09-04T15:38:01.538741Z",
+     "shell.execute_reply": "2026-09-04T15:38:01.538414Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Restored databases:\n",
+      "  Elements: ['La', 'Ce', 'Pr', 'Nd', 'Sm', 'Eu', 'Gd', 'Tb', 'Dy', 'Y']\n",
+      "  Heavy REEs: ['Tb', 'Dy', 'Y']\n",
+      "  PC88A elements: ['Ce', 'Dy', 'Eu', 'Gd', 'La', 'Nd', 'Pr', 'Sm', 'Tb', 'Y']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Remove Ho from extractant coefficients\n",
+    "ext_db.remove_element_from_extractant(\"PC88A\", \"Ho\")\n",
+    "\n",
+    "# Remove Ho separation factor pairs\n",
+    "for pair in [\"Ho_Dy\", \"Y_Ho\", \"Ho_Gd\"]:\n",
+    "    try:\n",
+    "        sf_db.remove_pair(\"PC88A\", pair)\n",
+    "    except KeyError:\n",
+    "        pass\n",
+    "\n",
+    "# Remove Ho from element database\n",
+    "ree_db.remove_element(\"Ho\")\n",
+    "\n",
+    "print(\"Restored databases:\")\n",
+    "print(\"  Elements:\", ree_db.list_elements())\n",
+    "print(\"  Heavy REEs:\", ree_db.list_by_group(\"heavy\"))\n",
+    "print(\"  PC88A elements:\", sorted(ext_db.get(\"PC88A\").ph_coefficients.keys()))"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "982959b8",
-   "source": "## Summary\n\nThis notebook demonstrated the full workflow for extending the REE database with custom elements:\n\n| Step | Function | Purpose |\n|------|----------|---------|\n| Create element | `create_custom_element(...)` | Build an `REEElement` from physical properties |\n| Register element | `ree_db.add_element(symbol, elem)` | Make it available to all database queries |\n| Add extraction data | `ext_db.add_element_to_extractant(...)` | Provide pH/temperature coefficients for specific extractants |\n| Add SF data | `sf_db.add_pair(...)` | Provide separation factors for specific element pairs |\n| Update data | `remove_*` then re-add | Correct values when better literature data becomes available |\n\nAll modifications are runtime-only: they do not alter the YAML files on disk, so restarting Python restores the defaults.\n\nFor creating entirely new extractants (rather than adding elements to existing ones), see notebook `21_custom_extractants.ipynb`.",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "This notebook demonstrated the full workflow for extending the REE database with custom elements:\n",
+    "\n",
+    "| Step | Function | Purpose |\n",
+    "|------|----------|---------|\n",
+    "| Create element | `create_custom_element(...)` | Build an `REEElement` from physical properties |\n",
+    "| Register element | `ree_db.add_element(symbol, elem)` | Make it available to all database queries |\n",
+    "| Add extraction data | `ext_db.add_element_to_extractant(...)` | Provide pH/temperature coefficients for specific extractants |\n",
+    "| Add SF data | `sf_db.add_pair(...)` | Provide separation factors for specific element pairs |\n",
+    "| Update data | `remove_*` then re-add | Correct values when better literature data becomes available |\n",
+    "\n",
+    "All modifications are runtime-only: they do not alter the YAML files on disk, so restarting Python restores the defaults.\n",
+    "\n",
+    "For creating entirely new extractants (rather than adding elements to existing ones), see notebook `21_custom_extractants.ipynb`."
+   ]
   }
  ],
  "metadata": {
@@ -154,8 +663,16 @@
    "name": "python3"
   },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "version": "3.13.0"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.5"
   }
  },
  "nbformat": 4,

--- a/src/difflow_ree/README.md
+++ b/src/difflow_ree/README.md
@@ -116,12 +116,65 @@ print(f"Element recoveries: {results['element_recovery']}")
 
 ## Supported Extractants
 
-| Extractant | Type | Best For |
-|------------|------|----------|
-| D2EHPA | Acidic | Light REE separation |
-| PC88A | Acidic | General REE separation |
-| Cyanex272 | Acidic | Heavy REE, Co/Ni |
-| TBP | Neutral | Nitrate systems |
+| Extractant | Type | Mechanism | Driving variable | Best For |
+|------------|------|-----------|------------------|----------|
+| D2EHPA | Acidic | `cation_exchange` | pH | Light REE separation |
+| PC88A | Acidic | `cation_exchange` | pH | General REE separation |
+| Cyanex272 | Acidic | `cation_exchange` | pH | Heavy REE, Co/Ni |
+| TBP | Neutral | `solvating` | `[NO3-]` | Nitrate systems |
+
+The mechanism is carried by the extractant record and decides which correlation
+drives `D` (#195). TBP therefore requires a `nitrate_conc`:
+
+```python
+REEDistribution(
+    extractant="TBP", elements=("Nd",), nitrate_conc=3.0, concentration=1.1
+)
+```
+
+and raises without one. There is no other path: **TBP's `ph_coefficients` block
+has been deleted**, so `REEDistribution(extractant="TBP", ...,
+mechanism="cation_exchange")` now raises a `ValueError` naming TBP and pointing
+back at the nitrate path. The block modelled a neutral extractant (`pKa: null`,
+`protons_released: 0`) as a weak cation exchanger — there is no proton to
+exchange, no source reports a pH slope for TBP, and it carried the same refuted
+selectivity spread as the old nitrate block. `Extractant.ph_coefficients` is
+therefore `dict | None`.
+
+> **TBP's nitrate coefficients are now refitted from primary literature.**
+> They are the *only* literature-derived numbers in `data/extractants.yaml`;
+> D2EHPA / PC88A / Cyanex272 remain hand-tuned with no recorded source. Fit
+> basis: Kraikaew, Srinuttrakul & Chayavadhanakur (2005), *J. Metals, Materials
+> and Minerals* **15**(2), 89-95, Table 1, corrected to 3 M NO3⁻ / 1 M TBP /
+> 298.15 K; heat of extraction from Ganesh & Pandey (2019), *J. Rad. Nucl.
+> Appl.* **4**(2), 109-115 (`dH_Sm = -43.3 kJ/mol`).
+>
+> At the reference this now gives `D_La = 0.023` … `D_Dy = 0.24` — every value
+> below 1, `D_Dy/D_La = 10.2` (was 100), mean adjacent-pair separation factor
+> 1.29 per unit atomic number (La(57) to Dy(66) is 9 steps, Pm included). `b = 3.0` for every element is *stoichiometric*, not fitted. Every
+> temperature coefficient is now **positive**, i.e. exothermic (they were all
+> negative, which asserted the opposite).
+>
+> **Validity window:** neutral nitrate salt, ≤ 0.5 M free acid, 1–6 M NO3⁻,
+> 283–326 K. Use for relative REE selectivity, stage-count intuition, and trend
+> or sensitivity studies. Do **not** use for stage counts, solvent inventories,
+> absolute recoveries, HNO3-supplied nitrate, loaded solvent, or Y at any other
+> acidity. Tb is *interpolated*, not measured; nine of the ten temperature
+> coefficients are assumed equal to Sm. The full provenance, the per-element
+> measured/interpolated/assumed labels and the known gaps are written out on the
+> TBP record in `data/extractants.yaml` — read it before using any TBP number.
+>
+> The 0.5 M `extractant_conc` default is a cation-exchange default and knocks
+> TBP's `D` down 8x; TBP is run at ~30% v/v = 1.1 M.
+
+`pH` is on the concentration scale and `ionic_strength=None` (no activity
+correction, a conditional constant at the operating ionic strength) is the
+default and the right choice for a concentrated liquor (#194). When an ionic
+strength *is* supplied, the value fed to the activity model is clamped at that
+model's documented range limit, because the Davies bracket changes sign at
+I = 1.9404 M and above that the correction would multiply `D` instead of
+reducing it (6.5x at 3 M). Pass `extrapolate_activity_model=True` to opt into
+the raw extrapolation. See `docs/unit-operations-ree.md`.
 
 ## References
 

--- a/src/difflow_ree/__init__.py
+++ b/src/difflow_ree/__init__.py
@@ -62,6 +62,9 @@ from difflow_ree.database import (
     # Custom creation helpers
     create_custom_element,
     create_custom_extractant,
+    # Extraction mechanisms (#195)
+    EXTRACTION_MECHANISMS,
+    normalize_mechanism,
     # JAX-compatible accessors
     get_atomic_weight_array,
     get_price_array,
@@ -85,6 +88,13 @@ from difflow_ree.equilibrium import (
     REESpeciation,
     sulfate_speciation,
     chloride_speciation,
+    # Activity models and their declared validity ranges (#194)
+    ACTIVITY_MODELS,
+    AQUEOUS_MEDIA,
+    NITRATE_BEARING_MEDIA,
+    DAVIES_MAX_IONIC_STRENGTH,
+    DAVIES_SIGN_CHANGE_IONIC_STRENGTH,
+    activity_coefficient,
 )
 
 # =============================================================================
@@ -374,6 +384,14 @@ __all__ = [
     "REESpeciation",
     "sulfate_speciation",
     "chloride_speciation",
+    "ACTIVITY_MODELS",
+    "AQUEOUS_MEDIA",
+    "NITRATE_BEARING_MEDIA",
+    "DAVIES_MAX_IONIC_STRENGTH",
+    "DAVIES_SIGN_CHANGE_IONIC_STRENGTH",
+    "activity_coefficient",
+    "EXTRACTION_MECHANISMS",
+    "normalize_mechanism",
     # Units
     "REEExtractor",
     "REEExtractorParams",

--- a/src/difflow_ree/data/extractants.yaml
+++ b/src/difflow_ree/data/extractants.yaml
@@ -1,25 +1,94 @@
-# Extractant Properties and pH-Dependent Distribution Correlations
+# Extractant Properties and Distribution Correlations
 #
-# Distribution coefficient model:
-#   log10(D) = a + b*pH + c*pH^2 + d/T
+# EXTRACTION MECHANISM (#195)
+# Every extractant declares a normalized `mechanism:` key. It is the mechanism,
+# not the code, that decides which coefficient block drives D:
+#
+#   mechanism: cation_exchange -> driven by `ph_coefficients`
+#     RE3+ + p(HA)2 <-> RE(HA2)p + p H+
+#   mechanism: solvating       -> driven by `nitrate_coefficients`
+#     RE(NO3)3 + m S <-> RE(NO3)3.mS   (no protons released)
+#
+# The mapping from the free-form `type:` field is:
+#   acidic_phosphoric / acidic_phosphonic / acidic_phosphinic /
+#   acidic_carboxylic  -> cation_exchange
+#   solvating_neutral  -> solvating
+# `mechanism:` is stated explicitly on every record so it is data rather than
+# an inference; difflow_ree.database.normalize_mechanism reproduces the mapping
+# for records that omit it.
+#
+# CATION-EXCHANGE MODEL (`ph_coefficients`):
+#   log10(D) = a + b*pH + c*pH^2 + d*(1/T - 1/Tref)
 #
 # where:
 #   D = [REE]_org / [REE]_aq
-#   pH = -log10([H+])
+#   pH = -log10([H+])       <- CONCENTRATION SCALE, not the activity scale (#194)
 #   T = temperature (K)
 #
-# CALIBRATION NOTES:
-# These coefficients are calibrated to give realistic D values:
-#   - At pH 2.0: D typically 0.001-0.1 for LREE, 0.1-1 for HREE
-#   - At pH 3.0: D typically 0.05-1 for LREE, 1-30 for HREE
-#   - At pH 4.0: D typically 1-20 for LREE, 50-500 for HREE
-#   - Separation factors between adjacent REE: 1.5-4
+# pH SCALE AND ACTIVITY CONVENTION (#194)
+# `pH` here is -log10 of the free proton *concentration*. These are conditional
+# correlations: the a/b/c coefficients are fitted at the ionic strength of the
+# reported experiments and already absorb the activity coefficients at that
+# ionic strength. Consequently:
+#   - The defensible default is NO activity correction at all
+#     (REEDistribution(..., ionic_strength=None)), i.e. a conditional constant
+#     used at the ionic strength it was fitted at. This is the right choice for
+#     a 2-4 M chloride leach liquor.
+#   - If a correction to a different ionic strength is requested, it must be
+#     gamma_RE / gamma_H**p on the concentration scale, with p =
+#     stoichiometry.protons_released, NOT gamma_RE alone. Davies is only valid
+#     for I < 0.5 M and difflow_ree reports outside that range.
+#   - Davies does not merely lose accuracy above 0.5 M. Its bracket
+#     f(I) = sqrt(I)/(1+sqrt(I)) - 0.3 I changes SIGN at I = 1.940363884733242 M
+#     (the root of 0.3 I + 0.3 sqrt(I) - 1 = 0), above which
+#     gamma_RE/gamma_H**3 = 10**(-6 A f) exceeds 1 and the correction
+#     MULTIPLIES D: 0.228 at I = 0.1 M, 0.245 at 1.0 M, 6.49 at 3.0 M, 42.5 at
+#     4.0 M. difflow_ree therefore clamps the ionic strength it feeds the
+#     activity model at the model's documented limit, so the correction
+#     saturates rather than inverting, unless the caller explicitly passes
+#     extrapolate_activity_model=True (#194).
 #
-# Sources:
+# SOLVATING MODEL (`nitrate_coefficients`):
+#   log10(D) = a + b*log10([NO3-]/reference_nitrate)
+#              + c*log10([NO3-]/reference_nitrate)^2
+#              + d*(1/T - 1/Tref)
+#
+# so `a` is log10(D) AT the reference nitrate concentration and `b` is the
+# nitrate slope d log10(D) / d log10([NO3-]). There is no pH term.
+#
+# PROVENANCE OF THE COEFFICIENTS -- TWO DIFFERENT KINDS OF NUMBER
+#
+# This file now contains coefficient blocks of two DIFFERENT provenances. They
+# must not be mistaken for one another:
+#
+#   (1) HAND-TUNED, NO SOURCE  -- the `ph_coefficients` and
+#       `temperature_coefficients` of D2EHPA, PC88A and Cyanex272.
+#       These were chosen to give plausible-looking D values:
+#         - At pH 2.0: D typically 0.001-0.1 for LREE, 0.1-1 for HREE
+#         - At pH 3.0: D typically 0.05-1 for LREE, 1-30 for HREE
+#         - At pH 4.0: D typically 1-20 for LREE, 50-500 for HREE
+#         - Separation factors between adjacent REE: 1.5-4
+#       No fit, dataset or table is recorded for any of them anywhere in this
+#       repository. They are illustrative, not measured. Do not cite them, do
+#       not regress equilibrium constants against them, and do not use them
+#       for design numbers.
+#
+#   (2) LITERATURE-DERIVED    -- TBP's `nitrate_coefficients` and
+#       `temperature_coefficients` ONLY.
+#       Refitted from named, retrievable primary sources; the fit basis, the
+#       correction arithmetic, the per-element provenance (measured vs
+#       interpolated vs assumed), the validity window and the known gaps are
+#       all written out on the TBP record below. Read that block before using
+#       any TBP number.
+#
+# Nothing else in this file is literature-derived. In particular, TBP's
+# nitrate block being fitted says NOTHING about the three acidic extractants.
+#
+# Background reading behind the hand-tuned blocks (consulted qualitatively;
+# NOT the source of any specific number here):
 # - Gupta & Krishnamurthy (2005) Extractive Metallurgy of Rare Earths
-# - Xie et al. (2014) Hydrometallurgy reviews
+# - Xie, Zhang, Dreisinger & Doyle (2014) Miner. Eng. 56, 10
 # - Peppard et al. (1957) J. Inorg. Nucl. Chem.
-# - Various literature correlations
 
 extractants:
   D2EHPA:
@@ -29,13 +98,20 @@ extractants:
     density: 0.975  # g/mL
     pKa: 3.24  # in aqueous
     type: acidic_phosphoric
+    mechanism: cation_exchange  # normalized from type (#195)
     diluents: [kerosene, n-heptane, Shellsol_D70]
     typical_concentration: 0.5  # M in organic phase
 
     # Extraction mechanism: REE³⁺ + 3(HA)₂ ⇌ REE(HA₂)₃ + 3H⁺
+    # basis: dimer -> extractant_molecules counts (HA)₂ dimers, so the
+    # capacity in monomer equivalents is 3 * 2 = 6 mol D2EHPA per mol REE
+    # (max_loading = 1/6). D2EHPA is dimeric in aliphatic diluents at the low
+    # to moderate loadings these correlations cover; the monomeric (m = 3)
+    # stoichiometry is reported at high loading and in polar diluents. See #191.
     stoichiometry:
       protons_released: 3
       extractant_molecules: 3  # as dimers
+      basis: dimer
 
     # pH correlation coefficients: log10(D) = a + b*pH + c*pH²
     # Valid range: pH 1-5, T = 298K, [D2EHPA] = 0.5M
@@ -59,8 +135,19 @@ extractants:
       Y:  {a: -7.00, b: 2.65, c: 0.010, d: 0.0}
 
     # Temperature correction: add d*(1/T - 1/298.15) to log(D)
-    # Extraction is exothermic, D decreases with T
-    temperature_coefficients:  # d values in K
+    #
+    # OPEN QUESTION (unresolved, numbers deliberately unchanged). The comment
+    # line that used to sit here said "extraction is exothermic, D decreases
+    # with T", but under log10 D = ... + d*(1/T - 1/Tref) with
+    # d = -dH/(2.303 R), a NEGATIVE d is an ENDOTHERMIC dH -- these values
+    # imply dH = +29 to +46 kJ/mol, i.e. D *rising* with T, the opposite of
+    # the sentence. That may or may not be wrong: acidic organophosphorus REE
+    # extraction is reported both ways depending on system, and unlike TBP
+    # (see the TBP record, where the sign WAS refuted and fixed) no data was
+    # retrieved here either way. So the sign is left as-is and flagged rather
+    # than silently flipped. This is a separate question from the TBP refit
+    # and needs its own literature pass before any of these numbers move.
+    temperature_coefficients:  # d values in K; sign unverified, see above
       La: -1500
       Ce: -1600
       Pr: -1700
@@ -89,12 +176,16 @@ extractants:
     density: 0.955
     pKa: 4.10
     type: acidic_phosphonic
+    mechanism: cation_exchange  # normalized from type (#195)
     diluents: [kerosene, n-heptane, Shellsol_D70]
     typical_concentration: 0.5
 
+    # Extraction mechanism: REE³⁺ + 3(HA)₂ ⇌ REE(HA₂)₃ + 3H⁺
+    # Dimeric, as D2EHPA: 6 mol PC88A per mol REE (max_loading = 1/6). See #191.
     stoichiometry:
       protons_released: 3
       extractant_molecules: 3
+      basis: dimer
 
     # PC88A has better light REE selectivity than D2EHPA
     # Particularly good for Nd/Pr separation (SF ~ 3-4 vs 2-3 for D2EHPA)
@@ -116,6 +207,8 @@ extractants:
       Dy: {a: -6.32, b: 2.90, c: 0.010, d: 0.0}
       Y:  {a: -6.65, b: 2.75, c: 0.010, d: 0.0}
 
+    # Sign unverified; same open question as D2EHPA above (negative d implies
+    # ENDOTHERMIC extraction). Numbers deliberately unchanged.
     temperature_coefficients:
       La: -1400
       Ce: -1500
@@ -141,12 +234,17 @@ extractants:
     density: 0.920
     pKa: 6.37
     type: acidic_phosphinic
+    mechanism: cation_exchange  # normalized from type (#195)
     diluents: [kerosene, Shellsol_D70]
     typical_concentration: 0.3
 
+    # Extraction mechanism: REE³⁺ + 3(HA)₂ ⇌ REE(HA₂)₃ + 3H⁺
+    # Dimeric in aliphatic diluents: 6 mol Cyanex272 per mol REE
+    # (max_loading = 1/6). See #191.
     stoichiometry:
       protons_released: 3
       extractant_molecules: 3
+      basis: dimer
 
     # Cyanex 272 has high pKa - operates at higher pH (4-6)
     # Excellent Co/Ni rejection, used for specialty REE separations
@@ -167,6 +265,8 @@ extractants:
       Dy: {a: -7.15, b: 2.70, c: 0.005, d: 0.0}
       Y:  {a: -7.55, b: 2.58, c: 0.005, d: 0.0}
 
+    # Sign unverified; same open question as D2EHPA above (negative d implies
+    # ENDOTHERMIC extraction). Numbers deliberately unchanged.
     temperature_coefficients:
       La: -1300
       Ce: -1400
@@ -192,59 +292,273 @@ extractants:
     density: 0.979
     pKa: null  # Neutral extractant
     type: solvating_neutral
+    mechanism: solvating  # normalized from type (#195)
     diluents: [kerosene, n-dodecane]
     typical_concentration: 1.0  # Often 30% v/v in diluent
 
     # Solvating extraction from nitrate media
     # REE(NO3)3 + 3TBP ⇌ REE(NO3)3·3TBP
+    # Solvating, monomeric: 3 mol TBP per mol REE (max_loading = 1/3). See #191.
     stoichiometry:
       protons_released: 0
       extractant_molecules: 3
+      basis: monomer
       requires_nitrate: true
 
-    # TBP extraction depends on nitrate concentration, not pH
-    # Model: log10(D) = a + b*log10([NO3-]) + d/T
-    # Coefficients for [NO3-] = 3M reference
+    # =====================================================================
+    # TBP NITRATE COEFFICIENTS -- REFITTED FROM PRIMARY LITERATURE
+    # =====================================================================
+    # Model (as implemented by difflow_ree.equilibrium.distribution):
     #
-    # TBP shows reverse selectivity (HREE extracted more than LREE)
-    # at typical nitrate concentrations
+    #   log10(D) = a + b*log10([NO3-]/reference_nitrate)
+    #                + c*log10([NO3-]/reference_nitrate)^2
+    #                + d*(1/T - 1/298.15)
+    #                + n*log10([TBP]/reference_concentration)
+    #
+    #   `a` = log10(D) AT the reference: [NO3-] = 3.0 M, [TBP] = 1.0 M,
+    #         T = 298.15 K.
+    #   `b` = nitrate slope d log10(D) / d log10([NO3-]).
+    #   `d` = -dH / (2.303 R), so d > 0 <=> dH < 0 <=> EXOTHERMIC.
+    #
+    # WHAT WAS WRONG BEFORE, AND IS NOW FIXED
+    #   1. The old `a` values gave D_Dy/D_La = 100 at the reference. Measured:
+    #      10.2. The old spread was an acidic-organophosphorus selectivity
+    #      pattern, not a solvating one.
+    #   2. The old `a` values gave D_Dy = 3.16 at the reference. Measured
+    #      (corrected to the reference): 0.24.
+    #   3. Every old `d` was NEGATIVE, which under the model above means
+    #      ENDOTHERMIC. TBP extraction of REE nitrates is EXOTHERMIC. Every
+    #      `d` is now POSITIVE.
+    #   4. The old per-element `b` trend 2.50-2.85 had no support of any kind
+    #      and is removed; `b` is now the stoichiometric 3.0 for every element.
+    #
+    # ---------------------------------------------------------------------
+    # SOURCES (these four, and no others; nothing else here is a source)
+    # ---------------------------------------------------------------------
+    # S1  Kraikaew, Srinuttrakul & Chayavadhanakur (2005), "Solvent Extraction
+    #     Study of Rare Earths from Nitrate Medium by the Mixtures of TBP and
+    #     D2EHPA in Kerosene", J. Metals, Materials and Minerals 15(2), 89-95.
+    #     No DOI. https://jmmm.material.chula.ac.th/index.php/jmmm/article/view/1345
+    #     Table 1, p. 92. Conditions: RE nitrate from monazite, free acidity
+    #     0.2001 N, TBP in kerosene, equal phase volumes, 35 +/- 1 C.
+    #     >>> This is the ONLY source of the `a` values below. <<<
+    #
+    # S2  Topp & Weaver, ORNL-1811, "Distribution of Rare-Earth Nitrates
+    #     Between Tributyl Phosphate and Nitric Acid" (1954).
+    #     DOI 10.2172/4398970.
+    #     Used only to bound the validity window (Tables II/IV, 8.5-17.4 N).
+    #
+    # S3  Poos & Wilhelm, ISC-695, "Separation of Yttrium and Some Rare Earths
+    #     by Liquid-Liquid Extraction", Ames Laboratory (1954). OSTI 4332475.
+    #     Used only for the Y acidity-dependent-position caveat.
+    #
+    # S4  Ganesh & Pandey (2019), J. Rad. Nucl. Appl. 4(2), 109-115.
+    #     The DOI printed in the PDF (10.18576/jrna/040205) is NOT REGISTERED
+    #     IN CROSSREF -- it does not resolve. Cite the retrieved PDF instead:
+    #     https://www.naturalspublishing.com/files/published/q86xt25u4iq5o9.pdf
+    #     Table 1: dH_Sm = -43.3 +/- 6.2 kJ/mol (1.1 M TBP in n-dodecane,
+    #     3.8-3.89 M HNO3, 283-326 K, R^2 = 0.979).
+    #     Fig. 1: log D_Sm = 2.8055*log[TBP]_free - 2.8503, R^2 = 0.992.
+    #     >>> This is the ONLY source of the `d` value below. <<<
+    #
+    # S5  Jorjani & Shahbazi (2016), Arab. J. Chem. 9, S1532-S1539,
+    #     DOI 10.1016/j.arabjc.2012.04.002. Extraction fell as T went
+    #     25 -> 55 C. Corroborates exothermicity; supplies no number here.
+    #
+    # KNOWN GAP -- THE SINGLE HIGHEST-VALUE FOLLOW-UP
+    #     Fidelis (1970), "Temperature effect on the extraction of lanthanides
+    #     in the TBP-HNO3 system", J. Inorg. Nucl. Chem. 32, 997-1003,
+    #     DOI 10.1016/0022-1902(70)80079-3, measured the WHOLE lanthanide
+    #     series at 10/17/25/40 C -- i.e. exactly the per-element dH that is
+    #     assumed constant below. It is paywalled with no open-access copy and
+    #     was NOT used. Obtaining it would replace nine assumed `d` values
+    #     with nine measured ones. That is the next thing to do to this record.
+    #
+    # ---------------------------------------------------------------------
+    # FIT BASIS AND THE CORRECTION ARITHMETIC
+    # ---------------------------------------------------------------------
+    # S1 Table 1 reports D at 1.0 M TBP, at 6.06 M nitrate and 308.15 K.
+    # Corrected to the record's reference (3.0 M NO3-, 1.0 M TBP, 298.15 K):
+    #
+    #   a = log10(D_measured)
+    #       + 3*log10(3.0/6.06)              = -0.9162   (nitrate, b = 3)
+    #       - 2300*(1/308.15 - 1/298.15)     = +0.2504   (temperature, d = 2300)
+    #
+    #   i.e.  a = log10(D_measured) - 0.6658
+    #
+    # THE 6.06 M NITRATE IS DERIVED, NOT REPORTED. S1 does not state a nitrate
+    # concentration. 6.06 M was computed from S1's ppm feed table (sum of the
+    # RE nitrates, plus the 0.2 N free acid). THIS IS THE SINGLE LARGEST
+    # UNCERTAINTY IN THE `a` VALUES: the nitrate correction is 3*log10(3/[NO3-]),
+    # so a 10% error in the derived 6.06 M moves every `a` by 0.13 log units
+    # (35%) IN COMMON. Relative selectivity (the ratios, which is what these
+    # numbers are actually good for) is unaffected; the absolute level is not.
+    #
+    # ---------------------------------------------------------------------
+    # PER-ELEMENT PROVENANCE -- READ THIS BEFORE USING ANY SINGLE NUMBER
+    # ---------------------------------------------------------------------
+    #   La  DERIVED from S1 Table 1 (measured D, corrected as above)
+    #   Ce  DERIVED from S1 Table 1
+    #   Pr  DERIVED from S1 Table 1
+    #   Nd  DERIVED from S1 Table 1
+    #   Sm  DERIVED from S1 Table 1
+    #   Eu  DERIVED from S1 Table 1
+    #   Gd  DERIVED from S1 Table 1
+    #   Tb  *** INTERPOLATED -- NOT MEASURED ***
+    #       Log-linear in atomic number between Gd (Z = 64) and Dy (Z = 66).
+    #       NO TBP-nitrate distribution ratio for Tb exists in ANY source
+    #       retrieved for this refit. a_Tb is a straight-line fill-in with no
+    #       measurement behind it. Treat any Tb result as interpolation.
+    #   Dy  DERIVED from S1 Table 1
+    #   Y   DERIVED from S1 Table 1, but SPECIAL CASE -- see below.
+    #
+    # Y IS A SPECIAL CASE AND A SINGLE a_Y IS A FICTION.
+    #   Yttrium has no 4f shell; its effective position in the REE extraction
+    #   series is not fixed but SLIDES WITH ACIDITY -- Ho-like at high acidity,
+    #   La-like at very low acidity (S3). One number cannot represent that.
+    #   The a_Y written below is the ~6 M nitrate, LOW-FREE-ACID value from
+    #   S1's conditions (0.2 N), corrected like the rest. At any other acidity
+    #   it is wrong, and wrong by an unknown amount in a known direction.
+    #   Do not use Y at any acidity other than S1's.
+    #
+    # b = 3.0 IS STOICHIOMETRIC, NOT FITTED.
+    #   It is the 3 of RE(NO3)3 + 3 TBP <-> RE(NO3)3.3TBP. NO measured
+    #   d log D / d log[NO3-] in a neutral-salt system was found in any
+    #   retrieved source, so there is no fitted nitrate slope to write. The
+    #   only corroboration is INDIRECT: S4 Fig. 1 measured the TBP order as
+    #   2.81 (R^2 = 0.992), close to 3. All ten elements share b = 3.0 because
+    #   nothing in the data distinguishes them; the old 2.50-2.85 per-element
+    #   trend was invented.
+    #
+    # d = +2300 K FOR EVERY ELEMENT: ONE MEASUREMENT, NINE ASSUMPTIONS.
+    #   From S4's dH_Sm = -43.3 kJ/mol via d = -dH/(2.303 R)
+    #     = 43300 / (2.303 * 8.314) = 2262 K, rounded to 2300 K.
+    #   *** Sm is MEASURED. The other nine elements are ASSUMED EQUAL TO Sm
+    #       and are NO DATA. *** There is no per-element heat of extraction in
+    #   anything retrieved (that is what the Fidelis gap above would supply).
+    #   The sign, however, is solid and is the point: dH < 0, so d > 0, so D
+    #   FALLS as T rises. S5 corroborates the direction independently.
+    #
+    #   +/-40% AMBIGUITY IN THE MAGNITUDE. S4's Table 1 appears to have its dH
+    #   and slope columns TRANSPOSED between its two rows, so the value that
+    #   belongs to TBP is either -43.3 or -61.2 kJ/mol, giving d = +2261 K or
+    #   d = +3197 K. This cannot be resolved from the paper as published.
+    #   The defensible range is therefore d = +2260 to +3200 K; +2300 is the
+    #   low end of it. Any temperature study should sweep that range rather
+    #   than trust the single value.
+    #
+    # ---------------------------------------------------------------------
+    # VALIDITY WINDOW
+    # ---------------------------------------------------------------------
+    # These coefficients -- and in particular b = 3.0 -- are valid ONLY for:
+    #
+    #     nitrate supplied by a NEUTRAL SALT
+    #       (NH4NO3 / LiNO3 / Ca(NO3)2 / Mg(NO3)2 / Al(NO3)3),
+    #     free acid <= 0.5 M,
+    #     [NO3-] 1-6 M,
+    #     T 283-326 K.
+    #
+    # WHY ONE `b` CANNOT COVER MORE THAN THAT (both measured, both outside):
+    #   - NEAT TBP + CONCENTRATED HNO3: the slope is ~6, not 3
+    #     (S2 Tables II/IV, 8.5-17.4 N). Twice the exponent.
+    #   - DILUTE TBP + HNO3: at 1.1 M TBP, D actually FALLS with acidity,
+    #     because the acid consumes the extractant as the TBP.HNO3 adduct and
+    #     starves the RE complex of free TBP. The effective slope is ~0 or
+    #     NEGATIVE (S4 Fig. 4). Opposite sign.
+    #   A single b cannot be 3, 6 and -something at once. The neutral-salt,
+    #   low-acid window is the one where b = 3 is the right physics.
+    #
+    # TWO FURTHER CAVEATS ON THE LEVEL (not the shape):
+    #   - The model's extractant term uses TOTAL [TBP] (`[TBP]/1.0 M` raised to
+    #     concentration_exponent). The measured cube law holds in FREE TBP.
+    #     These differ whenever the solvent is loaded or the acid is high.
+    #   - S1's solvent was AT OR OVER SATURATION: an organic loading of 0.35 M
+    #     requires 1.05 M TBP of the 1.0 M available. So S1's D values -- and
+    #     hence every `a` below -- are LOADING-SUPPRESSED PROCESS values, not
+    #     trace-level D. Trace D would be higher.
+    #
+    # ---------------------------------------------------------------------
+    # USE FOR / DO NOT USE FOR
+    # ---------------------------------------------------------------------
+    # USE FOR:
+    #   - relative REE selectivity of TBP (the element ORDER and the ratios)
+    #   - showing why a TBP separation needs very many stages
+    #   - trend and sensitivity studies, gradient-based structure studies
+    #   - the DIRECTION of the temperature and nitrate dependences
+    #
+    # DO NOT USE FOR:
+    #   - stage counts or column sizing
+    #   - solvent inventories
+    #   - absolute recoveries or purities
+    #   - any system where the nitrate is supplied by HNO3 rather than a
+    #     neutral salt
+    #   - loaded solvent (these are already loading-suppressed; the loading
+    #     model would double-count)
+    #   - free acidity above ~0.5 M
+    #   - regressing equilibrium constants against these numbers
+    #   - Y at any acidity other than S1's 0.2 N
+    #
+    # AT THE REFERENCE (3.0 M NO3-, 1.0 M TBP, 298.15 K) THESE GIVE:
+    #   La 0.023, Ce 0.032, Pr 0.060, Nd 0.072, Sm 0.120, Eu 0.138,
+    #   Gd 0.174, Tb 0.204, Dy 0.240, Y 0.214
+    #   D_Dy/D_La = 10.2; mean adjacent-pair separation factor La->Dy = 1.29
+    #   (per unit atomic number over the 9 steps La(57) -> Dy(66), which
+    #   includes Pm(61); counting only the 8 gaps in the tracked element
+    #   list would inflate this to 1.34). Inside the 1.1-1.5 reported for
+    #   TBP; the old record implied 1.67, above that range.
+    #   Every D is below 1: TBP is a weak extractant and this now shows it.
+    #
+    # NOTE ON EXTRACTANT CONCENTRATION. Every Params class in difflow_ree
+    # defaults extractant_conc = 0.5 M, which with reference_concentration 1.0
+    # and concentration_exponent 3.0 multiplies every D above by 0.125. 0.5 M
+    # is a cation-exchange default and is meaningless for TBP: TBP is normally
+    # run at ~30% v/v, which for the density and MW on this record is 1.10 M
+    # (neat TBP is 3.68 M). Set extractant_conc ~ 1.1 explicitly for TBP.
     nitrate_coefficients:
-      La: {a: -1.50, b: 2.50, c: 0.0, d: 0.0}
-      Ce: {a: -1.30, b: 2.55, c: 0.0, d: 0.0}
-      Pr: {a: -1.10, b: 2.60, c: 0.0, d: 0.0}
-      Nd: {a: -0.90, b: 2.60, c: 0.0, d: 0.0}
-      Sm: {a: -0.40, b: 2.70, c: 0.0, d: 0.0}
-      Eu: {a: -0.20, b: 2.70, c: 0.0, d: 0.0}
-      Gd: {a: 0.00, b: 2.75, c: 0.0, d: 0.0}
-      Tb: {a: 0.30, b: 2.80, c: 0.0, d: 0.0}
-      Dy: {a: 0.50, b: 2.85, c: 0.0, d: 0.0}
-      Y:  {a: 0.20, b: 2.75, c: 0.0, d: 0.0}
+      La: {a: -1.63, b: 3.0, c: 0.0, d: 0.0}   # DERIVED, S1 Table 1
+      Ce: {a: -1.49, b: 3.0, c: 0.0, d: 0.0}   # DERIVED, S1 Table 1
+      Pr: {a: -1.22, b: 3.0, c: 0.0, d: 0.0}   # DERIVED, S1 Table 1
+      Nd: {a: -1.14, b: 3.0, c: 0.0, d: 0.0}   # DERIVED, S1 Table 1
+      Sm: {a: -0.92, b: 3.0, c: 0.0, d: 0.0}   # DERIVED, S1 Table 1
+      Eu: {a: -0.86, b: 3.0, c: 0.0, d: 0.0}   # DERIVED, S1 Table 1
+      Gd: {a: -0.76, b: 3.0, c: 0.0, d: 0.0}   # DERIVED, S1 Table 1
+      Tb: {a: -0.69, b: 3.0, c: 0.0, d: 0.0}   # INTERPOLATED Gd-Dy, NOT MEASURED
+      Dy: {a: -0.62, b: 3.0, c: 0.0, d: 0.0}   # DERIVED, S1 Table 1
+      Y:  {a: -0.67, b: 3.0, c: 0.0, d: 0.0}   # DERIVED, S1 Table 1; ACIDITY-SPECIFIC
 
-    # TBP also works with HNO3 - use ph_coefficients for acidic systems
-    # Lower sensitivity to pH than acidic extractants
-    ph_coefficients:
-      La: {a: -2.00, b: 0.50, c: 0.0, d: 0.0}
-      Ce: {a: -1.80, b: 0.55, c: 0.0, d: 0.0}
-      Pr: {a: -1.60, b: 0.60, c: 0.0, d: 0.0}
-      Nd: {a: -1.40, b: 0.60, c: 0.0, d: 0.0}
-      Sm: {a: -0.90, b: 0.70, c: 0.0, d: 0.0}
-      Eu: {a: -0.70, b: 0.70, c: 0.0, d: 0.0}
-      Gd: {a: -0.50, b: 0.75, c: 0.0, d: 0.0}
-      Tb: {a: -0.20, b: 0.80, c: 0.0, d: 0.0}
-      Dy: {a: 0.00, b: 0.85, c: 0.0, d: 0.0}
-      Y:  {a: -0.30, b: 0.75, c: 0.0, d: 0.0}
+    # NO ph_coefficients BLOCK -- DELETED ON PURPOSE.
+    # TBP formerly carried a `ph_coefficients` block, reachable via
+    #   REEDistribution(extractant="TBP", ..., mechanism="cation_exchange").
+    # It was removed because it was mechanistically indefensible, not merely
+    # uncalibrated:
+    #   - It modelled TBP as a weak CATION EXCHANGER, but this very record has
+    #     pKa: null and stoichiometry.protons_released: 0. There is no proton
+    #     to exchange. The model had no mechanism under it.
+    #   - No retrieved source reports a pH-slope correlation for TBP at all.
+    #   - It carried the same refuted 100x La-to-Dy spread as the old nitrate
+    #     block (see above), from the same unrecorded origin.
+    # Asking for TBP with mechanism="cation_exchange" now RAISES a ValueError
+    # naming TBP and pointing at the nitrate path. There is no fallback.
+    # TBP in HNO3 is a real system, but it is one this file has no coefficients
+    # for -- and per the validity window above, b = 3 would be wrong for it
+    # anyway (S2 measured ~6, S4 measured ~0 or negative). Anyone who needs it
+    # must supply fitted coefficients, not reach for a deleted block.
 
-    temperature_coefficients:
-      La: -800
-      Ce: -900
-      Pr: -1000
-      Nd: -1100
-      Sm: -1300
-      Eu: -1400
-      Gd: -1500
-      Tb: -1600
-      Dy: -1700
-      Y:  -1500
+    # d = -dH/(2.303 R) > 0 <=> EXOTHERMIC. All ten are +2300 K:
+    # Sm MEASURED (S4, dH = -43.3 kJ/mol); the other nine ASSUMED EQUAL TO Sm
+    # and carrying NO DATA. Defensible range +2260 to +3200 K (S4 column
+    # transposition, see above). Fidelis (1970) would replace all nine.
+    temperature_coefficients:  # d values in K
+      La: 2300   # ASSUMED = Sm (no data)
+      Ce: 2300   # ASSUMED = Sm (no data)
+      Pr: 2300   # ASSUMED = Sm (no data)
+      Nd: 2300   # ASSUMED = Sm (no data)
+      Sm: 2300   # MEASURED, S4 Table 1
+      Eu: 2300   # ASSUMED = Sm (no data)
+      Gd: 2300   # ASSUMED = Sm (no data)
+      Tb: 2300   # ASSUMED = Sm (no data)
+      Dy: 2300   # ASSUMED = Sm (no data)
+      Y:  2300   # ASSUMED = Sm (no data)
 
     valid_ph_range: [0.5, 4.0]  # Works in highly acidic conditions
     valid_temp_range: [283, 353]

--- a/src/difflow_ree/database.py
+++ b/src/difflow_ree/database.py
@@ -204,14 +204,91 @@ class REEDatabase:
 
 @dataclass(frozen=True)
 class PHCoefficients:
-    """pH-dependent distribution coefficient parameters.
+    """Quadratic distribution-coefficient parameters in a driving variable.
 
-    log10(D) = a + b*pH + c*pH^2
+    For a cation-exchange extractant the driving variable is pH on the
+    *concentration* scale (``pH = -log10([H+])``, see the header of
+    ``data/extractants.yaml``)::
+
+        log10(D) = a + b*pH + c*pH^2
+
+    The same container is reused for the solvating extractants (#195), where
+    the driving variable is the nitrate log-ratio ``s = log10([NO3-]/[NO3-]_ref)``
+    referenced to :attr:`Extractant.reference_nitrate`::
+
+        log10(D) = a + b*s + c*s^2
+
+    so that ``a`` is ``log10(D)`` *at the reference nitrate concentration* and
+    ``b`` is the nitrate slope ``d log10(D) / d log10([NO3-])``.
     """
     a: float
     b: float
     c: float
     d: float = 0.0  # Temperature coefficient (optional)
+
+
+# Normalized extraction mechanisms (#195). The mechanism decides which
+# coefficient block drives D and whether a proton term appears in the
+# activity correction (#194); it is data, not an assumption in the code.
+EXTRACTION_MECHANISMS = ("cation_exchange", "solvating")
+
+# Mapping from the historical free-form ``type`` field to the normalized
+# mechanism. Stated explicitly in data/extractants.yaml as well (#195).
+_TYPE_TO_MECHANISM = {
+    "acidic_phosphoric": "cation_exchange",
+    "acidic_phosphonic": "cation_exchange",
+    "acidic_phosphinic": "cation_exchange",
+    "acidic_carboxylic": "cation_exchange",
+    "solvating_neutral": "solvating",
+}
+
+
+def normalize_mechanism(extractant_type: str) -> str:
+    """Normalize an extractant ``type`` string to an extraction mechanism.
+
+    Args:
+        extractant_type: Free-form type from the extractant record, e.g.
+            ``"acidic_phosphoric"`` or ``"solvating_neutral"``.
+
+    Returns:
+        One of :data:`EXTRACTION_MECHANISMS`. Types that are not recognized
+        (including the ``"custom"`` default of
+        :func:`create_custom_extractant`) fall back to ``"cation_exchange"``,
+        which is the mechanism the ``ph_coefficients`` block describes.
+    """
+    if extractant_type in _TYPE_TO_MECHANISM:
+        return _TYPE_TO_MECHANISM[extractant_type]
+    if extractant_type.startswith("acidic"):
+        return "cation_exchange"
+    if extractant_type.startswith("solvating"):
+        return "solvating"
+    return "cation_exchange"
+
+
+def _load_coefficient_block(
+    block: dict | None,
+) -> dict[str, PHCoefficients] | None:
+    """Convert a YAML ``{element: {a, b, c, d}}`` block to PHCoefficients.
+
+    Args:
+        block: Raw YAML mapping, or None when the extractant does not carry
+            that coefficient block.
+
+    Returns:
+        Mapping of element symbol to :class:`PHCoefficients`, or None if
+        ``block`` was None.
+    """
+    if block is None:
+        return None
+    return {
+        element: PHCoefficients(
+            a=coeffs["a"],
+            b=coeffs["b"],
+            c=coeffs["c"],
+            d=coeffs.get("d", 0.0),
+        )
+        for element, coeffs in block.items()
+    }
 
 
 @dataclass
@@ -227,7 +304,13 @@ class Extractant:
     typical_concentration: float
     stoichiometry_protons: int
     stoichiometry_extractant: int
-    ph_coefficients: dict[str, PHCoefficients]
+    # None when the record carries no pH-driven correlation at all. That is not
+    # an oversight: TBP's ``ph_coefficients`` block was DELETED because it
+    # modelled a neutral solvating extractant (pKa null, protons_released 0) as
+    # a weak cation exchanger, with no proton to exchange and no source. Any
+    # consumer of this field must therefore handle None; there is no empty-dict
+    # stand-in and no fallback to another block.
+    ph_coefficients: dict[str, PHCoefficients] | None
     temperature_coefficients: dict[str, float]
     valid_ph_range: tuple[float, float]
     valid_temp_range: tuple[float, float]
@@ -241,6 +324,54 @@ class Extractant:
     heat_of_extraction: float | None = None
     heat_of_scrubbing: float | None = None
     heat_of_stripping: float | None = None
+    # Basis on which ``stoichiometry_extractant`` counts extractant species:
+    # "dimer" for the acidic organophosphorus extractants, which are dimeric in
+    # aliphatic diluents, "monomer" for neutral/solvating extractants (#191).
+    stoichiometry_basis: str = "monomer"
+    # Extraction mechanism (#195). None normalizes from ``extractant_type`` in
+    # __post_init__; the YAML states it explicitly so the mechanism is data
+    # rather than an inference.
+    mechanism: str | None = None
+    # Solvating-extraction data (#195). ``nitrate_coefficients`` is shaped like
+    # ``ph_coefficients`` but is driven by log10([NO3-]/reference_nitrate).
+    nitrate_coefficients: dict[str, PHCoefficients] | None = None
+    reference_nitrate: float | None = None
+    # True when the extractant only works from a nitrate (salting) medium, so
+    # using it without a nitrate concentration is an error rather than a
+    # silent fall-back to the pH correlation (#195).
+    requires_nitrate: bool = False
+
+    def __post_init__(self):
+        """Normalize the extraction mechanism (#195)."""
+        if self.mechanism is None:
+            self.mechanism = normalize_mechanism(self.extractant_type)
+        if self.mechanism not in EXTRACTION_MECHANISMS:
+            raise ValueError(
+                f"Extractant '{self.name}': unknown mechanism "
+                f"{self.mechanism!r}. Supported mechanisms: "
+                f"{list(EXTRACTION_MECHANISMS)}."
+            )
+
+    @property
+    def monomers_per_ree(self) -> float:
+        """Extractant monomer equivalents bound per mol REE.
+
+        This is the ``m`` in the extractant balance
+
+            [HA]_total = [HA]_free + m * [RE-complex]
+
+        so the maximum organic loading is ``1 / m`` mol REE per mol extractant.
+        Derived from the declared stoichiometry and its basis rather than
+        hard-coded, so that the capacity and the free-extractant exponent can
+        never disagree (#191).
+        """
+        per_species = 2.0 if self.stoichiometry_basis == "dimer" else 1.0
+        return self.stoichiometry_extractant * per_species
+
+    @property
+    def max_loading(self) -> float:
+        """Maximum REE loading capacity (mol REE per mol extractant)."""
+        return 1.0 / self.monomers_per_ree
 
 
 class ExtractantDatabase:
@@ -263,14 +394,13 @@ class ExtractantDatabase:
         self._modifiers: dict[str, dict] = data.get("modifiers", {})
 
         for name, props in data["extractants"].items():
-            ph_coeffs = {}
-            for element, coeffs in props["ph_coefficients"].items():
-                ph_coeffs[element] = PHCoefficients(
-                    a=coeffs["a"],
-                    b=coeffs["b"],
-                    c=coeffs["c"],
-                    d=coeffs.get("d", 0.0),
-                )
+            ph_coeffs = _load_coefficient_block(props.get("ph_coefficients"))
+            # Solvating-extraction coefficients, driven by the nitrate
+            # log-ratio rather than by pH (#195). Absent for the acidic
+            # cation exchangers.
+            nitrate_coeffs = _load_coefficient_block(
+                props.get("nitrate_coefficients")
+            )
 
             self._extractants[name] = Extractant(
                 name=name,
@@ -283,6 +413,7 @@ class ExtractantDatabase:
                 typical_concentration=props["typical_concentration"],
                 stoichiometry_protons=props["stoichiometry"]["protons_released"],
                 stoichiometry_extractant=props["stoichiometry"]["extractant_molecules"],
+                stoichiometry_basis=props["stoichiometry"].get("basis", "monomer"),
                 ph_coefficients=ph_coeffs,
                 temperature_coefficients=props["temperature_coefficients"],
                 valid_ph_range=tuple(props["valid_ph_range"]),
@@ -294,6 +425,13 @@ class ExtractantDatabase:
                 heat_of_extraction=props.get("heat_of_extraction"),
                 heat_of_scrubbing=props.get("heat_of_scrubbing"),
                 heat_of_stripping=props.get("heat_of_stripping"),
+                # Mechanism and solvating-extraction data (#195)
+                mechanism=props.get("mechanism"),
+                nitrate_coefficients=nitrate_coeffs,
+                reference_nitrate=props.get("reference_nitrate"),
+                requires_nitrate=bool(
+                    props["stoichiometry"].get("requires_nitrate", False)
+                ),
             )
 
     def get(self, name: str) -> Extractant:
@@ -376,7 +514,8 @@ class ExtractantDatabase:
 
         Raises:
             KeyError: If extractant doesn't exist
-            ValueError: If element already has data for this extractant, or
+            ValueError: If the extractant carries no ``ph_coefficients`` block
+                at all, if the element already has data for this extractant, or
                 if required coefficient keys are missing
         """
         if extractant_name not in self._extractants:
@@ -386,6 +525,18 @@ class ExtractantDatabase:
             )
 
         extractant = self._extractants[extractant_name]
+
+        if extractant.ph_coefficients is None:
+            raise ValueError(
+                f"Extractant '{extractant_name}' carries no 'ph_coefficients' "
+                f"block, so a pH-driven coefficient for '{element}' cannot be "
+                f"added to it. Its mechanism is {extractant.mechanism!r}; for "
+                "a solvating extractant the pH-driven correlation does not "
+                "exist and creating one here would reintroduce exactly the "
+                "unsupported model that was deleted from the record. Add to "
+                "'nitrate_coefficients' instead, or register a separate "
+                "extractant with fitted pH coefficients."
+            )
 
         if element in extractant.ph_coefficients:
             raise ValueError(
@@ -427,7 +578,10 @@ class ExtractantDatabase:
             raise KeyError(f"Extractant '{extractant_name}' not found")
 
         extractant = self._extractants[extractant_name]
-        if element not in extractant.ph_coefficients:
+        if (
+            extractant.ph_coefficients is None
+            or element not in extractant.ph_coefficients
+        ):
             raise KeyError(
                 f"Element '{element}' not found in extractant '{extractant_name}'"
             )
@@ -671,11 +825,16 @@ def create_custom_extractant(
     typical_concentration: float = 0.5,
     stoichiometry_protons: int = 3,
     stoichiometry_extractant: int = 3,
+    stoichiometry_basis: str = "monomer",
     valid_ph_range: tuple[float, float] = (1.0, 5.0),
     valid_temp_range: tuple[float, float] = (283.0, 333.0),
     reference_concentration: float = 0.5,
     concentration_exponent: float = 3.0,
     cost_usd_kg: float = 10.0,
+    mechanism: str | None = None,
+    nitrate_coefficients: dict[str, dict[str, float]] | None = None,
+    reference_nitrate: float | None = None,
+    requires_nitrate: bool = False,
 ) -> Extractant:
     """Create a custom extractant with user-defined properties.
 
@@ -690,6 +849,11 @@ def create_custom_extractant(
         ph_coefficients: pH-dependent distribution coefficients for each REE element.
             Format: {"La": {"a": -8.0, "b": 2.2, "c": 0.01, "d": 0.0}, ...}
             Model: log10(D) = a + b*pH + c*pH^2 + d/T
+            Still REQUIRED here, even for ``mechanism="solvating"``. Note the
+            asymmetry with the YAML path, where a record may omit the block
+            entirely (TBP does, and :attr:`Extractant.ph_coefficients` is
+            therefore ``dict | None``): a custom solvating extractant must
+            still supply one. Loosening this is a separate change.
         temperature_coefficients: Temperature correction for each element (K).
             Format: {"La": -1500, "Nd": -1700, ...}
         density: Density (g/mL), default 1.0
@@ -698,11 +862,37 @@ def create_custom_extractant(
         typical_concentration: Typical operating concentration (M), default 0.5
         stoichiometry_protons: Number of protons released per extraction, default 3
         stoichiometry_extractant: Number of extractant molecules, default 3
+        stoichiometry_basis: What ``stoichiometry_extractant`` counts,
+            ``"monomer"`` (default, matching :class:`Extractant`) or
+            ``"dimer"`` (#191). The acidic organophosphorus extractants
+            (D2EHPA, PC88A, Cyanex 272) are DIMERIC in aliphatic diluents:
+            their ``stoichiometry_extractant = 3`` counts three dimers, i.e.
+            six monomer equivalents per REE, so
+            :attr:`Extractant.monomers_per_ree` is 6 and
+            :attr:`Extractant.max_loading` is 1/6. Leaving this at
+            ``"monomer"`` for such an extractant reports 3 and 1/3 instead --
+            a factor-of-two capacity error, which is exactly the bug #191 was
+            filed about. Pass ``stoichiometry_basis="dimer"`` whenever the
+            custom extractant is a dimerizing acid.
         valid_ph_range: Valid pH range as (min, max), default (1.0, 5.0)
         valid_temp_range: Valid temperature range in K as (min, max), default (283, 333)
         reference_concentration: Reference concentration for correlations (M), default 0.5
         concentration_exponent: Exponent n in D ∝ [HA]^n, default 3.0
         cost_usd_kg: Cost in USD per kg, default 10.0
+        mechanism: Extraction mechanism, one of :data:`EXTRACTION_MECHANISMS`
+            (#195). None normalizes from ``extractant_type``; an unrecognized
+            type (including the ``"custom"`` default) normalizes to
+            ``"cation_exchange"``, which is what ``ph_coefficients`` describes.
+        nitrate_coefficients: Solvating-extraction coefficients keyed by element,
+            same ``{a, b, c, d}`` shape as ``ph_coefficients`` but driven by
+            ``log10([NO3-]/reference_nitrate)`` (#195). Required for
+            ``mechanism="solvating"``.
+        reference_nitrate: Nitrate concentration (M) the ``nitrate_coefficients``
+            are referenced to, i.e. the concentration at which ``a`` equals
+            ``log10(D)``.
+        requires_nitrate: True when the extractant only works from a nitrate
+            medium, so using it without a nitrate concentration is an error
+            rather than a silent fall-back to the pH correlation (#195).
 
     Returns:
         Extractant object ready for registration
@@ -741,6 +931,12 @@ def create_custom_extractant(
     # Validate required parameters
     if not name:
         raise ValueError("name cannot be empty")
+    if stoichiometry_basis not in ("monomer", "dimer"):
+        raise ValueError(
+            f"stoichiometry_basis must be 'monomer' or 'dimer', got "
+            f"{stoichiometry_basis!r}. The acidic organophosphorus extractants "
+            "are dimeric in aliphatic diluents (#191)."
+        )
     if not ph_coefficients:
         raise ValueError("ph_coefficients is required and cannot be empty")
     if not temperature_coefficients:
@@ -791,6 +987,10 @@ def create_custom_extractant(
         typical_concentration=float(typical_concentration),
         stoichiometry_protons=int(stoichiometry_protons),
         stoichiometry_extractant=int(stoichiometry_extractant),
+        # (#191) Without this the custom path silently reports monomers_per_ree
+        # = 3 for a dimeric extractant that every built-in acidic record
+        # reports as 6.
+        stoichiometry_basis=stoichiometry_basis,
         ph_coefficients=ph_coeffs_objects,
         temperature_coefficients=temperature_coefficients,
         valid_ph_range=tuple(valid_ph_range),
@@ -798,6 +998,13 @@ def create_custom_extractant(
         reference_concentration=float(reference_concentration),
         concentration_exponent=float(concentration_exponent),
         cost_usd_kg=float(cost_usd_kg),
+        # Mechanism / solvating-extraction data (#195)
+        mechanism=mechanism,
+        nitrate_coefficients=_load_coefficient_block(nitrate_coefficients),
+        reference_nitrate=(
+            float(reference_nitrate) if reference_nitrate is not None else None
+        ),
+        requires_nitrate=bool(requires_nitrate),
     )
 
 

--- a/src/difflow_ree/equilibrium/__init__.py
+++ b/src/difflow_ree/equilibrium/__init__.py
@@ -21,6 +21,14 @@ from difflow_ree.equilibrium.speciation import (
     REESpeciation,
     sulfate_speciation,
     chloride_speciation,
+    # Activity models and their declared validity ranges (#194)
+    ACTIVITY_MODELS,
+    AQUEOUS_MEDIA,
+    NITRATE_BEARING_MEDIA,
+    DAVIES_MAX_IONIC_STRENGTH,
+    DAVIES_SIGN_CHANGE_IONIC_STRENGTH,
+    activity_coefficient,
+    activity_coefficient_davies,
 )
 
 __all__ = [
@@ -34,4 +42,11 @@ __all__ = [
     "REESpeciation",
     "sulfate_speciation",
     "chloride_speciation",
+    "ACTIVITY_MODELS",
+    "AQUEOUS_MEDIA",
+    "NITRATE_BEARING_MEDIA",
+    "DAVIES_MAX_IONIC_STRENGTH",
+    "DAVIES_SIGN_CHANGE_IONIC_STRENGTH",
+    "activity_coefficient",
+    "activity_coefficient_davies",
 ]

--- a/src/difflow_ree/equilibrium/distribution.py
+++ b/src/difflow_ree/equilibrium/distribution.py
@@ -1,24 +1,88 @@
-"""pH-dependent distribution coefficient models for REE extraction.
+"""Distribution coefficient models for REE extraction.
 
 Distribution coefficient D = [REE]_org / [REE]_aq
 
-Model: log10(D) = a + b*pH + c*pH^2 + d*(1/T - 1/Tref)
+The driving variable depends on the extraction *mechanism*, which is carried
+by the extractant record rather than assumed by this module (#195):
+
+- ``cation_exchange`` (D2EHPA, PC88A, Cyanex272)::
+
+      RE3+ + p (HA)2  <->  RE(HA2)p + p H+
+      log10(D) = a + b*pH + c*pH^2 + d*(1/T - 1/Tref)
+
+- ``solvating`` (TBP, and the diglycolamide/malonamide families to come)::
+
+      RE(NO3)3 + m S  <->  RE(NO3)3.mS        (no protons released)
+      log10(D) = a + b*s + c*s^2 + d*(1/T - 1/Tref),
+      s = log10([NO3-] / [NO3-]_ref)
+
+pH SCALE (#194): ``pH`` is ``-log10([H+])``, the *concentration* scale, matching
+the header of ``data/extractants.yaml``. The correlations are conditional
+constants fitted at the ionic strength of their source experiments, so the
+defensible default is no activity correction at all (``ionic_strength=None``).
+
+ACTIVITY RANGE (#194): when an ionic strength *is* supplied, the value handed to
+the activity model is clamped at that model's documented validity limit. Davies'
+bracket ``sqrt(I)/(1+sqrt(I)) - 0.3 I`` changes sign at I = 1.940363884733242 M,
+above which the correction would MULTIPLY D (6.5x at 3 M, 42.5x at 4 M) instead
+of reducing it -- precisely the 2-4 M chloride regime #194 is about. Clamping is
+arithmetic, so it holds for tracers too, where no Python check can see the value.
+Raw extrapolation is available on request via ``extrapolate_activity_model=True``.
 
 All functions are JAX-compatible for automatic differentiation.
 """
 
+import warnings
 from dataclasses import dataclass
 from typing import Literal
 
 import jax.numpy as jnp
+import numpy as np
 from jax import Array
 
 from difflow.numerics import safe_divide
 from difflow_ree.database import (
     get_extractant_database,
     get_extractant,
+    EXTRACTION_MECHANISMS,
     PHCoefficients,
 )
+from difflow_ree.equilibrium.speciation import (
+    ACTIVITY_MODELS,
+    AQUEOUS_MEDIA,
+    NITRATE_BEARING_MEDIA,
+    activity_coefficient,
+)
+
+
+# How an out-of-range / not-applicable activity correction is reported (#194).
+OutOfRangeAction = Literal["warn", "raise", "ignore"]
+
+
+def _concrete_bounds(value) -> tuple[float, float] | None:
+    """Return ``(min, max)`` of ``value`` as floats, or None for a JAX tracer.
+
+    Works for Python scalars, numpy scalars, and *concrete* JAX/numpy arrays of
+    any shape -- a concrete array is inspectable and must be range-checked, it
+    is only ``float()`` that refuses it because it is non-scalar (#194). None
+    is returned only when the value genuinely cannot be inspected, i.e. it is
+    an abstract tracer under ``jit``/``grad``/``vmap``. Every JAX abstraction
+    error raised here (``TracerArrayConversionError``,
+    ``ConcretizationTypeError``) is a ``TypeError`` subclass.
+
+    Args:
+        value: Scalar, array or tracer.
+
+    Returns:
+        ``(minimum, maximum)`` as Python floats, or None if abstract or empty.
+    """
+    try:
+        arr = np.asarray(value, dtype=float)
+    except (TypeError, ValueError):
+        return None
+    if arr.size == 0:
+        return None
+    return float(arr.min()), float(arr.max())
 
 
 # =============================================================================
@@ -29,101 +93,708 @@ from difflow_ree.database import (
 class REEDistribution:
     """REE distribution coefficient calculator.
 
-    Computes D values based on pH, temperature, and extractant concentration.
+    Which correlation drives ``D`` is decided by the *extraction mechanism*
+    carried on the extractant record, not assumed by this class (#195):
+    ``cation_exchange`` extractants are driven by pH via ``ph_coefficients``,
+    ``solvating`` extractants by the nitrate concentration via
+    ``nitrate_coefficients``. There is no silent fall-back between the two, and
+    a record need not carry both: TBP carries only ``nitrate_coefficients``, so
+    asking for it with ``mechanism="cation_exchange"`` raises.
+    Two things are actually checked, and they are the only two the data can
+    support: the *driving ion* must have a positive concentration (a solvating
+    extractant with no nitrate raises), and, when the caller states a
+    :attr:`medium`, it must satisfy the record's ``requires_nitrate`` flag.
+
+    ACTIVITY CONVENTION (#194). ``pH`` is on the *concentration* scale,
+    ``pH = -log10([H+])``. The tabulated correlations are conditional constants
+    fitted at the ionic strength of their source experiments, so
+    ``ionic_strength=None`` -- no activity correction at all -- is a first-class
+    and usually the *correct* choice: for a 2-4 M chloride leach liquor a
+    conditional constant used at the liquor's own ionic strength is the standard
+    and defensible treatment, and every implemented activity model is out of its
+    validity range there. Supplying ``ionic_strength`` requests a correction to
+    a different ionic strength; that correction is
+    ``gamma_RE3+ / gamma_H+**p`` with ``p = Extractant.stoichiometry_protons``,
+    which is the residual activity factor once the concentration-scale ``[H+]**-p``
+    dependence is already carried by the ``b*pH`` term.
+
+    THE DAVIES SIGN INVERSION, AND WHY THE MODEL INPUT IS CLAMPED (#194).
+    Davies writes ``log10(gamma) = -A z^2 f(I)`` with
+    ``f(I) = sqrt(I)/(1+sqrt(I)) - 0.3 I``. ``f`` is *not* monotone: it peaks
+    near I = 0.4 M and changes sign at
+
+        I = 1.940363884733242 M
+
+    (the root of ``0.3 I + 0.3 sqrt(I) - 1 = 0``; see
+    :data:`~difflow_ree.equilibrium.speciation.DAVIES_SIGN_CHANGE_IONIC_STRENGTH`).
+    Above that ionic strength ``gamma_RE/gamma_H**3 = 10**(-6 A f)`` exceeds 1
+    and the "correction" *multiplies* D instead of reducing it: 0.228 at
+    I = 0.1 M, 0.245 at 1.0 M, 1.0 at 1.9404 M, 6.49 at 3.0 M, 42.5 at 4.0 M.
+    That is precisely the 2-4 M chloride regime issue #194 was filed about, so
+    it is not an acceptable silent behaviour and a warning is not a sufficient
+    guard (warnings are routinely filtered, and cannot fire at all for a value
+    that is an abstract tracer).
+
+    The chosen guard is therefore in the *arithmetic*, not only in the report:
+    the ionic strength handed to the activity model is clamped to that model's
+    documented ``max_ionic_strength`` (0.5 M for Davies) unless
+    :attr:`extrapolate_activity_model` is set. Beyond the documented range the
+    correction saturates at its end-of-range value instead of reversing; it is
+    never inverted, and ``d D / d I`` is exactly zero there, which is the
+    honest statement that the model carries no information about that regime.
+    This is the only option of the three considered that also holds under
+    ``jit``/``grad``/``vmap``, where the ionic strength is an abstract tracer
+    and *no* Python-level check can inspect it: refusing to trace would have
+    broken gradient-based design studies outright, and an opt-in flag for
+    traced values would have left the inverted branch reachable by anyone who
+    set the flag for an in-range sweep. Raw, possibly inverted Davies remains
+    available, but only by explicitly asking for it with
+    ``extrapolate_activity_model=True``.
 
     Attributes:
         extractant: Name of extractant (D2EHPA, PC88A, Cyanex272, TBP)
         elements: List of REE symbols to include
         concentration: Extractant concentration (M)
+        nitrate_conc: Aqueous nitrate concentration (M). Required for
+            solvating extractants such as TBP, whose distribution ratio is
+            driven by the salting anion rather than by pH (#195). Ignored by
+            cation-exchange extractants. ``None`` (or a non-positive value)
+            means no nitrate is available to drive the correlation.
+        medium: Aqueous medium, one of
+            :data:`~difflow_ree.equilibrium.speciation.AQUEOUS_MEDIA`
+            (``"sulfate"``, ``"chloride"``, ``"nitrate"``, ``"mixed"``), or
+            ``None`` (default) to leave it unstated. This is the *only* medium
+            concept the data supports: the extractant records carry a single
+            medium constraint, ``stoichiometry.requires_nitrate``, so declaring
+            ``medium="chloride"`` or ``"sulfate"`` for a nitrate-requiring
+            extractant is detected and raises. No record declares a chloride or
+            sulfate *incompatibility*, so no other medium combination is
+            rejected; a cation-exchange extractant is accepted in every medium
+            (#195, D10b).
+        mechanism: Explicit mechanism override, one of
+            ``"cation_exchange"`` / ``"solvating"``. ``None`` (default) takes
+            the mechanism from the extractant record. An override is only
+            honoured when the record actually carries that mechanism's
+            coefficient block; asking for ``"cation_exchange"`` on a record
+            that has none raises. In particular TBP no longer has a
+            ``ph_coefficients`` block at all -- it was deleted as
+            mechanistically unsupported (TBP is neutral: pKa None, zero protons
+            released) -- so ``REEDistribution(extractant="TBP", ...,
+            mechanism="cation_exchange")`` now raises a ValueError pointing at
+            the nitrate path, rather than silently using it.
+        activity_model: Aqueous activity model used when ``ionic_strength`` is
+            supplied, a key of
+            :data:`difflow_ree.equilibrium.speciation.ACTIVITY_MODELS`
+            (``"davies"``, ``"none"``). Each declares its own validity range
+            (#194).
+        on_out_of_range: What to do when ``ionic_strength`` is outside the
+            chosen model's validity range, cannot be checked because it is an
+            abstract tracer, or when the correction is not the right physics for
+            the mechanism: ``"warn"`` (default, UserWarning), ``"raise"``
+            (ValueError) or ``"ignore"``. This controls *reporting* only; the
+            clamp described above applies regardless.
+        extrapolate_activity_model: Opt in to feeding the activity model an
+            ionic strength beyond its documented validity range, reproducing raw
+            (and, above 1.94 M for Davies, sign-inverted) coefficients. Default
+            False. Setting this is the explicit request that makes an inverted
+            ``D`` reachable; nothing else does (#194).
+
+    Example:
+        >>> # Cation exchange: driven by pH
+        >>> dist = REEDistribution(extractant="D2EHPA", elements=("Nd",))
+        >>> float(dist.get_D("Nd", pH=3.0)) > 0
+        True
+        >>> # Solvating: driven by nitrate, pH is not a driving variable
+        >>> tbp = REEDistribution(
+        ...     extractant="TBP", elements=("Nd",), nitrate_conc=3.0
+        ... )
+        >>> float(tbp.get_D("Nd")) > 0
+        True
     """
     extractant: str
     elements: tuple[str, ...]
     concentration: float = 0.5  # M
+    nitrate_conc: float | None = None  # M; see #195
+    medium: str | None = None  # see AQUEOUS_MEDIA (#195)
+    mechanism: str | None = None  # None -> take from the record (#195)
+    activity_model: str = "davies"  # see ACTIVITY_MODELS (#194)
+    on_out_of_range: OutOfRangeAction = "warn"  # (#194)
+    extrapolate_activity_model: bool = False  # (#194) opt in to raw Davies
 
     def __post_init__(self):
-        """Load extractant data."""
+        """Load extractant data and resolve/validate the mechanism (#195)."""
         self._ext_data = get_extractant(self.extractant)
+
+        if self.medium is not None and self.medium not in AQUEOUS_MEDIA:
+            raise ValueError(
+                f"Unknown medium {self.medium!r}. Recognized aqueous media: "
+                f"{list(AQUEOUS_MEDIA)} (#195)."
+            )
+
+        # Mechanism: explicit override, else the record's own declaration.
+        self._mechanism_is_override = self.mechanism is not None
+        if self.mechanism is None:
+            self.mechanism = self._ext_data.mechanism
+        if self.mechanism not in EXTRACTION_MECHANISMS:
+            raise ValueError(
+                f"REEDistribution(extractant={self.extractant!r}): unknown "
+                f"mechanism {self.mechanism!r}. Supported mechanisms: "
+                f"{list(EXTRACTION_MECHANISMS)}."
+            )
+
+        if self.activity_model not in ACTIVITY_MODELS:
+            raise ValueError(
+                f"Unknown activity_model {self.activity_model!r}. Implemented "
+                f"models: {sorted(ACTIVITY_MODELS)}. Bromley and SIT are not "
+                "implemented because difflow_ree does not carry their "
+                "ion-interaction parameters (#194)."
+            )
+        if self.on_out_of_range not in ("warn", "raise", "ignore"):
+            raise ValueError(
+                f"on_out_of_range must be 'warn', 'raise' or 'ignore', got "
+                f"{self.on_out_of_range!r}."
+            )
+
+        # Warnings are emitted once per instance per distinct condition so a
+        # stage loop cannot spam (#194); the check itself is Python-level.
+        self._reported: set = set()
+
+        self._check_medium()
+        self._validate_mechanism_data(self.nitrate_conc)
+
+    # -------------------------------------------------------------------
+    # Mechanism dispatch (#195)
+    # -------------------------------------------------------------------
+
+    def _check_medium(self) -> None:
+        """Check the declared medium against the record's medium constraint.
+
+        The extractant records carry exactly one medium constraint,
+        ``stoichiometry.requires_nitrate``, so exactly one thing can be
+        detected here: a nitrate-requiring extractant declared to be operating
+        in a medium that supplies no nitrate. Nothing in the data expresses a
+        chloride or sulfate *incompatibility* for the acidic extractants, so
+        nothing else is rejected, and an unstated ``medium`` is not guessed at
+        (#195, D10b).
+
+        Raises:
+            ValueError: If ``requires_nitrate`` and the declared medium is not
+                one of :data:`NITRATE_BEARING_MEDIA`.
+        """
+        if self.medium is None or not self._ext_data.requires_nitrate:
+            return
+        if self.medium in NITRATE_BEARING_MEDIA:
+            return
+        raise ValueError(
+            f"Extractant {self.extractant!r} requires a nitrate medium "
+            f"(stoichiometry.requires_nitrate is true on its record) but was "
+            f"declared with medium={self.medium!r}, which supplies no nitrate. "
+            f"Nitrate-bearing media: {list(NITRATE_BEARING_MEDIA)}. Its "
+            "coefficients do not cover this medium; use a cation-exchange "
+            "extractant, or state the medium the correlation was fitted in "
+            "(#195)."
+        )
+
+    def _validate_mechanism_data(self, nitrate_conc) -> None:
+        """Fail loudly when the record cannot support the chosen mechanism.
+
+        Args:
+            nitrate_conc: Nitrate concentration (M) that will drive a solvating
+                correlation, or None for a non-nitrate medium.
+
+        Raises:
+            ValueError: If the mechanism's coefficient block is missing, or a
+                solvating / ``requires_nitrate`` extractant is used without a
+                positive nitrate concentration. Never falls back to the other
+                mechanism's coefficients (#195).
+        """
+        ext = self._ext_data
+
+        if self.mechanism == "solvating":
+            if ext.nitrate_coefficients is None:
+                raise ValueError(
+                    f"Extractant {self.extractant!r} is used with "
+                    "mechanism='solvating' but its record carries no "
+                    "'nitrate_coefficients' block, so its distribution ratio "
+                    "cannot be computed from the nitrate concentration (#195)."
+                )
+            if ext.reference_nitrate is None:
+                raise ValueError(
+                    f"Extractant {self.extractant!r} has "
+                    "'nitrate_coefficients' but no 'reference_nitrate', so the "
+                    "nitrate coefficients have no reference concentration to be "
+                    "interpreted against (#195)."
+                )
+            self._require_nitrate_medium(nitrate_conc)
+        else:  # cation_exchange
+            if not ext.ph_coefficients:
+                # No silent fall-back to nitrate_coefficients, and no
+                # AttributeError/KeyError leaking out of a later get_D: the
+                # record simply has no pH-driven correlation, and for a
+                # solvating extractant it never should have had one.
+                extra = ""
+                if ext.nitrate_coefficients:
+                    extra = (
+                        f" {self.extractant} extracts by SOLVATION, not by "
+                        "cation exchange: its record has pKa=None and "
+                        f"stoichiometry.protons_released="
+                        f"{ext.stoichiometry_protons}, so there is no proton "
+                        "to exchange and the pH-driven block it used to carry "
+                        "was DELETED as mechanistically unsupported (it had no "
+                        "source, and reproduced a selectivity spread that the "
+                        "measured data refutes). Use the nitrate path instead: "
+                        f"REEDistribution(extractant={self.extractant!r}, ..., "
+                        "nitrate_conc=<[NO3-] in M>) with the default "
+                        "mechanism, referenced to "
+                        f"{ext.reference_nitrate} M nitrate. If you really "
+                        "mean the HNO3 system, it is a real system but this "
+                        "database has no coefficients fitted for it -- supply "
+                        "your own via create_custom_extractant()."
+                    )
+                raise ValueError(
+                    f"Extractant {self.extractant!r} is used with "
+                    "mechanism='cation_exchange' but its record carries no "
+                    "'ph_coefficients' block (#195)." + extra
+                )
+            if ext.requires_nitrate and not self._mechanism_is_override:
+                raise ValueError(
+                    f"Extractant {self.extractant!r} requires a nitrate medium "
+                    "but resolved to a pH-driven cation-exchange model. This "
+                    "is a data inconsistency; declare mechanism: solvating on "
+                    "the record (#195)."
+                )
+
+    def _require_nitrate_medium(self, nitrate_conc) -> None:
+        """Raise unless a usable nitrate concentration was supplied (#195).
+
+        This is a *driving-ion* check, not a medium check: it asserts that the
+        salting anion the solvating correlation is a function of actually has a
+        positive concentration. The medium itself is checked separately, and
+        only when the caller states one, in :meth:`_check_medium`.
+
+        Args:
+            nitrate_conc: Nitrate concentration (M), possibly None, an array,
+                or a tracer. A concrete array is checked at its *minimum*, so a
+                per-stage profile containing a zero is rejected.
+
+        Raises:
+            ValueError: If it is None, or has a concrete non-positive value.
+        """
+        name = self.extractant
+        # The "way out" depends on whether the record still carries a pH block.
+        # TBP's was deleted (neutral extractant, no proton to exchange, no
+        # source), so for TBP there is exactly one path and the message must
+        # not advertise a second one that raises.
+        if self._ext_data.ph_coefficients:
+            escape = (
+                f"{name} extracts by solvation from a nitrate medium; if you "
+                "specifically mean the HNO3 system that its 'ph_coefficients' "
+                "block describes, opt in explicitly with "
+                "mechanism='cation_exchange' (#195)."
+            )
+        else:
+            escape = (
+                f"This is the only path: {name} extracts by solvation and its "
+                "record carries no 'ph_coefficients' block -- the pH-driven "
+                "block it used to have was deleted as mechanistically "
+                "unsupported, so mechanism='cation_exchange' raises rather "
+                "than providing an alternative (#195)."
+            )
+        hint = (
+            f"Pass nitrate_conc=<[NO3-] in M> (the record is referenced to "
+            f"{self._ext_data.reference_nitrate} M). " + escape
+        )
+        if nitrate_conc is None:
+            raise ValueError(
+                f"Extractant {name!r} requires a nitrate concentration: it was "
+                f"used with nitrate_conc=None, so the salting anion that drives "
+                f"its correlation has no value. {hint}"
+            )
+        bounds = _concrete_bounds(nitrate_conc)
+        if bounds is not None and bounds[0] <= 0.0:
+            raise ValueError(
+                f"Extractant {name!r} requires a nitrate concentration: it was "
+                f"used with nitrate_conc={bounds[0]:g}, which is not a positive "
+                f"concentration of the salting anion its correlation is a "
+                f"function of. {hint}"
+            )
+
+    def _coefficients(self, element: str) -> PHCoefficients:
+        """Coefficient record for ``element`` under the active mechanism.
+
+        Args:
+            element: REE symbol.
+
+        Returns:
+            The :class:`PHCoefficients` driving this element's correlation.
+
+        Raises:
+            KeyError: If the element is absent from the mechanism's block, with
+                a message naming the extractant, the mechanism and the block.
+        """
+        if self.mechanism == "solvating":
+            block = self._ext_data.nitrate_coefficients
+            block_name = "nitrate_coefficients"
+        else:
+            block = self._ext_data.ph_coefficients
+            block_name = "ph_coefficients"
+        if not block:
+            # Defensive: __post_init__ already refuses this combination, so
+            # reaching here means the record was mutated afterwards. Fail with
+            # the same explanation rather than a TypeError on None[element].
+            raise ValueError(
+                f"Extractant {self.extractant!r} has no {block_name!r} block, "
+                f"so no coefficients exist for element {element!r} under "
+                f"mechanism={self.mechanism!r}."
+            )
+        try:
+            return block[element]
+        except KeyError:
+            raise KeyError(
+                f"Extractant {self.extractant!r} has no {block_name} entry for "
+                f"element {element!r} (mechanism={self.mechanism!r}). "
+                f"Available: {sorted(block)}."
+            ) from None
+
+    # -------------------------------------------------------------------
+    # Activity correction (#194)
+    # -------------------------------------------------------------------
+
+    def _report(self, key: str, message: str) -> None:
+        """Warn / raise / ignore once per instance for a given condition.
+
+        Args:
+            key: Deduplication key so a stage loop cannot spam (#194).
+            message: Text of the warning or error.
+
+        Raises:
+            ValueError: If ``on_out_of_range == "raise"``.
+        """
+        if self.on_out_of_range == "ignore":
+            return
+        if self.on_out_of_range == "raise":
+            raise ValueError(message)
+        if key in self._reported:
+            return
+        self._reported.add(key)
+        warnings.warn(message, UserWarning, stacklevel=3)
+
+    def _check_activity_range(self, ionic_strength) -> None:
+        """Parameter-time validity report for the activity model (#194).
+
+        Runs at the Python level, once per distinct condition per instance. It
+        inspects *any* concrete input -- scalar or array, checking the array's
+        maximum -- and reports when the value is outside the model's documented
+        range. When the value is an abstract tracer (``jit``/``grad``/``vmap``)
+        there is nothing to inspect, and that fact is itself reported through
+        :attr:`on_out_of_range` rather than passed over in silence.
+
+        This is a *report*, not the guard. The guard against the Davies sign
+        inversion is the clamp in :meth:`_activity_correction`, which does not
+        depend on being able to inspect the value and therefore holds under
+        tracing too.
+
+        Args:
+            ionic_strength: Ionic strength (M), possibly None, an array, or a
+                tracer.
+        """
+        if ionic_strength is None or self.activity_model == "none":
+            return
+
+        # A solvating extractant's ionic-strength dependence is a nitrate
+        # salting effect on the anion, which the aqueous-cation correction does
+        # not represent. Do not silently reuse the cation-exchange form (#194).
+        if self.mechanism == "solvating":
+            self._report(
+                "solvating_activity",
+                f"Extractant {self.extractant!r} extracts by a solvating "
+                "mechanism (p = 0 protons released), so the activity "
+                "correction applied here is the aqueous RE3+ free-ion "
+                "coefficient alone. Its real ionic-strength dependence is a "
+                "nitrate salting effect on the anion activity, which "
+                f"{self.activity_model!r} does not represent. Prefer "
+                "ionic_strength=None (conditional constant fitted at the "
+                "operating ionic strength) for solvating systems (#194).",
+            )
+
+        model = ACTIVITY_MODELS[self.activity_model]
+        limit = model["max_ionic_strength"]
+        flip = model.get("sign_change_ionic_strength")
+        bounds = _concrete_bounds(ionic_strength)
+
+        if bounds is None:
+            # Abstract tracer: no Python-level check can see the value. Say so
+            # rather than pretending the range was checked. The arithmetic is
+            # still safe -- _activity_correction clamps the model input -- so
+            # this reports an unverified input, not an inverted result.
+            if not self.extrapolate_activity_model:
+                self._report(
+                    "traced",
+                    "ionic_strength is a JAX tracer, so its validity against "
+                    f"the {self.activity_model!r} activity model "
+                    f"(I < {limit:g} M) cannot be range-checked. The ionic "
+                    "strength fed to the model is clamped at "
+                    f"{limit:g} M so the correction cannot invert (#194); the "
+                    "correction, and hence d D / d I, is therefore flat beyond "
+                    "that. Pass a concrete ionic_strength to get the check, "
+                    "ionic_strength=None for a conditional constant, "
+                    "on_out_of_range='ignore' to silence this, or "
+                    "extrapolate_activity_model=True to extrapolate on purpose."
+                )
+            else:
+                self._report(
+                    "traced_extrapolating",
+                    "ionic_strength is a JAX tracer and "
+                    "extrapolate_activity_model=True, so the "
+                    f"{self.activity_model!r} activity model is being used "
+                    f"outside its validity range (I < {limit:g} M) with no "
+                    "check possible. "
+                    + (
+                        f"Above I = {flip:.6g} M the correction changes sign "
+                        "and multiplies D instead of reducing it (#194)."
+                        if flip is not None else ""
+                    )
+                )
+            return
+
+        I = bounds[1]  # check the maximum; a concrete array is inspectable
+        if I > limit:
+            inverted = flip is not None and I > flip
+            self._report(
+                f"range:{self.activity_model}:{I:.6g}",
+                f"ionic_strength={I:g} M is outside the documented validity "
+                f"range of the {self.activity_model!r} activity model "
+                f"(I < {limit:g} M). "
+                + (
+                    f"It is also above I = {flip:.6g} M, where the "
+                    f"{self.activity_model!r} bracket changes sign, so the raw "
+                    "correction would MULTIPLY D rather than reduce it. "
+                    if inverted else ""
+                )
+                + (
+                    "The model input is clamped at "
+                    f"{limit:g} M so the correction saturates instead of "
+                    "inverting; it is not an extrapolation and carries no "
+                    "information about this regime. "
+                    if not self.extrapolate_activity_model
+                    else "extrapolate_activity_model=True, so the raw "
+                    "extrapolated coefficients are used as requested. "
+                )
+                + "For a concentrated liquor (2-4 M chloride, say) the "
+                "defensible treatment is ionic_strength=None, i.e. a "
+                "conditional constant fitted at that ionic strength. Pass "
+                "on_out_of_range='raise' to make this an error or 'ignore' to "
+                "silence it (#194).",
+            )
+
+    def _model_ionic_strength(self, ionic_strength) -> Array:
+        """Ionic strength actually handed to the activity model (#194).
+
+        Clamped to the model's documented ``max_ionic_strength`` unless
+        :attr:`extrapolate_activity_model` is set. The clamp is what makes the
+        sign inversion described in the class docstring unreachable: it is
+        arithmetic, so it holds for concrete values, concrete arrays and
+        abstract tracers alike, where no Python-level check can.
+
+        Args:
+            ionic_strength: Ionic strength (M), scalar, array or tracer.
+
+        Returns:
+            The (possibly clamped) ionic strength as a JAX array.
+        """
+        I = jnp.asarray(ionic_strength)
+        if self.extrapolate_activity_model:
+            return I
+        limit = ACTIVITY_MODELS[self.activity_model]["max_ionic_strength"]
+        if not np.isfinite(limit):
+            return I
+        return jnp.minimum(I, limit)
+
+    def _activity_correction(self, ionic_strength) -> Array | float:
+        """Residual activity factor applied to the correlated ``D`` (#194).
+
+        With ``pH`` on the concentration scale the ``b*pH`` term already carries
+        the ``[H+]**-p`` dependence, so what remains of
+
+            D = K [HA]**p gamma_RE / (gamma_H**p [H+]**p)
+
+        is ``gamma_RE / gamma_H**p``, with ``p`` the number of protons released
+        per REE taken from the extractant record. For a solvating extractant
+        ``p = 0`` and there is no proton term at all.
+
+        The ionic strength is passed through :meth:`_model_ionic_strength`
+        first, so beyond the model's documented range the factor saturates
+        rather than inverting (see the class docstring; Davies inverts above
+        I = 1.940363884733242 M).
+
+        Args:
+            ionic_strength: Ionic strength (M), or None for no correction.
+
+        Returns:
+            Multiplicative correction factor (1.0 when no correction applies).
+        """
+        if ionic_strength is None or self.activity_model == "none":
+            return 1.0
+
+        p = self._ext_data.stoichiometry_protons  # static Python int
+        I = self._model_ionic_strength(ionic_strength)
+        gamma_RE = activity_coefficient(3, I, self.activity_model)
+        if p == 0:
+            # Solvating / neutral extractant: no protons are exchanged.
+            return gamma_RE
+        gamma_H = activity_coefficient(1, I, self.activity_model)
+        return gamma_RE / jnp.power(gamma_H, p)
+
+    # -------------------------------------------------------------------
+    # Distribution coefficients
+    # -------------------------------------------------------------------
 
     def get_D(
         self,
         element: str,
-        pH: Array | float,
+        pH: Array | float | None = None,
         T: Array | float = 298.15,
         ionic_strength: Array | float | None = None,
+        nitrate_conc: Array | float | None = None,
     ) -> Array:
-        """Calculate distribution coefficient for single element.
+        """Calculate distribution coefficient for a single element.
+
+        The correlation used depends on the active mechanism (#195):
+
+        - ``cation_exchange``::
+
+              log10(D) = a + b*pH + c*pH^2 + d*(1/T - 1/Tref)
+                         + n*log10([HA]/[HA]_ref)
+
+          with ``pH = -log10([H+])`` on the **concentration** scale, matching
+          the header of ``data/extractants.yaml`` (#194).
+
+        - ``solvating``::
+
+              s = log10([NO3-] / reference_nitrate)
+              log10(D) = a + b*s + c*s^2 + d*(1/T - 1/Tref)
+                         + n*log10([S]/[S]_ref)
+
+          Here ``a`` is ``log10(D)`` **at** ``reference_nitrate`` (3 M for TBP)
+          and ``b`` is the nitrate slope ``d log10(D) / d log10([NO3-])``, so
+          the coefficients mean exactly what the YAML says they mean. ``pH`` is
+          not a driving variable and is ignored.
 
         Args:
-            element: REE symbol (e.g., "Nd")
-            pH: Solution pH
-            T: Temperature (K)
-            ionic_strength: Aqueous ionic strength (M). When provided, the pH
-                correlation (fit at near-ideal dilute conditions) is corrected
-                for non-ideality by the aqueous RE3+ activity coefficient via
-                the Davies equation (#111): D_eff = D * gamma_RE3+(I). Higher
-                ionic strength lowers the RE3+ activity coefficient and thus the
-                effective distribution coefficient. None leaves D uncorrected
-                (constant-ionic-strength assumption, backward compatible).
+            element: REE symbol (e.g., "Nd").
+            pH: Solution pH on the concentration scale, ``-log10([H+])``.
+                Required for cation exchange; ignored (and optional) for
+                solvating extractants.
+            T: Temperature (K).
+            ionic_strength: Aqueous ionic strength (M), scalar or array.
+                ``None`` (default and, for a concentrated liquor, the
+                recommended choice) applies no activity correction: the
+                correlation is used as the conditional constant it is, at the
+                ionic strength it was fitted at. When a value is given, ``D``
+                is multiplied by ``gamma_RE3+ / gamma_H+**p`` from
+                :attr:`activity_model`, with
+                ``p = Extractant.stoichiometry_protons``. A value outside the
+                model's documented validity range is reported according to
+                :attr:`on_out_of_range` and, unless
+                :attr:`extrapolate_activity_model` is set, the ionic strength
+                fed to the model is clamped at the range limit so the
+                correction saturates instead of changing sign (Davies inverts
+                above I = 1.940363884733242 M; see the class docstring) (#194).
+            nitrate_conc: Nitrate concentration (M) overriding
+                :attr:`nitrate_conc` for this call. Useful for differentiating
+                with respect to nitrate concentration.
 
         Returns:
-            Distribution coefficient D
+            Distribution coefficient D.
+
+        Raises:
+            ValueError: If ``pH`` is omitted for a cation-exchange extractant,
+                or a solvating extractant is used without a nitrate
+                concentration.
+            KeyError: If the element is absent from the mechanism's coefficient
+                block.
         """
-        pH = jnp.asarray(pH)
         T = jnp.asarray(T)
+        coeffs = self._coefficients(element)
 
-        # Get pH coefficients
-        coeffs = self._ext_data.ph_coefficients[element]
-
-        # Base log(D) from pH correlation
-        log_D = coeffs.a + coeffs.b * pH + coeffs.c * pH**2
+        if self.mechanism == "solvating":
+            c_nitrate = (
+                self.nitrate_conc if nitrate_conc is None else nitrate_conc
+            )
+            self._require_nitrate_medium(c_nitrate)
+            # Driving variable is the nitrate log-ratio about the reference
+            # concentration the coefficients were tabulated at (#195).
+            s = jnp.log10(
+                jnp.asarray(c_nitrate) / self._ext_data.reference_nitrate
+            )
+            log_D = coeffs.a + coeffs.b * s + coeffs.c * s**2
+        else:
+            if pH is None:
+                raise ValueError(
+                    f"Extractant {self.extractant!r} extracts by cation "
+                    "exchange, so get_D requires pH (concentration scale, "
+                    "-log10([H+]))."
+                )
+            pH = jnp.asarray(pH)
+            log_D = coeffs.a + coeffs.b * pH + coeffs.c * pH**2
 
         # Temperature correction
         T_ref = 298.15
         d_T = self._ext_data.temperature_coefficients[element]
         log_D = log_D + d_T * (1/T - 1/T_ref)
 
-        # Concentration correction: D ∝ [HA]^n
+        # Extractant-concentration correction: D ∝ [HA]^n.
+        #
+        # (#190) This is the ONE place the extractant-concentration dependence
+        # is applied to D. The loading correction in equilibrium/loading.py
+        # (`apparent_D`, the (1 - theta)^n free-extractant depletion factor) is
+        # deliberately NOT composed with this term in the stage path: doing
+        # both double-counts the same free-extractant effect. See #190, and
+        # #196 for the mass-action closure that would replace both.
         n = self._ext_data.concentration_exponent
         C_ref = self._ext_data.reference_concentration
         log_D = log_D + n * jnp.log10(self.concentration / C_ref)
 
         D = jnp.power(10.0, log_D)
 
-        # Ionic-strength (activity) correction via the Davies equation (#111)
-        if ionic_strength is not None:
-            from difflow_ree.equilibrium.speciation import activity_coefficient_davies
-            gamma_RE = activity_coefficient_davies(3, ionic_strength)
-            D = D * gamma_RE
-
-        return D
+        # Ionic-strength (activity) correction (#111, convention fixed in #194).
+        # The range check is Python-level and deduplicated; the correction
+        # itself is traced and differentiable.
+        self._check_activity_range(ionic_strength)
+        return D * self._activity_correction(ionic_strength)
 
     def get_D_all(
         self,
-        pH: Array | float,
+        pH: Array | float | None = None,
         T: Array | float = 298.15,
         ionic_strength: Array | float | None = None,
+        nitrate_conc: Array | float | None = None,
     ) -> dict[str, Array]:
         """Calculate distribution coefficients for all elements.
 
         Args:
-            pH: Solution pH
+            pH: Solution pH (concentration scale); see :meth:`get_D`.
             T: Temperature (K)
             ionic_strength: Aqueous ionic strength (M); see :meth:`get_D`.
+            nitrate_conc: Nitrate concentration (M); see :meth:`get_D`.
 
         Returns:
             Dictionary mapping element symbols to D values
         """
-        return {elem: self.get_D(elem, pH, T, ionic_strength) for elem in self.elements}
+        return {
+            elem: self.get_D(elem, pH, T, ionic_strength, nitrate_conc)
+            for elem in self.elements
+        }
 
     def get_D_array(
         self,
-        pH: Array | float,
+        pH: Array | float | None = None,
         T: Array | float = 298.15,
     ) -> Array:
         """Calculate D values as JAX array (in element order).
 
         Args:
-            pH: Solution pH
+            pH: Solution pH (concentration scale); see :meth:`get_D`.
             T: Temperature (K)
 
         Returns:
@@ -136,7 +807,7 @@ class REEDistribution:
         self,
         element1: str,
         element2: str,
-        pH: Array | float,
+        pH: Array | float | None = None,
         T: Array | float = 298.15,
     ) -> Array:
         """Calculate separation factor between two elements.
@@ -192,18 +863,26 @@ class REEDistribution:
 def get_distribution_coefficient(
     element: str,
     extractant: str,
-    pH: Array | float,
+    pH: Array | float | None = None,
     T: Array | float = 298.15,
     concentration: float = 0.5,
+    nitrate_conc: float | None = None,
+    mechanism: str | None = None,
+    medium: str | None = None,
 ) -> Array:
     """Calculate distribution coefficient for a single element.
 
     Args:
         element: REE symbol (e.g., "Nd")
         extractant: Extractant name (e.g., "D2EHPA")
-        pH: Solution pH
+        pH: Solution pH (concentration scale); required for cation exchange,
+            ignored for solvating extractants
         T: Temperature (K)
         concentration: Extractant concentration (M)
+        nitrate_conc: Aqueous nitrate concentration (M), required for solvating
+            extractants such as TBP (#195)
+        mechanism: Explicit mechanism override; see :class:`REEDistribution`
+        medium: Declared aqueous medium; see :class:`REEDistribution` (#195)
 
     Returns:
         Distribution coefficient D
@@ -212,6 +891,9 @@ def get_distribution_coefficient(
         extractant=extractant,
         elements=(element,),
         concentration=concentration,
+        nitrate_conc=nitrate_conc,
+        mechanism=mechanism,
+        medium=medium,
     )
     return dist.get_D(element, pH, T)
 
@@ -219,18 +901,26 @@ def get_distribution_coefficient(
 def get_distribution_coefficients(
     elements: list[str],
     extractant: str,
-    pH: Array | float,
+    pH: Array | float | None = None,
     T: Array | float = 298.15,
     concentration: float = 0.5,
+    nitrate_conc: float | None = None,
+    mechanism: str | None = None,
+    medium: str | None = None,
 ) -> dict[str, Array]:
     """Calculate distribution coefficients for multiple elements.
 
     Args:
         elements: List of REE symbols
         extractant: Extractant name
-        pH: Solution pH
+        pH: Solution pH (concentration scale); see
+            :func:`get_distribution_coefficient`
         T: Temperature (K)
         concentration: Extractant concentration (M)
+        nitrate_conc: Aqueous nitrate concentration (M), required for solvating
+            extractants such as TBP (#195)
+        mechanism: Explicit mechanism override; see :class:`REEDistribution`
+        medium: Declared aqueous medium; see :class:`REEDistribution` (#195)
 
     Returns:
         Dictionary mapping element symbols to D values
@@ -239,6 +929,9 @@ def get_distribution_coefficients(
         extractant=extractant,
         elements=tuple(elements),
         concentration=concentration,
+        nitrate_conc=nitrate_conc,
+        mechanism=mechanism,
+        medium=medium,
     )
     return dist.get_D_all(pH, T)
 
@@ -247,9 +940,12 @@ def get_separation_factor(
     element1: str,
     element2: str,
     extractant: str,
-    pH: Array | float,
+    pH: Array | float | None = None,
     T: Array | float = 298.15,
     concentration: float = 0.5,
+    nitrate_conc: float | None = None,
+    mechanism: str | None = None,
+    medium: str | None = None,
 ) -> Array:
     """Calculate separation factor between two elements.
 
@@ -257,15 +953,26 @@ def get_separation_factor(
         element1: First element symbol
         element2: Second element symbol
         extractant: Extractant name
-        pH: Solution pH
+        pH: Solution pH (concentration scale); see
+            :func:`get_distribution_coefficient`
         T: Temperature (K)
         concentration: Extractant concentration (M)
+        nitrate_conc: Aqueous nitrate concentration (M), required for solvating
+            extractants such as TBP (#195)
+        mechanism: Explicit mechanism override; see :class:`REEDistribution`
+        medium: Declared aqueous medium; see :class:`REEDistribution` (#195)
 
     Returns:
         Separation factor D1/D2
     """
-    D1 = get_distribution_coefficient(element1, extractant, pH, T, concentration)
-    D2 = get_distribution_coefficient(element2, extractant, pH, T, concentration)
+    D1 = get_distribution_coefficient(
+        element1, extractant, pH, T, concentration, nitrate_conc, mechanism,
+        medium,
+    )
+    D2 = get_distribution_coefficient(
+        element2, extractant, pH, T, concentration, nitrate_conc, mechanism,
+        medium,
+    )
     return D1 / D2
 
 

--- a/src/difflow_ree/equilibrium/loading.py
+++ b/src/difflow_ree/equilibrium/loading.py
@@ -26,14 +26,47 @@ class LoadingIsotherm:
     Models the relationship between aqueous REE concentration
     and organic phase loading.
 
+    The stoichiometry ``m`` is the single source of truth for capacity: the
+    extractant balance in monomer equivalents is
+
+        [HA]_total = [HA]_free + m * [RE-complex]
+
+    so the maximum loading is ``1 / m`` mol REE per mol extractant and the
+    free-extractant exponent in :meth:`apparent_D` is the same ``m``. Storing
+    ``m`` rather than a separate ``max_loading`` literal makes it impossible
+    for the two to disagree (#191). Use :func:`get_loading_isotherm` to build
+    one with ``m`` taken from the extractant database.
+
+    .. warning:: **Breaking API change in #191.** ``max_loading`` used to be a
+       constructor field with the default 0.33, so ``LoadingIsotherm(
+       max_loading=0.33)`` was valid. It is now a read-only property derived
+       from ``m``, and that call raises ``TypeError``. Construct with
+       ``LoadingIsotherm(m=...)`` instead: the old ``max_loading=0.33``
+       becomes ``m=3.0``, and the D2EHPA/PC88A/Cyanex272 records that the
+       YAML declares as three *dimers* become ``m=6.0``, halving the capacity
+       that the 0.33 literal claimed. ``max_ree_conc`` therefore also halves
+       for those extractants relative to any pre-#191 result.
+
     Attributes:
-        max_loading: Maximum REE loading capacity (mol REE / mol extractant)
+        m: Extractant monomer equivalents bound per mol REE. The database
+            value is 6.0 for the acidic organophosphorus extractants
+            (3 dimers) and 3.0 for TBP; the default here is the monomer
+            stoichiometry 3.0.
         K_L: Langmuir constant (L/mol)
         extractant_conc: Extractant concentration (M)
     """
-    max_loading: float = 0.33  # Typical for acidic extractants (1 REE per 3 HA)
+    m: float = 3.0  # monomer equivalents per REE; max_loading = 1/m (#191)
     K_L: float = 10.0  # Langmuir constant
     extractant_conc: float = 0.5  # M
+
+    @property
+    def max_loading(self) -> float:
+        """Maximum REE loading capacity (mol REE / mol extractant).
+
+        Derived as ``1 / m`` so capacity and stoichiometry cannot
+        disagree (#191).
+        """
+        return 1.0 / self.m
 
     @property
     def max_ree_conc(self) -> float:
@@ -70,29 +103,46 @@ class LoadingIsotherm:
     def apparent_D(
         self,
         D_infinite: Array | float,
-        c_org: Array | float,
+        theta: Array | float,
     ) -> Array:
         """Calculate apparent D accounting for loading.
 
         At high loading, effective D decreases due to
-        reduced free extractant concentration.
+        reduced free extractant concentration:
 
-        D_app = D_inf * (1 - theta)^n
+            D_app = D_inf * (1 - theta)^m
 
-        where theta = loading fraction, n = stoichiometry
+        where ``1 - theta`` is the fraction of extractant still free and
+        ``m`` is the number of extractant monomers bound per REE.
+
+        Caller's obligation (#189): ``theta`` is a **dimensionless** loading
+        fraction, mol REE bound divided by mol REE capacity, equivalently
+
+            theta = m * n_REE(organic) / n_extractant
+
+        computed from quantities in the same units (both concentrations or
+        both molar flows). Passing a concentration, a molar flow, or a flow
+        ratio here is a units error: the result is raised to the m-th power,
+        so the error is amplified. :meth:`loading_fraction` converts an
+        organic REE *concentration* to this fraction.
+
+        Note (#190): ``D_inf`` must not already carry a free-extractant
+        depletion factor. ``REEDistribution.get_D`` does carry one (its
+        ``n * log10([HA]/C_ref)`` term), which is why the stage path in
+        ``difflow_ree.units.extraction`` no longer calls this method.
 
         Args:
-            D_infinite: D at infinite dilution
-            c_org: Current organic phase REE concentration (M)
+            D_infinite: D at infinite dilution (zero loading)
+            theta: Dimensionless loading fraction (0 = clean solvent,
+                1 = extractant fully saturated)
 
         Returns:
             Apparent distribution coefficient
         """
         D_infinite = jnp.asarray(D_infinite)
-        theta = self.loading_fraction(c_org)
-        # Stoichiometry effect: each REE binds ~3 extractant molecules
-        n = 3.0
-        return D_infinite * jnp.power(jnp.maximum(1 - theta, 0.01), n)
+        theta = jnp.asarray(theta)
+        # Stoichiometry effect: each REE binds m extractant monomers (#191)
+        return D_infinite * jnp.power(jnp.maximum(1 - theta, 0.01), self.m)
 
 
 def langmuir_loading(
@@ -174,24 +224,57 @@ def loading_correction(
 ) -> dict[str, Array]:
     """Apply loading correction to D values for all elements.
 
-    In multi-component systems, total loading affects all D values.
+    In multi-component systems, total loading affects all D values:
+
+        D_app,i = D_inf,i * (1 - theta_total)^m
+
+    with ``theta_total`` the summed organic REE concentration divided by
+    ``isotherm.max_ree_conc`` and ``m = isotherm.m``. It is the multi-component
+    form of :meth:`LoadingIsotherm.apparent_D` and carries the same caller
+    obligations: ``D_values`` must not already carry a free-extractant
+    depletion factor (#190), and the free fraction is floored at 0.01 so the
+    correction saturates rather than reaching zero.
+
+    .. warning:: **Breaking change in #191.** Two things moved, and the output
+       changes by orders of magnitude for the acidic extractants:
+
+       * the exponent was the literal ``3``; it is now ``isotherm.m``, which
+         is 6.0 for D2EHPA, PC88A and Cyanex272 (three dimers) and 3.0 for TBP;
+       * ``theta_total`` is computed against ``isotherm.max_ree_conc``, which
+         itself halved for those extractants because ``max_loading`` went from
+         the 0.33 literal to ``1/m = 1/6``.
+
+       At an organic REE concentration of 0.0413 M in 0.5 M D2EHPA the
+       correction was ``(1 - 0.25030)^3 = 0.42136`` and is now
+       ``(1 - 0.49560)^6 = 0.016468``, a factor of 25.59 smaller. Callers that
+       calibrated against the old form must refit.
 
     Args:
         D_values: Dictionary of infinite-dilution D values
-        c_org: Current organic concentrations for each element
+        c_org: Current organic concentrations for each element (M), keyed by
+            element; keys need not match ``D_values``
         isotherm: Loading isotherm model
 
     Returns:
-        Corrected D values accounting for total loading
+        Corrected D values accounting for total loading, with the same keys as
+        ``D_values``
+
+    Example:
+        >>> from difflow_ree.equilibrium.loading import (
+        ...     get_loading_isotherm, loading_correction)
+        >>> iso = get_loading_isotherm("D2EHPA", 0.5)   # m = 6, cap 1/12 M
+        >>> out = loading_correction({"Nd": 10.0}, {"Nd": 0.0413}, iso)
+        >>> float(out["Nd"])                            # doctest: +ELLIPSIS
+        0.1646...
     """
     # Calculate total loading fraction
     total_c_org = sum(jnp.asarray(c) for c in c_org.values())
     theta_total = isotherm.loading_fraction(total_c_org)
 
     # Apply correction to all elements
-    # D_app = D_inf * (1 - theta)^n
-    n = 3.0  # Stoichiometry
-    correction = jnp.power(jnp.maximum(1 - theta_total, 0.01), n)
+    # D_app = D_inf * (1 - theta)^m, with m the monomer stoichiometry taken
+    # from the isotherm rather than hard-coded (#191)
+    correction = jnp.power(jnp.maximum(1 - theta_total, 0.01), isotherm.m)
 
     return {elem: D * correction for elem, D in D_values.items()}
 
@@ -230,11 +313,22 @@ def competitive_langmuir(
 # Extractant Capacity Data
 # =============================================================================
 
-# Typical maximum loading capacities (mol REE per mol extractant)
+# Langmuir constants only. Capacity and stoichiometry are NOT duplicated here:
+# they are derived from the extractant record in ``difflow_ree.database``
+# (``Extractant.monomers_per_ree`` / ``Extractant.max_loading``), which reads
+# the declared extraction mechanism from ``data/extractants.yaml``. There is one
+# source of truth for m (#191).
+#
+# BREAKING CHANGE (#191): this module-level dict is public, and the per-
+# extractant ``"stoichiometry"`` and ``"max_loading"`` keys it used to carry
+# were deleted, not merely re-valued. ``EXTRACTANT_CAPACITIES["D2EHPA"]
+# ["max_loading"]`` now raises ``KeyError``; read
+# ``difflow_ree.database.get_extractant("D2EHPA").max_loading`` (or
+# ``.monomers_per_ree``) instead. The values also changed: the deleted
+# ``max_loading`` literal was 0.33 for the acidic extractants where the
+# database now derives 1/6, because the YAML declares three *dimers*.
 EXTRACTANT_CAPACITIES = {
     "D2EHPA": {
-        "stoichiometry": 3,  # 3 extractant molecules per REE
-        "max_loading": 0.33,  # mol REE / mol extractant
         "typical_K_L": {
             "La": 5.0,
             "Ce": 8.0,
@@ -249,8 +343,6 @@ EXTRACTANT_CAPACITIES = {
         },
     },
     "PC88A": {
-        "stoichiometry": 3,
-        "max_loading": 0.33,
         "typical_K_L": {
             "La": 3.0,
             "Ce": 5.0,
@@ -265,8 +357,6 @@ EXTRACTANT_CAPACITIES = {
         },
     },
     "Cyanex272": {
-        "stoichiometry": 3,
-        "max_loading": 0.33,
         "typical_K_L": {
             "La": 2.0,
             "Ce": 3.0,
@@ -281,8 +371,6 @@ EXTRACTANT_CAPACITIES = {
         },
     },
     "TBP": {
-        "stoichiometry": 3,
-        "max_loading": 0.33,
         "typical_K_L": {
             "La": 2.0,
             "Ce": 2.5,
@@ -305,6 +393,12 @@ def get_loading_isotherm(
 ) -> LoadingIsotherm:
     """Create loading isotherm for specified extractant.
 
+    The stoichiometry ``m`` (and hence the capacity ``1/m``) is read from the
+    extractant database, which derives it from the extraction mechanism
+    declared in ``data/extractants.yaml``, rather than from a hard-coded
+    literal here (#191). ``EXTRACTANT_CAPACITIES`` supplies only the Langmuir
+    constants.
+
     Args:
         extractant: Extractant name
         concentration: Extractant concentration (M)
@@ -315,12 +409,14 @@ def get_loading_isotherm(
     if extractant not in EXTRACTANT_CAPACITIES:
         raise ValueError(f"Unknown extractant: {extractant}")
 
+    from difflow_ree.database import get_extractant
+
     data = EXTRACTANT_CAPACITIES[extractant]
     # Use average K_L across elements
     avg_K_L = sum(data["typical_K_L"].values()) / len(data["typical_K_L"])
 
     return LoadingIsotherm(
-        max_loading=data["max_loading"],
+        m=get_extractant(extractant).monomers_per_ree,
         K_L=avg_K_L,
         extractant_conc=concentration,
     )

--- a/src/difflow_ree/equilibrium/speciation.py
+++ b/src/difflow_ree/equilibrium/speciation.py
@@ -302,15 +302,54 @@ def speciation_correction(
 # Ionic Strength Effects
 # =============================================================================
 
+# Ionic strength (M) at which the Davies bracket
+#
+#     f(I) = sqrt(I)/(1 + sqrt(I)) - 0.3 I
+#
+# changes sign. Solving f(I) = 0 with x = sqrt(I) gives 0.3 x^2 + 0.3 x - 1 = 0,
+# i.e. x = (-1 + sqrt(1 + 40/3))/2 and I = x^2 (#194). Above this ionic strength
+# Davies predicts gamma > 1 for every ion, and any ratio of Davies coefficients
+# built from it INVERTS: gamma_RE/gamma_H**3 = 10**(-6 A f) crosses 1 here and
+# grows without bound. This is why difflow_ree never extrapolates Davies
+# silently -- see REEDistribution and DAVIES_MAX_IONIC_STRENGTH.
+DAVIES_SIGN_CHANGE_IONIC_STRENGTH = 1.940363884733242  # M
+
+# Documented validity limit of the Davies equation (M).
+DAVIES_MAX_IONIC_STRENGTH = 0.5
+
+# Aqueous media difflow_ree recognizes. The same vocabulary as
+# :class:`REESpeciation.medium`, reused by
+# :class:`difflow_ree.equilibrium.distribution.REEDistribution` so that a
+# nitrate-requiring (solvating) extractant declared to be operating in a
+# chloride or sulfate liquor is detected rather than merely described in an
+# error message (#195). "mixed" is treated as containing nitrate.
+AQUEOUS_MEDIA = ("sulfate", "chloride", "nitrate", "mixed")
+
+# Media that supply the nitrate (salting) anion a solvating extractant needs.
+NITRATE_BEARING_MEDIA = ("nitrate", "mixed")
+
+
 def activity_coefficient_davies(
     z: int,
     ionic_strength: Array | float,
 ) -> Array:
     """Calculate activity coefficient using Davies equation.
 
-    log(gamma) = -A * z² * (sqrt(I)/(1 + sqrt(I)) - 0.3*I)
+    log10(gamma) = -A * z^2 * f(I),  f(I) = sqrt(I)/(1 + sqrt(I)) - 0.3*I
 
-    Valid for I < 0.5 M.
+    VALIDITY (#194). The equation is documented for I < 0.5 M
+    (:data:`DAVIES_MAX_IONIC_STRENGTH`). Beyond that it is not merely an
+    inaccurate extrapolation: ``f`` changes sign at
+    I = 1.940363884733242 M (:data:`DAVIES_SIGN_CHANGE_IONIC_STRENGTH`, the
+    root of 0.3 I + 0.3 sqrt(I) - 1 = 0), so above ~1.94 M this function
+    returns gamma > 1 and any correction built as a ratio of Davies
+    coefficients reverses direction. For example
+    ``gamma_RE3+ / gamma_H+**3 = 10**(-6 A f)`` equals 0.228 at I = 0.1 M,
+    0.245 at I = 1.0 M, 1.0 at I = 1.9404 M and 6.49 at I = 3.0 M -- the
+    correction that *reduces* D in dilute solution *multiplies* it by 6.5 in a
+    3 M liquor. This function does not guard against that; callers must
+    (:class:`difflow_ree.equilibrium.distribution.REEDistribution` clamps the
+    ionic strength it feeds here unless extrapolation is explicitly requested).
 
     Args:
         z: Ion charge
@@ -326,6 +365,72 @@ def activity_coefficient_davies(
     log_gamma = -A * z**2 * (sqrt_I / (1 + sqrt_I) - 0.3 * I)
 
     return jnp.power(10.0, log_gamma)
+
+
+# Aqueous activity models available to the distribution correlations (#194).
+# Each model declares its own documented validity range so that using it
+# outside that range is a reported extrapolation rather than a silent one.
+# Bromley and SIT are deliberately absent: difflow_ree does not carry their
+# ion-interaction parameters and will not invent them.
+ACTIVITY_MODELS: dict[str, dict] = {
+    "davies": {
+        "max_ionic_strength": DAVIES_MAX_IONIC_STRENGTH,  # M
+        # Ionic strength at which the model's own bracket changes sign, so that
+        # ratios of its coefficients invert. None for models that cannot invert.
+        "sign_change_ionic_strength": DAVIES_SIGN_CHANGE_IONIC_STRENGTH,
+        "description": (
+            "Davies equation, log10(gamma) = -A z^2 "
+            "(sqrt(I)/(1+sqrt(I)) - 0.3 I), A = 0.509 at 25 C"
+        ),
+        "reference": "Davies, C.W. Ion Association, Butterworths, 1962.",
+    },
+    "none": {
+        # No correction at all: the correlation is used as the conditional
+        # constant it is, at the ionic strength it was fitted at. This is the
+        # defensible option for a 2-4 M chloride liquor.
+        "max_ionic_strength": float("inf"),
+        "sign_change_ionic_strength": None,
+        "description": (
+            "No activity correction; the correlation is treated as a "
+            "conditional constant valid at its fitting ionic strength"
+        ),
+        "reference": "n/a",
+    },
+}
+
+
+def activity_coefficient(
+    z: int,
+    ionic_strength: Array | float,
+    model: str = "davies",
+) -> Array:
+    """Aqueous activity coefficient from a named activity model (#194).
+
+    Args:
+        z: Ion charge.
+        ionic_strength: Ionic strength (M).
+        model: Model name, a key of :data:`ACTIVITY_MODELS`. ``"davies"`` uses
+            the Davies equation (valid for I < 0.5 M); ``"none"`` returns 1.0,
+            i.e. the correlation is used as a conditional constant.
+
+    Returns:
+        Activity coefficient (dimensionless).
+
+    Raises:
+        ValueError: If ``model`` is not an implemented activity model. Models
+            whose ion-interaction parameters difflow_ree does not carry
+            (Bromley, SIT) raise here rather than being approximated.
+    """
+    if model not in ACTIVITY_MODELS:
+        raise ValueError(
+            f"Unknown activity model {model!r}. Implemented models: "
+            f"{sorted(ACTIVITY_MODELS)}. Models such as Bromley or SIT are "
+            "not implemented because difflow_ree does not carry their "
+            "ion-interaction parameters."
+        )
+    if model == "none":
+        return jnp.ones_like(jnp.asarray(ionic_strength, dtype=float))
+    return activity_coefficient_davies(z, ionic_strength)
 
 
 def ionic_strength_from_composition(

--- a/src/difflow_ree/flowsheets/extract_scrub_strip.py
+++ b/src/difflow_ree/flowsheets/extract_scrub_strip.py
@@ -54,6 +54,16 @@ class ExtractScrubStripParams(ParamsMixin):
         solvent_to_feed_ratio: O/A in extraction
         scrub_to_solvent_ratio: Scrub/O ratio
         strip_to_solvent_ratio: Strip/O ratio
+        nitrate_conc: Aqueous nitrate concentration (M), required for solvating
+            extractants such as TBP whose D is nitrate- rather than pH-driven
+            (#195). None for the acidic cation-exchange extractants. Threaded
+            to all three sections.
+        mechanism: Explicit extraction-mechanism override passed to
+            REEDistribution ("cation_exchange" / "solvating"). None takes the
+            mechanism from the extractant record (#195). Threaded to all
+            three sections, so a circuit never mixes mechanisms.
+        capacity_sharpness: Sharpness k of the extraction section's smooth
+            loading limiters; see REEExtractorParams (#193).
     """
     extractant: str
     elements: tuple[str, ...]
@@ -69,6 +79,9 @@ class ExtractScrubStripParams(ParamsMixin):
     solvent_to_feed_ratio: float = 1.0
     scrub_to_solvent_ratio: float = 0.2
     strip_to_solvent_ratio: float = 0.5
+    nitrate_conc: float | None = None  # see #195
+    mechanism: str | None = None  # see #195
+    capacity_sharpness: int = 8  # see REEExtractorParams (#193)
 
 
 class ExtractScrubStripCircuit:
@@ -130,6 +143,9 @@ class ExtractScrubStripCircuit:
             diluent=params.diluent,
             pH=params.extraction_pH,
             extractant_conc=params.extractant_conc,
+            nitrate_conc=params.nitrate_conc,  # see #195
+            mechanism=params.mechanism,  # see #195
+            capacity_sharpness=params.capacity_sharpness,  # see #193
         ))
 
         # Scrubbing section
@@ -141,6 +157,8 @@ class ExtractScrubStripCircuit:
             diluent=params.diluent,
             pH=params.scrubbing_pH,
             extractant_conc=params.extractant_conc,
+            nitrate_conc=params.nitrate_conc,  # see #195
+            mechanism=params.mechanism,  # see #195
         ))
 
         # Stripping section
@@ -151,6 +169,8 @@ class ExtractScrubStripCircuit:
             diluent=params.diluent,
             pH=params.stripping_pH,
             extractant_conc=params.extractant_conc,
+            nitrate_conc=params.nitrate_conc,  # see #195
+            mechanism=params.mechanism,  # see #195
         ))
 
     def __call__(
@@ -324,6 +344,8 @@ def design_extract_scrub_strip(
     extractant: str,
     target_purity: float = 0.95,
     target_recovery: float = 0.90,
+    nitrate_conc: float | None = None,
+    mechanism: str | None = None,
 ) -> ExtractScrubStripParams:
     """Design 3-section circuit for given separation.
 
@@ -333,6 +355,9 @@ def design_extract_scrub_strip(
         extractant: Extractant to use
         target_purity: Target product purity
         target_recovery: Target recovery of target elements
+        nitrate_conc: Aqueous nitrate concentration (M), required for solvating
+            extractants such as TBP (#195)
+        mechanism: Explicit mechanism override; see REEDistribution (#195)
 
     Returns:
         Recommended ExtractScrubStripParams
@@ -371,4 +396,6 @@ def design_extract_scrub_strip(
         n_stripping_stages=n_stripping,
         extraction_pH=extraction_pH,
         scrubbing_pH=scrubbing_pH,
+        nitrate_conc=nitrate_conc,  # see #195
+        mechanism=mechanism,  # see #195
     )

--- a/src/difflow_ree/flowsheets/extract_strip.py
+++ b/src/difflow_ree/flowsheets/extract_strip.py
@@ -44,6 +44,15 @@ class ExtractStripParams(ParamsMixin):
         extractant_conc: Extractant concentration (M)
         solvent_to_feed_ratio: Organic/aqueous ratio in extraction
         strip_to_solvent_ratio: Strip acid/organic ratio
+        nitrate_conc: Aqueous nitrate concentration (M), required for solvating
+            extractants such as TBP whose D is nitrate- rather than pH-driven
+            (#195). Threaded to both sections.
+        mechanism: Explicit extraction-mechanism override passed to
+            REEDistribution ("cation_exchange" / "solvating"). None takes the
+            mechanism from the extractant record (#195). Threaded to both
+            sections, so a circuit never mixes mechanisms.
+        capacity_sharpness: Sharpness k of the extraction section's smooth
+            loading limiters; see REEExtractorParams (#193).
     """
     extractant: str
     elements: tuple[str, ...]
@@ -55,6 +64,9 @@ class ExtractStripParams(ParamsMixin):
     extractant_conc: float = 0.5
     solvent_to_feed_ratio: float = 1.0
     strip_to_solvent_ratio: float = 0.5
+    nitrate_conc: float | None = None  # see #195
+    mechanism: str | None = None  # see #195
+    capacity_sharpness: int = 8  # see REEExtractorParams (#193)
 
 
 class ExtractStripCircuit:
@@ -109,6 +121,9 @@ class ExtractStripCircuit:
             diluent=params.diluent,
             pH=params.extraction_pH,
             extractant_conc=params.extractant_conc,
+            nitrate_conc=params.nitrate_conc,  # see #195
+            mechanism=params.mechanism,  # see #195
+            capacity_sharpness=params.capacity_sharpness,  # see #193
         ))
 
         # Create stripping section
@@ -119,6 +134,8 @@ class ExtractStripCircuit:
             diluent=params.diluent,
             pH=params.stripping_pH,
             extractant_conc=params.extractant_conc,
+            nitrate_conc=params.nitrate_conc,  # see #195
+            mechanism=params.mechanism,  # see #195
         ))
 
     def __call__(
@@ -279,6 +296,8 @@ def design_extract_strip(
     extractant: str,
     target_recovery: float = 0.99,
     extraction_pH: float = 3.5,
+    nitrate_conc: float | None = None,
+    mechanism: str | None = None,
 ) -> ExtractStripParams:
     """Design extract-strip circuit for given feed.
 
@@ -287,6 +306,9 @@ def design_extract_strip(
         extractant: Extractant to use
         target_recovery: Target recovery fraction
         extraction_pH: Operating pH
+        nitrate_conc: Aqueous nitrate concentration (M), required for solvating
+            extractants such as TBP (#195)
+        mechanism: Explicit mechanism override; see REEDistribution (#195)
 
     Returns:
         Recommended ExtractStripParams
@@ -296,7 +318,12 @@ def design_extract_strip(
     elements = tuple(feed_composition.keys())
 
     # Get D values at operating pH
-    dist = REEDistribution(extractant=extractant, elements=elements)
+    dist = REEDistribution(
+        extractant=extractant,
+        elements=elements,
+        nitrate_conc=nitrate_conc,  # see #195
+        mechanism=mechanism,  # see #195
+    )
     D_values = dist.get_D_all(extraction_pH)
 
     # Find element with lowest D (hardest to extract)
@@ -315,4 +342,6 @@ def design_extract_strip(
         n_extraction_stages=n_ext,
         n_stripping_stages=n_strip,
         extraction_pH=extraction_pH,
+        nitrate_conc=nitrate_conc,  # see #195
+        mechanism=mechanism,  # see #195
     )

--- a/src/difflow_ree/flowsheets/full_train.py
+++ b/src/difflow_ree/flowsheets/full_train.py
@@ -50,6 +50,17 @@ class SeparationTrainParams(ParamsMixin):
         group_separation: Whether to separate into light/middle/heavy
         individual_separation: Whether to separate individual elements
         target_purities: Target purity for each element
+        nitrate_conc: Aqueous nitrate concentration (M), required for solvating
+            extractants such as TBP whose D is nitrate- rather than pH-driven
+            (#195). None for the acidic cation-exchange extractants. Threaded
+            into every circuit the train builds.
+        mechanism: Explicit extraction-mechanism override passed to
+            REEDistribution ("cation_exchange" / "solvating"). None takes the
+            mechanism from the extractant record (#195). Threaded into every
+            section of every circuit the train builds, so no circuit mixes
+            mechanisms.
+        capacity_sharpness: Sharpness k of the smooth loading limiters in each
+            circuit's extraction section; see REEExtractorParams (#193).
     """
     elements: tuple[str, ...] = ("La", "Ce", "Pr", "Nd", "Sm", "Eu", "Gd", "Tb", "Dy", "Y")
     extractant: str = "D2EHPA"
@@ -58,6 +69,9 @@ class SeparationTrainParams(ParamsMixin):
     include_ce_removal: bool = True
     group_separation: bool = True
     individual_separation: bool = False  # Full individual sep is complex
+    nitrate_conc: float | None = None  # see #195
+    mechanism: str | None = None  # see #195
+    capacity_sharpness: int = 8  # see REEExtractorParams (#193)
     target_purities: dict = field(default_factory=lambda: {
         "Nd": 0.99,
         "Dy": 0.99,
@@ -102,6 +116,9 @@ class GroupSeparator:
         light_elements: tuple[str, ...] = ("La", "Ce", "Pr", "Nd"),
         middle_elements: tuple[str, ...] = ("Sm", "Eu"),
         heavy_elements: tuple[str, ...] = ("Gd", "Tb", "Dy", "Y"),
+        nitrate_conc: float | None = None,
+        mechanism: str | None = None,
+        capacity_sharpness: int = 8,
     ):
         """Initialize separator.
 
@@ -112,6 +129,11 @@ class GroupSeparator:
             light_elements: Elements for light group
             middle_elements: Elements for middle group
             heavy_elements: Elements for heavy group
+            nitrate_conc: Aqueous nitrate concentration (M), required for
+                solvating extractants such as TBP (#195)
+            mechanism: Explicit mechanism override; see REEDistribution (#195)
+            capacity_sharpness: Sharpness k of the extraction sections' smooth
+                loading limiters; see REEExtractorParams (#193)
         """
         self.elements = elements
         self.extractant = extractant
@@ -119,6 +141,9 @@ class GroupSeparator:
         self.light_elements = light_elements
         self.middle_elements = middle_elements
         self.heavy_elements = heavy_elements
+        self.nitrate_conc = nitrate_conc
+        self.mechanism = mechanism
+        self.capacity_sharpness = capacity_sharpness
 
         # Circuit 1: Separate heavy from light+middle
         self._heavy_circuit = ExtractScrubStripCircuit(ExtractScrubStripParams(
@@ -131,6 +156,9 @@ class GroupSeparator:
             n_stripping_stages=5,
             extraction_pH=3.0,  # All extract
             scrubbing_pH=2.0,   # Reject light+middle
+            nitrate_conc=nitrate_conc,  # see #195
+            mechanism=mechanism,  # see #195
+            capacity_sharpness=capacity_sharpness,  # see #193
         ))
 
         # Circuit 2: Separate middle from light (on Circuit 1 scrub liquor)
@@ -145,6 +173,9 @@ class GroupSeparator:
             n_stripping_stages=5,
             extraction_pH=3.5,
             scrubbing_pH=2.5,
+            nitrate_conc=nitrate_conc,  # see #195
+            mechanism=mechanism,  # see #195
+            capacity_sharpness=capacity_sharpness,  # see #193
         ))
 
     def __call__(
@@ -257,6 +288,9 @@ class FullSeparationTrain:
                 light_elements=light,
                 middle_elements=middle,
                 heavy_elements=heavy,
+                nitrate_conc=params.nitrate_conc,  # see #195
+                mechanism=params.mechanism,  # see #195
+                capacity_sharpness=params.capacity_sharpness,  # see #193
             )
         else:
             self._group_separator = None
@@ -325,6 +359,8 @@ def design_separation_train(
     feed_analysis: dict[str, float],
     target_products: list[str],
     annual_capacity_tonnes: float = 1000,
+    nitrate_conc: float | None = None,
+    mechanism: str | None = None,
 ) -> SeparationTrainParams:
     """Design separation train for given feed and products.
 
@@ -332,6 +368,9 @@ def design_separation_train(
         feed_analysis: REE composition in feed (wt%)
         target_products: List of target product elements
         annual_capacity_tonnes: Annual REE production capacity
+        nitrate_conc: Aqueous nitrate concentration (M), required for solvating
+            extractants such as TBP (#195)
+        mechanism: Explicit mechanism override; see REEDistribution (#195)
 
     Returns:
         Recommended SeparationTrainParams
@@ -353,4 +392,6 @@ def design_separation_train(
         include_ce_removal=include_ce,
         group_separation=True,
         individual_separation=individual_sep,
+        nitrate_conc=nitrate_conc,  # see #195
+        mechanism=mechanism,  # see #195
     )

--- a/src/difflow_ree/flowsheets/split_shell.py
+++ b/src/difflow_ree/flowsheets/split_shell.py
@@ -44,6 +44,12 @@ class SplitShellParams(ParamsMixin):
         product_groups: Element groups for each product
         pH: Operating pH
         extractant_conc: Extractant concentration
+        nitrate_conc: Aqueous nitrate concentration (M), required for solvating
+            extractants such as TBP whose D is nitrate- rather than pH-driven
+            (#195)
+        mechanism: Explicit extraction-mechanism override passed to
+            REEDistribution ("cation_exchange" / "solvating"). None takes the
+            mechanism from the extractant record (#195).
     """
     extractant: str
     elements: tuple[str, ...]
@@ -54,6 +60,8 @@ class SplitShellParams(ParamsMixin):
     pH: float = 3.5
     extractant_conc: float = 0.5
     solvent_to_feed_ratio: float = 1.0
+    nitrate_conc: float | None = None  # see #195
+    mechanism: str | None = None  # see #195
 
 
 def _kremser_fraction_extracted(E, n_stages):
@@ -125,6 +133,8 @@ class SplitShellCascade:
             extractant=params.extractant,
             elements=params.elements,
             concentration=params.extractant_conc,
+            nitrate_conc=params.nitrate_conc,
+            mechanism=params.mechanism,
         )
 
     def __call__(
@@ -330,6 +340,8 @@ def optimize_split_points(
     n_stages: int,
     n_products: int,
     pH: float = 3.5,
+    nitrate_conc: float | None = None,
+    mechanism: str | None = None,
 ) -> tuple[int, ...]:
     """Find split points that maximise inter-group separation.
 
@@ -359,6 +371,10 @@ def optimize_split_points(
         n_stages: Total stages available
         n_products: Number of products desired
         pH: Operating pH
+        nitrate_conc: Aqueous nitrate concentration (M), required for solvating
+            extractants such as TBP whose D is nitrate- rather than pH-driven
+            (#195)
+        mechanism: Explicit mechanism override; see REEDistribution (#195)
 
     Returns:
         Tuple of split stage numbers (length n_products - 1), sorted
@@ -378,6 +394,8 @@ def optimize_split_points(
         extractant=extractant,
         elements=tuple(elements),
         concentration=0.5,
+        nitrate_conc=nitrate_conc,
+        mechanism=mechanism,
     )
     D_vals = dist.get_D_all(pH)
     # Sort elements from lowest D (hardest to extract) to highest D

--- a/src/difflow_ree/units/extraction.py
+++ b/src/difflow_ree/units/extraction.py
@@ -20,6 +20,216 @@ from difflow_ree.kinetics.extraction_kinetics import approach_to_equilibrium
 
 
 # =============================================================================
+# Phase flow bookkeeping
+# =============================================================================
+
+#: Relative floor applied to a phase carrier flow before it is used as a
+#: denominator.  It is *relative* to the total flow of the streams involved,
+#: never an absolute molar flow, so every ratio in this module is invariant to
+#: the unit the flows are expressed in (#189).  The absolute ``1e-10`` floor it
+#: replaced silently destroyed that invariance below about ``1e-11`` mol/s: a
+#: cascade expressed in mol/s and the identical cascade expressed in Tmol/s
+#: returned different recoveries (0.3255 vs 0.0330 for the D2EHPA/Nd case in
+#: ``tests/ree/test_ree_loading_capacity.py``).  With a relative floor the
+#: supported range is the whole float64 range, limited only by underflow of the
+#: flows themselves.
+_PHASE_FLOW_FLOOR_REL = 1e-12
+
+
+def _concrete(x) -> float | None:
+    """Return ``x`` as a Python float, or None if it is a JAX tracer.
+
+    Used for guards that must fire on obviously-broken input but must not
+    force a traced value to a concrete one.  Under ``jit``/``grad`` the value
+    is a tracer and the guard is skipped, which is the price of keeping the
+    unit traceable; the guard still fires on every eager call, which is how
+    the mis-specified stream is caught in practice.
+    """
+    try:
+        return float(x)
+    except Exception:  # TracerArrayConversionError, ConcretizationTypeError
+        return None
+
+
+def _soft_saturation(
+    total: Array | float,
+    capacity: Array | float,
+    k: float,
+) -> Array:
+    """Smooth ``min(1, capacity / total)`` with sharpness ``k``.
+
+    Mathematically ``(1 + (total / capacity)**k)**(-1/k)``: 1 well below
+    capacity, ``capacity / total`` well above it, and C-infinity everywhere,
+    including at ``total == capacity`` where the hard ``jnp.where`` clamp it
+    replaced put a kink in the gradient (#193).
+
+    Evaluated in the scaled form ``c / (c**k + t**k)**(1/k)`` with ``c`` and
+    ``t`` divided by their own maximum, so neither ``total**k`` nor
+    ``capacity**k`` can overflow and ``capacity == 0`` gives a clean 0 rather
+    than ``inf``/``nan``.  The degenerate ``total == capacity == 0`` returns 1
+    (nothing to limit), guarded with the double-``where`` idiom so reverse-mode
+    AD does not see a ``0 ** (1/k)`` derivative.
+
+    Args:
+        total: Quantity to be limited (a molar flow, or a loading fraction)
+        capacity: The limit, in the same units as ``total``
+        k: Sharpness; larger tracks ``min`` more closely, at the cost of
+            curvature ``k / 4`` in log-log at the crossing point
+
+    Returns:
+        Multiplier in (0, 1]
+    """
+    total = jnp.asarray(total, dtype=jnp.float64)
+    capacity = jnp.asarray(capacity, dtype=jnp.float64)
+    # Nothing to limit, and the scaled form would be 0/0.
+    degenerate = jnp.logical_and(total <= 0.0, capacity <= 0.0)
+    magnitude = jnp.maximum(jnp.maximum(total, capacity), 0.0)
+    magnitude = jnp.where(degenerate, 1.0, magnitude)
+    c = capacity / magnitude
+    t = total / magnitude
+    # max(c, t) == 1 whenever not degenerate, so u is in [1, 2]: no overflow
+    # from total**k, and no underflow-to-zero of the sum.
+    u = jnp.power(c, k) + jnp.power(t, k)
+    u = jnp.where(degenerate, 1.0, u)
+    return jnp.where(degenerate, 1.0, c / jnp.power(u, 1.0 / k))
+
+
+def _smooth_free_fraction(theta: Array | float, k: float) -> Array:
+    """Smooth ``max(1 - theta, 0)``: the extractant left free at loading theta.
+
+    ``1 - theta * softmin(theta, 1)`` with the same power-mean softmin as
+    :func:`_soft_saturation`, so both limiters in this module are driven by the
+    single ``capacity_sharpness`` knob.
+
+    Why not ``jnp.maximum(1 - theta, 0)`` (#193): that is a hard kink with a
+    *dead lever* beyond it.  Past ``theta = 1`` the clipped free fraction is
+    identically zero, so ``E`` is identically zero, so ``d(recovery)/d(anything
+    upstream)`` is exactly 0 and a gradient-based optimizer -- or a
+    ``difflow.planning`` delta vector -- sees a column of zeros and never moves
+    the lever again.  That is precisely the pathology
+    ``difflow.planning.health`` flags.  A recycled extract-strip solvent
+    travels this path, so it is not a corner case.
+
+    This form is strictly positive for every finite ``theta``: it behaves as
+    ``1 - theta`` for ``theta << 1``, equals ``1 - 2**(-1/k)`` at saturation,
+    and decays as ``theta**(-k) / k`` beyond it.  Its derivative is
+    ``-(1 + theta**k)**(-(k+1)/k)``, which is negative everywhere and never
+    identically zero.
+
+    Evaluated in two algebraically identical branches, because the literal
+    expression loses the answer to cancellation once it falls below float64
+    epsilon: at ``theta = 101`` with ``k = 8`` the true value is 1.2e-17 and
+    ``1 - theta * (...)`` rounds to exactly 0.0, resurrecting the dead lever
+    this function exists to remove.  Above ``theta = 1`` the equivalent
+    ``-expm1(-log1p(theta**-k) / k)`` is used instead, which is accurate down
+    to the underflow of ``theta**-k`` (about ``theta = 1e38`` for ``k = 8``).
+    The two branches agree to the last bit at ``theta = 1``.
+
+    Args:
+        theta: Dimensionless loading fraction (0 = clean, 1 = saturated)
+        k: Sharpness, shared with the capacity limiter
+
+    Returns:
+        Free-extractant fraction in (0, 1]
+    """
+    theta = jnp.asarray(theta, dtype=jnp.float64)
+    beyond = theta > 1.0
+    # Double-where so neither branch's derivative is evaluated on the input
+    # that would make it non-finite (theta**-k overflows for small theta).
+    theta_lo = jnp.where(beyond, 1.0, theta)
+    theta_hi = jnp.where(beyond, theta, 1.0)
+    below = 1.0 - theta_lo * _soft_saturation(theta_lo, 1.0, k)
+    above = -jnp.expm1(-jnp.log1p(jnp.power(theta_hi, -k)) / k)
+    return jnp.where(beyond, above, below)
+
+
+def _phase_flows(
+    flows: dict,
+    extractant: str,
+    diluent: str,
+    require: tuple[str, ...] = ("aqueous", "organic"),
+    stream_name: str = "stream",
+) -> tuple[Array, Array]:
+    """Split a stream's molar flows into aqueous and organic carrier flows.
+
+    One definition shared by :class:`REEExtractor` and
+    :class:`REEMixerSettler` so the two cannot disagree (#192). The organic
+    phase is the extractant plus the diluent; everything else (water, acid,
+    dissolved REE, spectators) is aqueous. Using only ``H2O`` for the aqueous
+    flow underestimates it for the concentrated leach liquors this package
+    targets, and a silent ``1.0`` default for a missing phase hides a
+    mis-specified stream behind a plausible-looking number, so a phase that is
+    required but absent raises instead.
+
+    Two checks, not one.  The key check is on the *Python-level* key set and
+    always runs.  Checking keys alone was not enough: ``{"H2O": 0.0, "D2EHPA":
+    1.0, "kerosene": 5.0}`` has an aqueous key, so it passed, and then a zero
+    ``F_aq`` was clamped to a magic ``1e-10`` and produced an extraction factor
+    of order ``1e10``.  So a required phase whose flows are *concretely* zero
+    or negative raises as well.  That second check needs the value, so it is
+    skipped when the value is a tracer (under ``jit``/``grad``); the relative
+    floor in the callers is what keeps the traced path finite.
+
+    Args:
+        flows: Species molar flows, as returned by ``get_flows``
+        extractant: Extractant species name
+        diluent: Organic diluent species name
+        require: Phases that must have at least one contributing species;
+            a subset of ``("aqueous", "organic")``
+        stream_name: Name used in the error message
+
+    Returns:
+        (F_aq, F_org): Total aqueous and total organic molar flows. A phase
+        with no contributing species (and not in ``require``) returns 0.
+
+    Raises:
+        ValueError: If a required phase has no contributing species, or if its
+            contributing species carry a concretely zero (or negative) total
+            flow.
+    """
+    organic_species = {extractant, diluent}
+    org_keys = [k for k in flows if k in organic_species]
+    aq_keys = [k for k in flows if k not in organic_species]
+
+    present = sorted(flows)
+    if "aqueous" in require and not aq_keys:
+        raise ValueError(
+            f"{stream_name} has no aqueous phase: every species present is an "
+            f"organic carrier. Species present: {present}; organic carriers "
+            f"(extractant, diluent): {sorted(organic_species)}."
+        )
+    if "organic" in require and not org_keys:
+        raise ValueError(
+            f"{stream_name} has no organic phase: neither the extractant "
+            f"'{extractant}' nor the diluent '{diluent}' is present. "
+            f"Species present: {present}."
+        )
+
+    zero = jnp.asarray(0.0)
+    F_aq = sum((jnp.asarray(flows[k]) for k in aq_keys), zero)
+    F_org = sum((jnp.asarray(flows[k]) for k in org_keys), zero)
+
+    for phase, keys, value in (
+        ("aqueous", aq_keys, F_aq),
+        ("organic", org_keys, F_org),
+    ):
+        if phase not in require:
+            continue
+        total = _concrete(value)
+        if total is not None and not total > 0.0:
+            raise ValueError(
+                f"{stream_name} declares an {phase} phase but its total flow "
+                f"is {total}. The phase ratio D * F_org / F_aq is undefined "
+                f"for a phase with no flow; a previous release silently "
+                f"floored it and returned an extraction factor of order 1e10. "
+                f"Contributing species: {sorted(keys)}; all species present: "
+                f"{present}."
+            )
+
+    return F_aq, F_org
+
+
+# =============================================================================
 # REE Extractor Parameters
 # =============================================================================
 
@@ -38,6 +248,55 @@ class REEExtractorParams(ParamsMixin):
         include_speciation: Whether to account for aqueous speciation
         speciation_medium: Aqueous medium type for speciation
         ligand_conc: Ligand concentration for speciation (M)
+        nitrate_conc: Aqueous nitrate concentration (M), required for
+            solvating extractants such as TBP (#195)
+        mechanism: Explicit extraction-mechanism override passed to the unit's
+            REEDistribution, one of "cation_exchange" or "solvating". None
+            (default) takes the mechanism from the extractant record (#195).
+        capacity_sharpness: Sharpness k of the two smooth loading limiters
+            (#193): the total-capacity limiter
+            ``scale = (1 + (total/capacity)**k)**(-1/k)`` applied to the newly
+            extracted total, and the entering-solvent free fraction
+            ``1 - theta * (1 + theta**k)**(-1/k)``. Both replace hard clamps
+            (``jnp.where`` and ``jnp.maximum(1 - theta, 0)``) whose gradients
+            kink at, and die beyond, the constraint an economic optimum sits
+            on.
+
+            The smoothing is *not* free, and the cost is a small unconditional
+            haircut below capacity rather than none at all. Exact values of
+            ``scale``:
+
+            ==========  ==========  ==========  ==========
+            total/cap   k = 4       k = 8       k = 16
+            ==========  ==========  ==========  ==========
+            0.50        0.98496     0.99951     0.9999990
+            0.75        0.93358     0.98814     0.99938
+            1.00        0.84090     0.91700     0.95760
+            ==========  ==========  ==========  ==========
+
+            Trade-off: the log-log slope ``d ln scale / d ln ratio`` is bounded
+            in [-1, 0] for every k, so k does not affect first-derivative
+            magnitude; what grows with k is the *curvature*, whose maximum
+            ``|d^2 ln scale / d(ln ratio)^2| = k/4`` sits at the crossing
+            point. Small k gives a well-conditioned but visibly wrong model
+            below capacity; large k gives a faithful model with a sharper
+            (though still C-infinity) turn that a line search must resolve.
+
+            The default was raised from 4 to 8 deliberately. At k = 4 a routine
+            run at half capacity lost 1.5% of the extraction unconditionally,
+            and ``include_loading`` defaults to True so every default result
+            carried it; at k = 8 that becomes 0.05%, below any physical
+            uncertainty in the correlations, while the curvature only doubles.
+            Raise it further (16, 32) to approach ``min()`` when the solve has
+            converged and the extra curvature is affordable; lower it to 2-4
+            when an optimizer is far from the solution and needs the gentler
+            surface.
+
+            Flowsheet note: the REE flowsheet Params in
+            ``difflow_ree.flowsheets`` do not yet expose this knob, so reach it
+            through the extractor they build,
+            ``circuit._extractor.params = circuit._extractor.params.update(
+            capacity_sharpness=16)``.
     """
     n_stages: int | float | Array
     extractant: str
@@ -49,6 +308,9 @@ class REEExtractorParams(ParamsMixin):
     include_speciation: bool = False
     speciation_medium: str = "sulfate"
     ligand_conc: float = 0.5
+    nitrate_conc: float | None = None
+    mechanism: str | None = None
+    capacity_sharpness: int = 8
 
     def __post_init__(self):
         """Validate extractor parameters."""
@@ -80,6 +342,10 @@ class REEExtractorParams(ParamsMixin):
         if self.extractant_conc <= 0:
             raise ValueError(
                 f"extractant_conc must be > 0, got {self.extractant_conc}"
+            )
+        if self.capacity_sharpness <= 0:
+            raise ValueError(
+                f"capacity_sharpness must be > 0, got {self.capacity_sharpness}"
             )
 
 
@@ -140,6 +406,8 @@ class REEExtractor:
             extractant=params.extractant,
             elements=params.elements,
             concentration=params.extractant_conc,
+            nitrate_conc=params.nitrate_conc,
+            mechanism=params.mechanism,
         )
         if params.include_loading:
             self._isotherm = get_loading_isotherm(
@@ -175,7 +443,17 @@ class REEExtractor:
         Returns:
             raffinate: Aqueous outlet (depleted)
             extract: Organic outlet (loaded)
-            info: Stage profiles and diagnostics
+            info: Stage profiles and diagnostics. With ``include_loading``
+                enabled it also reports the capacity condition (#193):
+                ``theta_total`` (dimensionless organic loading, 1.0 =
+                saturated), ``theta_solvent``, ``free_fraction_in``,
+                ``capacity`` (F_extractant / m as a molar flow),
+                ``uncapped_extracted``, ``capacity_scale``,
+                ``capacity_clamped_fraction`` and ``capacity_sharpness``.
+
+        Raises:
+            ValueError: If the feed has no aqueous species or the solvent has
+                no organic carrier (#192).
         """
         p = self.params
         pH = pH if pH is not None else p.pH
@@ -185,18 +463,41 @@ class REEExtractor:
         feed_flows = get_flows(feed)
         solvent_flows = get_flows(solvent)
 
-        # Get aqueous and organic carrier flows
-        # Use total aqueous flow (all species not in organic phase)
-        # For concentrated solutions, using only H2O underestimates F_aq
-        organic_species = {p.extractant, p.diluent}
-        F_aq = sum(
-            jnp.asarray(v) for k, v in feed_flows.items()
-            if k not in organic_species
+        # Get aqueous and organic carrier flows from the one shared
+        # definition (#192): organic = extractant + diluent, aqueous =
+        # everything else. Raises rather than defaulting when a phase is
+        # missing from the stream it is required in.
+        F_aq, _ = _phase_flows(
+            feed_flows, p.extractant, p.diluent,
+            require=("aqueous",), stream_name="REEExtractor feed",
         )
-        F_aq = jnp.maximum(F_aq, 1e-10)  # Prevent division by zero
-        F_extractant = solvent_flows.get(p.extractant, 0.0)
-        F_diluent = solvent_flows.get(p.diluent, 1.0)
-        F_org = F_extractant + F_diluent
+        _, F_org = _phase_flows(
+            solvent_flows, p.extractant, p.diluent,
+            require=("organic",), stream_name="REEExtractor solvent",
+        )
+        # Guard the denominator with a floor *relative* to the streams' own
+        # total flow, not the absolute 1e-10 that used to sit here (#189).
+        # An absolute floor is a hidden unit: it made recoveries depend on
+        # whether the cascade was written in mol/s or Tmol/s. This one is
+        # invariant to a uniform rescale by construction, so #189's invariance
+        # claim holds over the whole float64 range. ``_phase_flows`` has
+        # already raised if F_aq is concretely zero; this only catches the
+        # traced path.
+        F_aq = jnp.maximum(F_aq, _PHASE_FLOW_FLOOR_REL * (F_aq + F_org))
+        # The loading capacity is a molar flow of extractant, F_extractant / m
+        # (#191, #193), so with include_loading enabled the solvent has to say
+        # how much extractant it carries. Without it the capacity would be
+        # identically zero and the unit would silently return zero recovery.
+        # This is a Python-level key check, not a check on a traced value.
+        if self._isotherm is not None and p.extractant not in solvent_flows:
+            raise ValueError(
+                f"REEExtractor solvent does not declare a flow of the "
+                f"extractant '{p.extractant}', but include_loading=True needs "
+                f"it to compute the loading capacity F_extractant / m. "
+                f"Species present: {sorted(solvent_flows)}. Add the extractant "
+                f"to the solvent stream, or set include_loading=False."
+            )
+        F_extractant = jnp.asarray(solvent_flows.get(p.extractant, 0.0))
 
         # Get distribution coefficients
         D_values = self._distribution.get_D_all(pH, T)
@@ -214,29 +515,73 @@ class REEExtractor:
         extract_flows = dict(solvent_flows)
         stage_profiles = {}
 
+        # Where each loading effect lives (#189, #190, #191).
+        #
+        # Free-extractant depletion, D proportional to [HA]_free^n, is applied
+        # in EXACTLY ONE place: the ``n * log10(concentration / C_ref)`` term
+        # in ``REEDistribution.get_D`` (difflow_ree/equilibrium/distribution.py),
+        # where the correlation carries the extractant-concentration
+        # dependence. The per-element ``LoadingIsotherm.apparent_D`` call that
+        # used to sit in this loop applied the same (1 - theta)^m physics a
+        # second time, so D fell off as the 2m-th power of free extractant
+        # instead of the m-th (#190). It has been removed from the stage path;
+        # ``apparent_D`` remains supported public API for callers holding a D
+        # that does not already carry the concentration term.
+        #
+        # What remains here is finite capacity, which is a different effect:
+        # extractant already carrying REE cannot carry more (theta_solvent
+        # below), and the stage total cannot exceed F_extractant / m (the
+        # smooth limiter after the loop, #193). Both are expressed as genuine
+        # dimensionless loading fractions,
+        #
+        #     theta = m * (REE molar flow in organic) / (extractant molar flow)
+        #
+        # which is invariant to the unit the flows are expressed in (#189).
+        # Converging a single mass-action extractant balance would subsume all
+        # of this and is tracked separately (#196).
+        if self._isotherm is not None:
+            m = self._isotherm.m
+            k_sharp = float(p.capacity_sharpness)
+            F_ree_solvent = sum(
+                jnp.asarray(solvent_flows.get(e, 0.0)) for e in p.elements
+            )
+            # Relative floor again (#189): F_org is the same stream's own
+            # carrier flow, so this is a unit-invariant guard, not a magic
+            # molar flow.
+            F_ext_safe = jnp.maximum(
+                F_extractant, _PHASE_FLOW_FLOOR_REL * F_org
+            )
+            theta_solvent = m * F_ree_solvent / F_ext_safe
+            # Smooth, never dead (#193). ``jnp.maximum(1 - theta, 0)`` kinked
+            # here and was exactly zero beyond theta = 1, which killed the
+            # gradient on the recycled-solvent path an extract-strip circuit
+            # travels; see _smooth_free_fraction.
+            free_fraction_in = _smooth_free_fraction(theta_solvent, k_sharp)
+
         for elem in p.elements:
             D = D_values[elem]
             F_in = jnp.asarray(feed_flows.get(elem, 0.0))
             F_solvent = jnp.asarray(solvent_flows.get(elem, 0.0))
 
-            # Apply loading correction if enabled
-            if self._isotherm is not None:
-                # Estimate average loading (iterative would be more accurate)
-                avg_loading = F_in * 0.5 / F_org  # Rough estimate
-                D = self._isotherm.apparent_D(D, avg_loading)
-
             # Extraction factor E = D * (F_org / F_aq)
             E = D * F_org / F_aq
 
-            # Adjust for initial organic loading (loaded solvent reduces capacity)
+            # Adjust for initial organic loading (loaded solvent reduces the
+            # extractant left free to bind more REE). theta_solvent is the
+            # stage-level dimensionless loading of the entering solvent (#189).
             if self._isotherm is not None:
-                initial_loading = F_solvent / jnp.maximum(F_org, 1e-10)
-                capacity = self._isotherm.max_ree_conc
-                E = E * jnp.maximum(1.0 - initial_loading / capacity, 0.0)
+                E = E * free_fraction_in
             else:
                 # Simple loading correction without isotherm:
-                # Reduce E based on ratio of existing loading to feed
-                loading_ratio = F_solvent / jnp.maximum(F_in + F_solvent, 1e-10)
+                # Reduce E based on ratio of existing loading to feed. Guarded
+                # with a where rather than an absolute 1e-10 floor, which was
+                # a hidden unit here too (#189): with both flows below 1e-10
+                # the floored ratio was not the ratio at all.
+                denom = F_in + F_solvent
+                safe_denom = jnp.where(denom > 0.0, denom, 1.0)
+                loading_ratio = jnp.where(
+                    denom > 0.0, F_solvent / safe_denom, 0.0
+                )
                 E = E * (1.0 - loading_ratio)
 
             # Kremser equation for counter-current extraction
@@ -261,20 +606,32 @@ class REEExtractor:
                 "recovery": 1.0 - frac_remaining,
             }
 
-        # Enforce total extractant loading capacity (Bug #112)
+        # Enforce total extractant loading capacity (Bug #112, smoothed #193)
         # The Kremser equation can predict extraction beyond physical capacity
-        # when multiple REE are extracted simultaneously
+        # when multiple REE are extracted simultaneously.
+        #
+        # The capacity is a molar flow, F_extractant / m, in the same units as
+        # the extracted total: the old ``max_ree_conc * F_org`` multiplied a
+        # concentration by a flow and used the whole organic flow, diluent
+        # included, as if it were extractant (#191/#193).
+        #
+        # The limiter is the smooth saturation
+        #     scale = (1 + (total/capacity)**k)**(-1/k)
+        # which is 1 well below capacity and capacity/total well above it, but
+        # unlike the hard jnp.where clamp it replaces is C-infinity, so
+        # jax.grad is continuous at the capacity constraint an optimizer sits
+        # on. It also guarantees total * scale < capacity strictly, so the
+        # extractant balance never binds more extractant than was fed.
+        capacity_info = {}
         if self._isotherm is not None:
             total_newly_extracted = sum(
                 extract_flows[elem] - jnp.asarray(solvent_flows.get(elem, 0.0))
                 for elem in p.elements
             )
-            max_capacity = self._isotherm.max_ree_conc * F_org
-            scale = jnp.where(
-                total_newly_extracted > max_capacity,
-                max_capacity / jnp.maximum(total_newly_extracted, 1e-10),
-                1.0,
-            )
+            total_newly_extracted = jnp.maximum(total_newly_extracted, 0.0)
+            max_capacity = F_extractant / self._isotherm.m
+            k = k_sharp
+            scale = _soft_saturation(total_newly_extracted, max_capacity, k)
             for elem in p.elements:
                 F_solvent_elem = jnp.asarray(solvent_flows.get(elem, 0.0))
                 newly_extracted = extract_flows[elem] - F_solvent_elem
@@ -284,6 +641,30 @@ class REEExtractor:
                     + F_solvent_elem
                     - extract_flows[elem]
                 )
+
+            # Make the capacity condition observable (#193): a design pinned
+            # against the capacity wall looks converged otherwise.
+            F_ree_org_out = sum(extract_flows[e] for e in p.elements)
+            capacity_info = {
+                # Dimensionless loading of the organic outlet, 1.0 = saturated
+                "theta_total": (
+                    self._isotherm.m * F_ree_org_out / F_ext_safe
+                ),
+                # Loading of the entering solvent, on the same basis
+                "theta_solvent": theta_solvent,
+                # Extractant capacity as a molar flow, F_extractant / m
+                "capacity": max_capacity,
+                # Uncapped Kremser prediction, same units as capacity
+                "uncapped_extracted": total_newly_extracted,
+                # Limiter multiplier applied to the newly extracted total
+                "capacity_scale": scale,
+                # Fraction of the uncapped prediction the limiter removed
+                "capacity_clamped_fraction": 1.0 - scale,
+                "capacity_sharpness": jnp.asarray(k),
+                # Free-extractant fraction of the *entering* solvent, the
+                # smooth replacement for max(1 - theta_solvent, 0) (#193)
+                "free_fraction_in": free_fraction_in,
+            }
 
         # Create output streams
         P = feed["P"]
@@ -297,6 +678,7 @@ class REEExtractor:
             "profiles": stage_profiles,
             "D_values": D_values,
         }
+        info.update(capacity_info)
 
         return raffinate, extract, info
 
@@ -327,6 +709,12 @@ class MixerSettlerParams(ParamsMixin):
     mixer_residence_time: float = 120.0  # 2 minutes typical
     settler_residence_time: float = 300.0  # 5 minutes typical
     stage_efficiency: float = 0.95
+    # Aqueous nitrate concentration (M), required for solvating extractants
+    # such as TBP whose D is nitrate- rather than pH-driven (#195).
+    nitrate_conc: float | None = None
+    # Explicit extraction-mechanism override ("cation_exchange"/"solvating")
+    # for this stage's REEDistribution; None takes it from the record (#195).
+    mechanism: str | None = None
     # Extraction kinetics (#118). When k_extraction (overall rate constant,
     # 1/s) is set, the effective stage efficiency is the kinetic approach to
     # equilibrium 1 - exp(-k * mixer_residence_time) rather than the fixed
@@ -340,8 +728,10 @@ class MixerSettlerParams(ParamsMixin):
     entrainment_org_in_aq: float = 0.0
     entrainment_aq_in_org: float = 0.0
     # Third-phase formation (#117). If set, an organic loading (mol REE per mol
-    # extractant) above this limit flags third-phase onset in info. None
-    # disables the check (backward compatible).
+    # extractant) above this limit flags third-phase onset in info, and info
+    # also carries the smooth signed margin ``limit - loading`` so the boundary
+    # can be posed as an inequality constraint rather than only read as a
+    # boolean (#193). None disables the check (backward compatible).
     third_phase_loading_limit: float | None = None
 
 
@@ -393,6 +783,8 @@ class REEMixerSettler:
             extractant=params.extractant,
             elements=params.elements,
             concentration=params.extractant_conc,
+            nitrate_conc=params.nitrate_conc,
+            mechanism=params.mechanism,
         )
 
     def __call__(
@@ -413,7 +805,16 @@ class REEMixerSettler:
         Returns:
             aqueous_out: Outlet aqueous stream
             organic_out: Outlet organic stream
-            info: Stage information
+            info: Stage information. With ``third_phase_loading_limit`` set it
+                also reports ``organic_loading``, the boolean
+                ``third_phase_formed`` and the smooth signed
+                ``third_phase_margin`` (#193).
+
+        Raises:
+            ValueError: If the aqueous inlet has no aqueous species, if the
+                organic inlet has no organic carrier (#192), or if
+                ``third_phase_loading_limit`` is set and the organic inlet
+                does not declare a flow of the extractant.
         """
         p = self.params
         pH = pH if pH is not None else p.pH
@@ -423,10 +824,39 @@ class REEMixerSettler:
         aq_flows = get_flows(aqueous_in)
         org_flows = get_flows(organic_in)
 
-        F_aq = aq_flows.get("H2O", 1.0)
-        F_extractant = org_flows.get(p.extractant, 0.0)
-        F_diluent = org_flows.get(p.diluent, 1.0)
-        F_org = F_extractant + F_diluent
+        # Same phase-flow definition as REEExtractor (#192). The aqueous flow
+        # is the whole aqueous phase, not just H2O, which for a concentrated
+        # leach liquor is a large difference and used to make the two units
+        # disagree on identical inputs.
+        F_aq, _ = _phase_flows(
+            aq_flows, p.extractant, p.diluent,
+            require=("aqueous",), stream_name="REEMixerSettler aqueous inlet",
+        )
+        _, F_org = _phase_flows(
+            org_flows, p.extractant, p.diluent,
+            require=("organic",), stream_name="REEMixerSettler organic inlet",
+        )
+        # Relative, unit-invariant floor rather than an absolute 1e-10 (#189);
+        # see _PHASE_FLOW_FLOOR_REL.
+        F_aq = jnp.maximum(F_aq, _PHASE_FLOW_FLOOR_REL * (F_aq + F_org))
+
+        # The third-phase check reports an organic loading, mol REE per mol
+        # extractant, so it needs the extractant's molar flow. Dividing by a
+        # missing flow floored at 1e-30 reported loadings of order 1e29 and
+        # called it a converged answer, which is worse than the silent default
+        # #192 objected to. REEExtractor already raises for the same condition;
+        # this is the same contract. Python-level key check, so it is safe
+        # under jit and grad.
+        if p.third_phase_loading_limit is not None and p.extractant not in org_flows:
+            raise ValueError(
+                f"REEMixerSettler organic inlet does not declare a flow of the "
+                f"extractant '{p.extractant}', but third_phase_loading_limit "
+                f"is set and the loading it is compared against is "
+                f"(mol REE in organic) / (mol extractant). Species present: "
+                f"{sorted(org_flows)}. Add the extractant to the organic "
+                f"stream, or set third_phase_loading_limit=None."
+            )
+        F_extractant = jnp.asarray(org_flows.get(p.extractant, 0.0))
 
         D_values = self._distribution.get_D_all(pH, T)
 
@@ -501,10 +931,25 @@ class REEMixerSettler:
         # Third-phase formation check (#117): organic loading vs the limit.
         if p.third_phase_loading_limit is not None:
             total_org_ree = sum(jnp.asarray(org_out_flows.get(e, 0.0)) for e in p.elements)
-            F_extractant = org_flows.get(p.extractant, 1.0)
-            loading = total_org_ree / jnp.maximum(jnp.asarray(F_extractant), 1e-30)
+            # The key check above guarantees the extractant is declared; a
+            # declared-but-zero flow can still arrive as a traced value, so the
+            # denominator keeps a floor -- relative to the organic carrier flow
+            # of the same stream, so it carries no hidden unit (#189).
+            loading = total_org_ree / jnp.maximum(
+                F_extractant, _PHASE_FLOW_FLOOR_REL * F_org
+            )
             info["organic_loading"] = loading
             info["third_phase_formed"] = loading > p.third_phase_loading_limit
+            # Signed margin so the limit can be used as a smooth inequality
+            # constraint in an optimization, not only read as a diagnostic
+            # boolean (#193). Positive is feasible; negative means a third
+            # phase has formed, and the magnitude says by how much. The
+            # boolean has zero gradient, so an optimizer would otherwise walk
+            # straight through the boundary because crossing it is profitable
+            # in the model.
+            info["third_phase_margin"] = (
+                jnp.asarray(p.third_phase_loading_limit) - loading
+            )
 
         return aqueous_out, organic_out, info
 

--- a/src/difflow_ree/units/scrubbing.py
+++ b/src/difflow_ree/units/scrubbing.py
@@ -37,6 +37,12 @@ class ScrubberParams(ParamsMixin):
         pH: Scrub solution pH (lower pH strips more)
         extractant_conc: Extractant concentration (M)
         scrub_type: Type of scrubbing (acid, REE, water)
+        nitrate_conc: Aqueous nitrate concentration (M), required for solvating
+            extractants such as TBP whose D is nitrate- rather than pH-driven
+            (#195)
+        mechanism: Explicit extraction-mechanism override passed to
+            REEDistribution ("cation_exchange" / "solvating"). None takes the
+            mechanism from the extractant record (#195).
     """
     n_stages: int | float | Array
     extractant: str
@@ -46,6 +52,8 @@ class ScrubberParams(ParamsMixin):
     pH: float | Array = 2.0  # Lower pH than extraction to strip impurities
     extractant_conc: float = 0.5
     scrub_type: Literal["acid", "ree", "water"] = "acid"
+    nitrate_conc: float | None = None  # see #195
+    mechanism: str | None = None  # see #195
 
 
 class REEScrubber:
@@ -98,6 +106,8 @@ class REEScrubber:
             extractant=params.extractant,
             elements=params.elements,
             concentration=params.extractant_conc,
+            nitrate_conc=params.nitrate_conc,
+            mechanism=params.mechanism,
         )
 
     def __call__(
@@ -233,10 +243,17 @@ def optimal_scrub_pH(
     min_target_retention: float = 0.95,
     pH_range: tuple[float, float] = (1.0, 4.0),
     n_points: int = 50,
+    nitrate_conc: float | None = None,
+    mechanism: str | None = None,
 ) -> tuple[float, float, float]:
     """Find optimal scrub pH for separation.
 
     Finds pH that maximizes impurity removal while retaining target.
+
+    Note:
+        Only meaningful for a cation-exchange extractant. A solvating
+        extractant's D is nitrate- rather than pH-driven (#195), so the scan is
+        flat in pH and the returned pH carries no information.
 
     Args:
         extractant: Extractant name
@@ -245,6 +262,9 @@ def optimal_scrub_pH(
         min_target_retention: Minimum fraction of target to retain
         pH_range: pH range to search
         n_points: Number of evaluation points
+        nitrate_conc: Aqueous nitrate concentration (M), required for solvating
+            extractants (#195)
+        mechanism: Explicit mechanism override; see REEDistribution (#195)
 
     Returns:
         Tuple of (optimal_pH, target_D, impurity_D)
@@ -252,6 +272,8 @@ def optimal_scrub_pH(
     dist = REEDistribution(
         extractant=extractant,
         elements=(target_element, impurity_element),
+        nitrate_conc=nitrate_conc,
+        mechanism=mechanism,
     )
 
     best_pH = pH_range[0]

--- a/src/difflow_ree/units/stripping.py
+++ b/src/difflow_ree/units/stripping.py
@@ -35,6 +35,12 @@ class StripperParams(ParamsMixin):
         extractant_conc: Extractant concentration (M)
         acid_type: Type of strip acid
         acid_conc: Acid concentration (M)
+        nitrate_conc: Aqueous nitrate concentration (M), required for solvating
+            extractants such as TBP whose D is nitrate- rather than pH-driven
+            (#195). For an HNO3 strip this is the nitrate the acid supplies.
+        mechanism: Explicit extraction-mechanism override passed to
+            REEDistribution ("cation_exchange" / "solvating"). None takes the
+            mechanism from the extractant record (#195).
     """
     n_stages: int | float | Array
     extractant: str
@@ -44,6 +50,8 @@ class StripperParams(ParamsMixin):
     extractant_conc: float = 0.5
     acid_type: Literal["HCl", "H2SO4", "HNO3"] = "HCl"
     acid_conc: float = 4.0  # M
+    nitrate_conc: float | None = None  # see #195
+    mechanism: str | None = None  # see #195
 
 
 class REEStripper:
@@ -103,6 +111,8 @@ class REEStripper:
             extractant=params.extractant,
             elements=params.elements,
             concentration=params.extractant_conc,
+            nitrate_conc=params.nitrate_conc,
+            mechanism=params.mechanism,
         )
 
     def __call__(

--- a/tests/ree/test_custom_data.py
+++ b/tests/ree/test_custom_data.py
@@ -245,6 +245,24 @@ class TestAddElementToExtractant:
         with pytest.raises(KeyError, match="not found"):
             ext_db.remove_element_from_extractant("PC88A", "Ho")
 
+    def test_adding_a_ph_element_to_tbp_raises(self, ext_db):
+        """TBP has NO ph_coefficients block -- it was deleted as
+        mechanistically unsupported (neutral extractant, pKa None, zero protons
+        released). Adding a pH coefficient here would recreate exactly that
+        model, so it must raise rather than lazily create the block."""
+        assert ext_db.get("TBP").ph_coefficients is None
+        with pytest.raises(ValueError, match="no 'ph_coefficients' block"):
+            ext_db.add_element_to_extractant(
+                "TBP", "Ho",
+                ph_coefficients={"a": -6.42, "b": 2.86, "c": 0.01},
+                temperature_coefficient=2300,
+            )
+
+    def test_removing_a_ph_element_from_tbp_raises_keyerror(self, ext_db):
+        """The None block must not leak a TypeError out of `in`."""
+        with pytest.raises(KeyError, match="not found"):
+            ext_db.remove_element_from_extractant("TBP", "Nd")
+
 
 # =============================================================================
 # Tests: SeparationFactorDatabase.add_pair / add_separation_factors

--- a/tests/ree/test_ree_loading_capacity.py
+++ b/tests/ree/test_ree_loading_capacity.py
@@ -1,0 +1,1356 @@
+"""Loading, capacity and phase-flow tests for the REE extraction units.
+
+One class per filed issue:
+
+- #189: the loading correction must be a dimensionless fraction, so results
+  cannot depend on the unit molar flows are expressed in.
+- #190: free-extractant depletion is applied exactly once. That one place is
+  the correlation's own ``n * log10([HA]/C_ref)`` term, which uses the fixed
+  ``extractant_conc`` parameter -- so the stage D carries no loading term at
+  all, rather than the m-th power a first reading of the issue suggests.
+- #191: capacity and stoichiometry come from one source of truth, and the
+  extractant balance closes.
+- #192: REEExtractor and REEMixerSettler share one definition of the phase
+  flows, and a missing phase raises instead of defaulting.
+- #193: *both* loading limiters are smooth, so gradients are trustworthy at
+  the constraints that bind, and the condition is observable in ``info``.
+
+Every test in this file was checked against a faithful reimplementation of the
+pre-fix arithmetic (``git show HEAD:src/difflow_ree/units/extraction.py`` plus
+the pre-#191 ``LoadingIsotherm``) to confirm it actually fails against the
+behaviour it claims to have fixed. Where a test cannot discriminate -- because
+the property it asserts is an identity, or because the issue's own prediction
+about the bug was wrong -- its docstring says so rather than implying a proof
+it does not deliver.
+"""
+
+from pathlib import Path
+
+import jax
+import numpy as np
+import pytest
+import yaml
+from jax.test_util import check_grads
+
+import difflow_ree
+from difflow.streams import make_stream, get_flows
+from difflow_ree.database import get_extractant, list_extractants
+from difflow_ree.equilibrium.distribution import REEDistribution
+from difflow_ree.equilibrium.loading import (
+    EXTRACTANT_CAPACITIES,
+    LoadingIsotherm,
+    get_loading_isotherm,
+    loading_correction,
+)
+from difflow_ree.units.extraction import (
+    MixerSettlerParams,
+    REEExtractor,
+    REEExtractorParams,
+    REEMixerSettler,
+    _phase_flows,
+    _smooth_free_fraction,
+    _soft_saturation,
+)
+
+
+def _extract_totals(extractor, feed_flows, solvent_flows, elements):
+    """Run an extractor on plain dicts and return (raffinate, extract) dicts."""
+    feed = make_stream(feed_flows, T=298.15, P=101325.0)
+    solvent = make_stream(solvent_flows, T=298.15, P=101325.0)
+    raffinate, extract, info = extractor(feed, solvent)
+    return get_flows(raffinate), get_flows(extract), info
+
+
+# =============================================================================
+# #189 -- the loading correction is dimensionless
+# =============================================================================
+
+class TestIssue189_DimensionlessLoading:
+    """#189: the loading correction must be a genuine dimensionless fraction.
+
+    A warning about what does *not* test this, because the first version of
+    this class got it wrong. #189 predicted that the pre-fix
+    ``avg_loading = F_in * 0.5 / F_org`` would make results depend on the unit
+    the flows were written in. That prediction was simply false: it is a
+    *ratio* of molar flows, so multiplying every flow by one constant leaves it
+    -- and every recovery -- byte-identical. A uniform-rescale test therefore
+    passes against the bug it claims to catch, and the two that used to live
+    here proved nothing. Reimplementing the pre-fix path
+    (``git show HEAD:src/difflow_ree/units/extraction.py``) confirms this.
+
+    What the pre-fix expression actually was is a quantity with the units of
+    L/mol -- ``(mol/s) / (mol/s) / (mol/L)`` once ``loading_fraction`` divided
+    by ``max_ree_conc`` -- assembled from the wrong phases: it read the
+    *aqueous feed* flow of the element and the *whole organic* flow, diluent
+    included. So the discriminating tests are the ones that hold the loading
+    physically fixed and move a quantity a true loading fraction cannot depend
+    on:
+
+    * how much inert diluent the solvent carries (the extractant is equally
+      loaded either way), and
+    * how much REE is in the aqueous feed (loading is a property of the
+      organic phase; a clean solvent is clean whatever it is about to meet).
+
+    Both are checked below, and both fail against the pre-fix path: the
+    diluent sweep moves the pre-fix free-extractant multiplier over
+    0.518 -> 0.988 (spread 0.47) where the fixed path holds it to 1.1e-16, and
+    the feed sweep moves it 0.9998 -> 0.4176 where the fixed path holds it at
+    exactly 1.0.
+    """
+
+    @staticmethod
+    def _free_fraction_multiplier(info, elements, F_aq, F_org, pH=3.0):
+        """Back out E / (D * F_org / F_aq): the entering-solvent free fraction.
+
+        Uses the correlation D rather than the reported stage D, so it is the
+        multiplier the *stage* applied however the model chose to apply it --
+        pre-fix that factor sat inside D, post-fix it sits in E.
+        """
+        D_corr = float(
+            REEDistribution(
+                extractant="D2EHPA", elements=elements, concentration=0.5
+            ).get_D(elements[0], pH=pH)
+        )
+        E = float(info["profiles"][elements[0]]["E"])
+        return E * F_aq / (D_corr * F_org)
+
+    def test_loading_does_not_depend_on_the_diluent_flow(self):
+        """Diluting the solvent with inert does not change how loaded it is.
+
+        theta = m * F_REE(organic) / F_extractant involves no diluent. The
+        pre-fix ``initial_loading / capacity = (F_solv / F_org) / max_ree_conc``
+        divided by the *whole* organic flow, so adding inert kerosene made the
+        model think the solvent had become less loaded.
+        """
+        elements = ("Nd",)
+        params = REEExtractorParams(
+            n_stages=4, extractant="D2EHPA", elements=elements, pH=3.0,
+            extractant_conc=0.5,
+        )
+        extractor = REEExtractor(params)
+
+        multipliers = []
+        thetas = []
+        for diluent_flow in (1.0, 5.0, 25.0, 100.0):
+            feed_flows = {"H2O": 10.0, "Nd": 0.1}
+            solvent_flows = {
+                "D2EHPA": 1.0, "kerosene": diluent_flow, "Nd": 0.05,
+            }
+            _, _, info = _extract_totals(
+                extractor, feed_flows, solvent_flows, elements
+            )
+            multipliers.append(
+                self._free_fraction_multiplier(
+                    info, elements,
+                    F_aq=sum(feed_flows.values()),
+                    F_org=1.0 + diluent_flow,
+                )
+            )
+            thetas.append(float(info["theta_solvent"]))
+
+        # theta is m * F_REE / F_extractant = 6 * 0.05 / 1.0, diluent-free
+        for theta in thetas:
+            assert theta == pytest.approx(0.3, rel=1e-12)
+        for mult in multipliers:
+            assert mult == pytest.approx(multipliers[0], rel=1e-12), (
+                f"the loading correction moved with the diluent flow: "
+                f"{multipliers}"
+            )
+
+    def test_loading_does_not_depend_on_the_aqueous_feed(self):
+        """A clean solvent is unloaded whatever the feed carries.
+
+        The pre-fix ``avg_loading = F_in * 0.5 / F_org`` read the aqueous feed
+        flow of the element, so a clean solvent was reported as progressively
+        more loaded the richer the feed got -- a category error, and the
+        substance of #189.
+        """
+        elements = ("Nd",)
+        params = REEExtractorParams(
+            n_stages=4, extractant="D2EHPA", elements=elements, pH=3.0,
+            extractant_conc=0.5,
+        )
+        extractor = REEExtractor(params)
+
+        for feed_nd in (1e-4, 1e-2, 0.1, 0.5):
+            feed_flows = {"H2O": 10.0, "Nd": feed_nd}
+            _, _, info = _extract_totals(
+                extractor, feed_flows, {"D2EHPA": 1.0, "kerosene": 5.0},
+                elements,
+            )
+            assert float(info["theta_solvent"]) == 0.0
+            mult = self._free_fraction_multiplier(
+                info, elements,
+                F_aq=sum(feed_flows.values()), F_org=6.0,
+            )
+            assert mult == pytest.approx(1.0, rel=1e-12), (
+                f"a clean solvent picked up a loading correction "
+                f"{mult} from a feed of {feed_nd}"
+            )
+
+    def test_theta_solvent_is_m_times_the_flow_ratio(self):
+        """theta_solvent is exactly m * F_REE(solvent) / F_extractant."""
+        elements = ("Nd", "Dy")
+        params = REEExtractorParams(
+            n_stages=4, extractant="D2EHPA", elements=elements, pH=3.0,
+            extractant_conc=0.5,
+        )
+        extractor = REEExtractor(params)
+        m = extractor._isotherm.m
+        _, _, info = _extract_totals(
+            extractor,
+            {"H2O": 10.0, "Nd": 0.1, "Dy": 0.1},
+            {"D2EHPA": 2.0, "kerosene": 5.0, "Nd": 0.05, "Dy": 0.02},
+            elements,
+        )
+        assert float(info["theta_solvent"]) == pytest.approx(
+            m * (0.05 + 0.02) / 2.0, rel=1e-14
+        )
+
+    @pytest.mark.parametrize(
+        "unit_scale", [1e12, 1e6, 1.0, 1e-6, 1e-12, 1e-30, 1e-150]
+    )
+    def test_recovery_invariant_over_the_whole_float64_range(self, unit_scale):
+        """A uniform rescale of every flow must not move any recovery.
+
+        Honest scope: this does *not* discriminate against #189's original
+        bug -- ``F_in * 0.5 / F_org`` was already invariant to a uniform
+        rescale, so the issue's own prediction was wrong (see the class
+        docstring). What it does discriminate against is the absolute
+        ``1e-10`` floor that ``F_aq = jnp.maximum(F_aq, 1e-10)`` used to put on
+        the aqueous flow, which is a hidden unit and broke this invariance
+        below about 1e-11: the case below returned recovery 0.32564 at scale 1
+        and 0.03297 at scale 1e-12. The floor is now relative to the streams'
+        own total flow, so the supported range is the whole float64 range.
+        """
+        elements = ("La", "Nd", "Dy")
+        params = REEExtractorParams(
+            n_stages=4,
+            extractant="D2EHPA",
+            elements=elements,
+            pH=2.0,
+            include_loading=True,
+            extractant_conc=0.5,
+        )
+        extractor = REEExtractor(params)
+        base_feed = {"H2O": 10.0, "La": 0.20, "Nd": 0.15, "Dy": 0.05}
+        base_solvent = {"D2EHPA": 1.0, "kerosene": 5.0}
+
+        def recoveries(scale):
+            feed_flows = {k: v * scale for k, v in base_feed.items()}
+            solvent_flows = {k: v * scale for k, v in base_solvent.items()}
+            _, ext_flows, _ = _extract_totals(
+                extractor, feed_flows, solvent_flows, elements
+            )
+            return {e: float(ext_flows[e]) / feed_flows[e] for e in elements}
+
+        reference = recoveries(1.0)
+        scaled = recoveries(unit_scale)
+        for elem in reference:
+            assert scaled[elem] == pytest.approx(reference[elem], rel=1e-12), (
+                f"{elem} recovery depends on the flow unit at scale "
+                f"{unit_scale}: {scaled[elem]} vs {reference[elem]}"
+            )
+
+    @pytest.mark.parametrize("unit_scale", [1e12, 1.0, 1e-12, 1e-150])
+    def test_include_loading_false_is_also_unit_invariant(self, unit_scale):
+        """The no-isotherm path had its own absolute floor; it is gone too.
+
+        ``loading_ratio = F_solvent / max(F_in + F_solvent, 1e-10)`` is not the
+        ratio it claims to be once both flows fall below 1e-10.
+        """
+        elements = ("Nd", "Dy")
+        params = REEExtractorParams(
+            n_stages=4, extractant="D2EHPA", elements=elements, pH=2.0,
+            include_loading=False, extractant_conc=0.5,
+        )
+        extractor = REEExtractor(params)
+        base_feed = {"H2O": 10.0, "Nd": 0.15, "Dy": 0.05}
+        base_solvent = {"D2EHPA": 1.0, "kerosene": 5.0, "Nd": 0.02}
+
+        def recoveries(scale):
+            feed_flows = {k: v * scale for k, v in base_feed.items()}
+            solvent_flows = {k: v * scale for k, v in base_solvent.items()}
+            _, ext_flows, _ = _extract_totals(
+                extractor, feed_flows, solvent_flows, elements
+            )
+            return {e: float(ext_flows[e]) / feed_flows[e] for e in elements}
+
+        reference = recoveries(1.0)
+        scaled = recoveries(unit_scale)
+        for elem in reference:
+            assert scaled[elem] == pytest.approx(reference[elem], rel=1e-12), (
+                f"{elem} at scale {unit_scale}: {scaled[elem]} vs "
+                f"{reference[elem]}"
+            )
+
+    def test_recovery_invariant_at_capacity(self):
+        """Invariance must also hold where the capacity limiter is active."""
+        # Feed far above capacity so the limiter dominates the answer.
+        elements = ("Nd", "Dy")
+
+        def recoveries(unit_scale):
+            params = REEExtractorParams(
+                n_stages=10,
+                extractant="D2EHPA",
+                elements=elements,
+                pH=3.0,
+                extractant_conc=0.5,
+            )
+            extractor = REEExtractor(params)
+            feed_flows = {
+                k: v * unit_scale
+                for k, v in {"H2O": 10.0, "Nd": 5.0, "Dy": 5.0}.items()
+            }
+            solvent_flows = {
+                k: v * unit_scale
+                for k, v in {"D2EHPA": 1.0, "kerosene": 5.0}.items()
+            }
+            _, ext, info = _extract_totals(
+                extractor, feed_flows, solvent_flows, elements
+            )
+            return (
+                {e: float(ext[e]) / feed_flows[e] for e in elements},
+                float(info["capacity_scale"]),
+            )
+
+        rec_mol, scale_mol = recoveries(1.0)
+        rec_tiny, scale_tiny = recoveries(1e-20)
+
+        assert scale_mol < 0.5, "limiter should be active in this test"
+        assert scale_mol == pytest.approx(scale_tiny, rel=1e-12)
+        for elem in rec_mol:
+            assert rec_mol[elem] == pytest.approx(rec_tiny[elem], rel=1e-12)
+
+    def test_apparent_D_takes_a_fraction(self):
+        """apparent_D's argument is theta, and theta = 1 means saturated."""
+        iso = get_loading_isotherm("D2EHPA", 0.5)
+        D_inf = 10.0
+
+        assert float(iso.apparent_D(D_inf, 0.0)) == pytest.approx(D_inf)
+        # Fully loaded: only the 0.01 floor on the free fraction remains
+        assert float(iso.apparent_D(D_inf, 1.0)) == pytest.approx(
+            D_inf * 0.01 ** iso.m
+        )
+        # Half loaded: exactly (1/2)^m
+        assert float(iso.apparent_D(D_inf, 0.5)) == pytest.approx(
+            D_inf * 0.5 ** iso.m
+        )
+
+
+# =============================================================================
+# #191 -- one source of truth for stoichiometry and capacity
+# =============================================================================
+
+class TestIssue191_Stoichiometry:
+    """#191: capacity is 1/m with m read from the extraction mechanism."""
+
+    def test_stoichiometry_matches_the_yaml_declaration(self):
+        """m comes from the YAML mechanism, not from a literal in the code.
+
+        ``max_loading * monomers_per_ree == 1`` is *not* worth asserting:
+        ``max_loading`` is defined as ``1 / monomers_per_ree``, so it holds for
+        any value of m and would have passed against the 0.33-vs-3-dimers
+        discrepancy #191 was filed about. The independent statement is that m
+        equals what ``data/extractants.yaml`` declares -- ``extractant_molecules``
+        times 2 on a dimer basis -- which is the source the issue says should
+        be read and which the pre-#191 code ignored entirely.
+        """
+        yaml_path = (
+            Path(difflow_ree.__file__).parent / "data" / "extractants.yaml"
+        )
+        with open(yaml_path) as fh:
+            records = yaml.safe_load(fh)["extractants"]
+
+        checked = 0
+        for name in list_extractants():
+            if name not in records:
+                continue  # runtime-registered extractant, not from the YAML
+            stoich = records[name]["stoichiometry"]
+            per_species = 2.0 if stoich.get("basis") == "dimer" else 1.0
+            expected = stoich["extractant_molecules"] * per_species
+            ext = get_extractant(name)
+            assert ext.monomers_per_ree == pytest.approx(expected, rel=1e-15), (
+                f"{name}: database says {ext.monomers_per_ree} monomers per "
+                f"REE, the YAML declares {stoich['extractant_molecules']} "
+                f"{stoich.get('basis', 'monomer')}(s) = {expected}"
+            )
+            # 0.33 was the pre-#191 literal for every acidic extractant; the
+            # YAML says 3 dimers, i.e. 1/6.
+            assert ext.max_loading == pytest.approx(1.0 / expected, rel=1e-15)
+            checked += 1
+
+        assert checked >= 4, "expected at least the four YAML extractants"
+
+    def test_isotherm_exponent_is_monomers_per_ree(self):
+        """The isotherm exponent equals the database stoichiometry."""
+        for name in list_extractants():
+            ext = get_extractant(name)
+            iso = get_loading_isotherm(name, 0.5)
+            assert iso.m == ext.monomers_per_ree, (
+                f"{name}: isotherm exponent {iso.m} != "
+                f"monomers_per_ree {ext.monomers_per_ree}"
+            )
+            assert iso.max_loading == pytest.approx(ext.max_loading, rel=1e-15)
+
+    def test_dimer_extractants_bind_six_monomers(self):
+        """The acidic extractants are declared as 3 dimers = 6 monomers."""
+        for name in ("D2EHPA", "PC88A", "Cyanex272"):
+            assert get_extractant(name).monomers_per_ree == 6.0
+            assert get_loading_isotherm(name, 0.5).max_loading == pytest.approx(
+                1.0 / 6.0
+            )
+        # TBP is a solvating extractant declared on a monomer basis
+        assert get_extractant("TBP").monomers_per_ree == 3.0
+
+    def test_isotherm_capacity_follows_m(self):
+        """LoadingIsotherm cannot hold a capacity that disagrees with m."""
+        iso = LoadingIsotherm(m=6.0, extractant_conc=0.5)
+        assert iso.max_loading == pytest.approx(1.0 / 6.0)
+        assert iso.max_ree_conc == pytest.approx(0.5 / 6.0)
+
+    def test_total_extractant_conservation(self):
+        """Bound extractant never exceeds the extractant fed.
+
+        Scope, stated plainly because #191 asked for a conservation test
+        believing it would have caught the stoichiometry discrepancy, and it
+        cannot. Without an independent free-extractant state (#196, not
+        implemented) there is nothing to conserve *against*: defining
+        ``free := F * (1 - theta)`` with ``theta := m * X / F`` makes
+        ``free + m * X == F`` the identity ``F - m*X + m*X == F``, true of any
+        model output whatsoever. That identity is therefore only asserted here
+        as a cheap check that ``info["theta_total"]`` really is the
+        model's own loading fraction on the flow basis the test assumes.
+
+        The load-bearing assertion is the *inequality* ``free > 0``: the model
+        must never bind more extractant than was fed. That one does
+        discriminate. The pre-fix capacity was ``max_ree_conc * F_org``, a
+        concentration times the whole organic flow, which for the case below
+        is 0.165 * 6 = 0.99 mol/s of REE -- around 3 mol/s of extractant bound
+        out of 1.0 mol/s fed. Reimplementing the pre-fix path gives
+        ``free = -2.0000`` at ``feed_ree = 1.0``, i.e. a hard failure here.
+
+        A second independent check: ``theta_total`` is recomputed from the
+        returned *streams*, not read from ``info``, so the reported loading
+        cannot drift from the flows the unit actually produced.
+        """
+        elements = ("La", "Nd", "Dy")
+        F_extractant = 1.0
+        params = REEExtractorParams(
+            n_stages=8,
+            extractant="D2EHPA",
+            elements=elements,
+            pH=3.0,
+            extractant_conc=0.5,
+        )
+        extractor = REEExtractor(params)
+        m = extractor._isotherm.m
+
+        # Sweep from dilute to well past saturation
+        for feed_ree in (1e-4, 1e-2, 0.05, 0.2, 1.0, 5.0):
+            feed_flows = {"H2O": 10.0}
+            feed_flows.update({e: feed_ree for e in elements})
+            solvent_flows = {"D2EHPA": F_extractant, "kerosene": 5.0}
+            _, ext_flows, info = _extract_totals(
+                extractor, feed_flows, solvent_flows, elements
+            )
+
+            bound_ree = sum(float(ext_flows[e]) for e in elements)
+            bound_extractant = m * bound_ree
+
+            # Independent of info: theta from the returned streams alone.
+            theta_from_streams = bound_extractant / F_extractant
+            assert theta_from_streams == pytest.approx(
+                float(info["theta_total"]), rel=1e-12
+            ), (
+                f"info['theta_total'] {float(info['theta_total'])} disagrees "
+                f"with the outlet streams {theta_from_streams} at feed "
+                f"{feed_ree}"
+            )
+
+            # THE discriminating assertion: the model must never bind more
+            # extractant than was fed. The pre-fix capacity gives -2.0 here.
+            free_extractant = F_extractant - bound_extractant
+            assert free_extractant > 0.0, (
+                f"negative free extractant at feed {feed_ree}: "
+                f"{bound_extractant} bound of {F_extractant} fed"
+            )
+
+            # Tautology by construction (see the docstring); kept only to pin
+            # the basis theta_total is expressed on.
+            assert free_extractant + bound_extractant == pytest.approx(
+                F_extractant, rel=0, abs=1e-12
+            ), f"extractant balance does not close at feed {feed_ree}"
+
+
+# =============================================================================
+# #192 -- one definition of the phase flows
+# =============================================================================
+
+class TestIssue192_PhaseFlows:
+    """#192: REEExtractor and REEMixerSettler agree on the phase flows."""
+
+    @pytest.mark.parametrize(
+        "feed_flows",
+        [
+            {"H2O": 10.0, "Nd": 0.1, "Dy": 0.05},
+            # Concentrated liquor: H2O is a poor proxy for the aqueous flow
+            {"H2O": 10.0, "Nd": 3.0, "Dy": 2.0, "Fe": 1.5},
+        ],
+    )
+    def test_single_stage_equivalence(self, feed_flows):
+        """N=1 Kremser and one 100%-efficient mixer-settler must agree.
+
+        This is the Kremser identity frac_remaining = 1/(1 + E) with
+        E = D * F_org / F_aq, so it holds only if both units compute F_aq and
+        F_org the same way.
+        """
+        elements = ("Nd", "Dy")
+        solvent_flows = {"D2EHPA": 1.0, "kerosene": 5.0}
+
+        ext_params = REEExtractorParams(
+            n_stages=1,
+            extractant="D2EHPA",
+            elements=elements,
+            pH=2.0,
+            include_loading=False,  # isolate the phase-flow definition
+            extractant_conc=0.5,
+        )
+        stage_params = MixerSettlerParams(
+            extractant="D2EHPA",
+            elements=elements,
+            pH=2.0,
+            extractant_conc=0.5,
+            stage_efficiency=1.0,
+        )
+
+        feed = make_stream(feed_flows, T=298.15, P=101325.0)
+        solvent = make_stream(solvent_flows, T=298.15, P=101325.0)
+
+        _, extract, _ = REEExtractor(ext_params)(feed, solvent)
+        _, organic_out, _ = REEMixerSettler(stage_params)(feed, solvent)
+
+        ext_flows = get_flows(extract)
+        org_flows = get_flows(organic_out)
+
+        for elem in elements:
+            rec_kremser = float(ext_flows[elem]) / feed_flows[elem]
+            rec_stage = float(org_flows[elem]) / feed_flows[elem]
+            assert rec_kremser == pytest.approx(rec_stage, rel=1e-10), (
+                f"{elem}: REEExtractor recovery {rec_kremser} != "
+                f"REEMixerSettler recovery {rec_stage}"
+            )
+
+    def test_aqueous_flow_is_the_whole_aqueous_phase(self):
+        """Everything that is not extractant or diluent is aqueous."""
+        flows = {"H2O": 10.0, "Nd": 3.0, "Fe": 1.5, "D2EHPA": 1.0, "kerosene": 5.0}
+        F_aq, F_org = _phase_flows(flows, "D2EHPA", "kerosene")
+        assert float(F_aq) == pytest.approx(14.5)
+        assert float(F_org) == pytest.approx(6.0)
+
+    def test_missing_organic_phase_raises(self):
+        """A solvent with no extractant and no diluent is an error, not 1.0."""
+        with pytest.raises(ValueError, match="no organic phase"):
+            _phase_flows({"H2O": 1.0, "Nd": 0.1}, "D2EHPA", "kerosene")
+
+    def test_missing_aqueous_phase_raises(self):
+        """An aqueous stream that is entirely organic is an error."""
+        with pytest.raises(ValueError, match="no aqueous phase"):
+            _phase_flows({"D2EHPA": 1.0, "kerosene": 5.0}, "D2EHPA", "kerosene")
+
+    def test_error_names_the_species_present(self):
+        """The message must name the missing phase and what was there."""
+        with pytest.raises(ValueError) as exc:
+            _phase_flows({"Organic": 10.0, "Nd": 0.0}, "D2EHPA", "kerosene")
+        message = str(exc.value)
+        assert "D2EHPA" in message and "kerosene" in message
+        assert "Organic" in message
+
+    def test_extractor_raises_on_solvent_without_carrier(self):
+        """The unit surfaces the error rather than defaulting F_org to 1.0."""
+        params = REEExtractorParams(
+            n_stages=3, extractant="D2EHPA", elements=("Nd",), pH=2.0
+        )
+        feed = make_stream({"H2O": 10.0, "Nd": 0.1}, T=298.15, P=101325.0)
+        solvent = make_stream({"Organic": 10.0, "Nd": 0.0}, T=298.15, P=101325.0)
+        with pytest.raises(ValueError, match="no organic phase"):
+            REEExtractor(params)(feed, solvent)
+
+    def test_mixer_settler_raises_on_solvent_without_carrier(self):
+        """Same contract in REEMixerSettler."""
+        params = MixerSettlerParams(
+            extractant="D2EHPA", elements=("Nd",), pH=2.0
+        )
+        aq = make_stream({"H2O": 10.0, "Nd": 0.1}, T=298.15, P=101325.0)
+        org = make_stream({"Organic": 10.0, "Nd": 0.0}, T=298.15, P=101325.0)
+        with pytest.raises(ValueError, match="no organic phase"):
+            REEMixerSettler(params)(aq, org)
+
+
+# =============================================================================
+# #193 -- the capacity limiter is smooth and observable
+# =============================================================================
+
+def _recovery_vs_solvent(solvent_scale, elements=("Nd", "Dy"), n_stages=6):
+    """Total REE recovery as a function of the solvent flow (traceable)."""
+    params = REEExtractorParams(
+        n_stages=n_stages,
+        extractant="D2EHPA",
+        elements=elements,
+        pH=3.0,
+        extractant_conc=0.5,
+    )
+    extractor = REEExtractor(params)
+    feed = make_stream(
+        {"H2O": 10.0, "Nd": 0.5, "Dy": 0.5}, T=298.15, P=101325.0
+    )
+    solvent = make_stream(
+        {
+            "D2EHPA": 1.0 * solvent_scale,
+            "kerosene": 5.0 * solvent_scale,
+        },
+        T=298.15,
+        P=101325.0,
+    )
+    _, extract, info = extractor(feed, solvent)
+    ext_flows = get_flows(extract)
+    total_extracted = sum(ext_flows[e] for e in elements)
+    return total_extracted / 1.0, info
+
+
+class TestIssue193_SmoothCapacityLimiter:
+    """#193: no kink in the gradient at the binding capacity constraint."""
+
+    @staticmethod
+    def _capacity_gap(scale):
+        """uncapped_extracted - capacity, the quantity the old clamp switched on."""
+        _, info = _recovery_vs_solvent(scale)
+        return float(info["uncapped_extracted"]) - float(info["capacity"])
+
+    def _solvent_scale_at_capacity(self):
+        """Bisect for the solvent flow where extraction just fills capacity."""
+        lo, hi = 1e-3, 1e3
+        assert self._capacity_gap(lo) > 0, "expected capacity-limited at low solvent"
+        assert self._capacity_gap(hi) < 0, "expected capacity-rich at high solvent"
+        for _ in range(200):
+            mid = 0.5 * (lo + hi)
+            if self._capacity_gap(mid) > 0:
+                lo = mid
+            else:
+                hi = mid
+            if hi - lo < 1e-13 * max(1.0, hi):
+                break
+        return 0.5 * (lo + hi)
+
+    def test_gradient_at_the_capacity_constraint(self):
+        """check_grads on recovery w.r.t. solvent flow, at the switch point."""
+        scale_star = self._solvent_scale_at_capacity()
+        _, info = _recovery_vs_solvent(scale_star)
+        assert float(info["uncapped_extracted"]) == pytest.approx(
+            float(info["capacity"]), rel=1e-6
+        ), "bisection did not land on the capacity point"
+
+        def recovery(scale):
+            rec, _ = _recovery_vs_solvent(scale)
+            return rec
+
+        check_grads(recovery, (scale_star,), order=1, modes=["rev"])
+
+    def test_gradient_is_continuous_across_the_constraint(self):
+        """Left and right derivatives must agree at the constraint."""
+        scale_star = self._solvent_scale_at_capacity()
+
+        def recovery(scale):
+            rec, _ = _recovery_vs_solvent(scale)
+            return rec
+
+        d = jax.grad(recovery)
+        eps = 1e-6 * scale_star
+        g_left = float(d(scale_star - eps))
+        g_right = float(d(scale_star + eps))
+        assert g_left == pytest.approx(g_right, rel=1e-4), (
+            f"gradient jumps at the capacity constraint: "
+            f"{g_left} (below) vs {g_right} (above)"
+        )
+
+    def test_capacity_condition_is_reported(self):
+        """A design pinned at the wall must be distinguishable in info."""
+        elements = ("Nd", "Dy")
+        params = REEExtractorParams(
+            n_stages=10,
+            extractant="D2EHPA",
+            elements=elements,
+            pH=3.0,
+            extractant_conc=0.5,
+        )
+        extractor = REEExtractor(params)
+
+        # Comfortably below capacity
+        _, _, info_lo = _extract_totals(
+            extractor,
+            {"H2O": 10.0, "Nd": 1e-3, "Dy": 1e-3},
+            {"D2EHPA": 1.0, "kerosene": 5.0},
+            elements,
+        )
+        # Far beyond capacity
+        _, _, info_hi = _extract_totals(
+            extractor,
+            {"H2O": 10.0, "Nd": 5.0, "Dy": 5.0},
+            {"D2EHPA": 1.0, "kerosene": 5.0},
+            elements,
+        )
+
+        for key in (
+            "theta_total",
+            "capacity",
+            "capacity_scale",
+            "capacity_clamped_fraction",
+            "uncapped_extracted",
+        ):
+            assert key in info_lo, f"info is missing {key}"
+
+        assert float(info_lo["capacity_scale"]) == pytest.approx(1.0, abs=1e-6)
+        assert float(info_lo["capacity_clamped_fraction"]) < 1e-6
+        assert float(info_lo["theta_total"]) < 0.05
+
+        assert float(info_hi["capacity_scale"]) < 0.1
+        assert float(info_hi["capacity_clamped_fraction"]) > 0.9
+        assert float(info_hi["theta_total"]) == pytest.approx(1.0, abs=0.05)
+        # Strictly under saturation: the limiter never binds more extractant
+        # than was fed.
+        assert float(info_hi["theta_total"]) < 1.0
+
+    def test_capacity_is_a_flow_from_the_extractant_only(self):
+        """capacity == F_extractant / m, with no diluent and no concentration."""
+        elements = ("Nd",)
+        params = REEExtractorParams(
+            n_stages=3,
+            extractant="D2EHPA",
+            elements=elements,
+            pH=3.0,
+            extractant_conc=0.5,
+        )
+        extractor = REEExtractor(params)
+        _, _, info = _extract_totals(
+            extractor,
+            {"H2O": 10.0, "Nd": 0.1},
+            {"D2EHPA": 2.0, "kerosene": 30.0},
+            elements,
+        )
+        m = extractor._isotherm.m
+        assert float(info["capacity"]) == pytest.approx(2.0 / m, rel=1e-12)
+
+    def test_solvent_without_extractant_flow_raises(self):
+        """Capacity is F_extractant / m, so the flow must be declared.
+
+        Otherwise the capacity is identically zero and the unit would
+        silently return zero recovery.
+        """
+        params = REEExtractorParams(
+            n_stages=3,
+            extractant="D2EHPA",
+            elements=("Nd",),
+            pH=3.0,
+            include_loading=True,
+        )
+        feed = make_stream({"H2O": 10.0, "Nd": 0.1}, T=298.15, P=101325.0)
+        solvent = make_stream({"kerosene": 5.0}, T=298.15, P=101325.0)
+        with pytest.raises(ValueError, match="does not declare a flow"):
+            REEExtractor(params)(feed, solvent)
+
+        # include_loading=False has no capacity, so it is allowed
+        params_no_loading = REEExtractorParams(
+            n_stages=3,
+            extractant="D2EHPA",
+            elements=("Nd",),
+            pH=3.0,
+            include_loading=False,
+        )
+        _, extract, _ = REEExtractor(params_no_loading)(feed, solvent)
+        assert float(get_flows(extract)["Nd"]) > 0.0
+
+    def test_sharpness_controls_the_transition(self):
+        """Larger capacity_sharpness approaches the hard clamp."""
+        elements = ("Nd", "Dy")
+        scales = {}
+        for k in (2, 4, 16):
+            params = REEExtractorParams(
+                n_stages=10,
+                extractant="D2EHPA",
+                elements=elements,
+                pH=3.0,
+                extractant_conc=0.5,
+                capacity_sharpness=k,
+            )
+            # Half of capacity: the hard clamp would not fire at all
+            _, _, info = _extract_totals(
+                REEExtractor(params),
+                {"H2O": 10.0, "Nd": 0.04, "Dy": 0.04},
+                {"D2EHPA": 1.0, "kerosene": 5.0},
+                elements,
+            )
+            scales[k] = float(info["capacity_scale"])
+            assert float(info["uncapped_extracted"]) < float(info["capacity"])
+
+        assert scales[2] < scales[4] < scales[16] <= 1.0
+        assert scales[16] == pytest.approx(1.0, abs=1e-3)
+
+    def test_third_phase_margin_is_a_signed_constraint(self):
+        """#193: the third-phase limit is usable as an inequality."""
+        elements = ("Nd", "Dy")
+        params = MixerSettlerParams(
+            extractant="D2EHPA",
+            elements=elements,
+            pH=3.0,
+            extractant_conc=0.5,
+            third_phase_loading_limit=0.1,
+        )
+        stage = REEMixerSettler(params)
+        org = make_stream({"D2EHPA": 1.0, "kerosene": 5.0}, T=298.15, P=101325.0)
+
+        # Lightly loaded: feasible, positive margin
+        aq_lo = make_stream(
+            {"H2O": 10.0, "Nd": 0.001, "Dy": 0.001}, T=298.15, P=101325.0
+        )
+        _, _, info_lo = stage(aq_lo, org)
+        assert not bool(info_lo["third_phase_formed"])
+        assert float(info_lo["third_phase_margin"]) > 0.0
+        assert float(info_lo["third_phase_margin"]) == pytest.approx(
+            0.1 - float(info_lo["organic_loading"])
+        )
+
+        # Heavily loaded: infeasible, negative margin
+        aq_hi = make_stream(
+            {"H2O": 10.0, "Nd": 1.0, "Dy": 1.0}, T=298.15, P=101325.0
+        )
+        _, _, info_hi = stage(aq_hi, org)
+        assert bool(info_hi["third_phase_formed"])
+        assert float(info_hi["third_phase_margin"]) < 0.0
+
+    def test_third_phase_margin_is_differentiable(self):
+        """The margin has a usable gradient; the boolean has none."""
+        def margin(nd_flow):
+            params = MixerSettlerParams(
+                extractant="D2EHPA",
+                elements=("Nd",),
+                pH=3.0,
+                extractant_conc=0.5,
+                third_phase_loading_limit=0.1,
+            )
+            stage = REEMixerSettler(params)
+            aq = make_stream({"H2O": 10.0, "Nd": nd_flow}, T=298.15, P=101325.0)
+            org = make_stream(
+                {"D2EHPA": 1.0, "kerosene": 5.0}, T=298.15, P=101325.0
+            )
+            _, _, info = stage(aq, org)
+            return info["third_phase_margin"]
+
+        g = float(jax.grad(margin)(0.05))
+        assert g < 0.0, "more REE must reduce the third-phase margin"
+        check_grads(margin, (0.05,), order=1, modes=["rev"])
+
+
+# =============================================================================
+# #190 -- free-extractant depletion applied exactly once
+# =============================================================================
+
+class TestIssue190_SingleDepletionCorrection:
+    """#190: exactly one free-extractant depletion mechanism, in the correlation.
+
+    The stage D therefore carries *no* loading dependence -- see
+    ``test_D_has_no_free_extractant_falloff_at_all``, which corrects the
+    "D falls off as the m-th power" reading this class was first written with.
+    """
+
+    ELEMENTS = ("Nd",)
+    F_EXTRACTANT = 1.0
+
+    def _sweep(self):
+        """Sweep aqueous REE dilute -> near-saturation at fixed extractant.
+
+        Returns a list of (theta, free_fraction, D_apparent, D_correlation)
+        with theta from an explicit extractant balance computed here in the
+        test rather than read from the model.
+        """
+        params = REEExtractorParams(
+            n_stages=1,
+            extractant="D2EHPA",
+            elements=self.ELEMENTS,
+            pH=3.0,
+            extractant_conc=0.5,
+        )
+        extractor = REEExtractor(params)
+        m = extractor._isotherm.m
+        D_corr = float(
+            REEDistribution(
+                extractant="D2EHPA", elements=self.ELEMENTS, concentration=0.5
+            ).get_D("Nd", pH=3.0)
+        )
+
+        rows = []
+        for feed_nd in np.geomspace(1e-5, 1.0, 24):
+            feed_flows = {"H2O": 10.0, "Nd": float(feed_nd)}
+            solvent_flows = {"D2EHPA": self.F_EXTRACTANT, "kerosene": 5.0}
+            raff, ext, _ = _extract_totals(
+                extractor, feed_flows, solvent_flows, self.ELEMENTS
+            )
+            F_org_ree = float(ext["Nd"])
+            F_aq_ree = float(raff["Nd"])
+
+            # Explicit free-extractant balance, in monomer equivalents:
+            #     [HA]_total = [HA]_free + m * [RE-complex]
+            free = self.F_EXTRACTANT - m * F_org_ree
+            free_fraction = free / self.F_EXTRACTANT
+            theta = 1.0 - free_fraction
+
+            F_aq = sum(feed_flows.values())
+            F_org = self.F_EXTRACTANT + 5.0
+            # Apparent D from the outlet split (a ratio of concentrations,
+            # expressed with the phase flows)
+            D_app = (F_org_ree / F_org) / ((F_aq_ree / F_aq) + 1e-300)
+            rows.append((theta, free_fraction, D_app, D_corr))
+        return m, rows
+
+    def test_dilute_limit_recovers_the_correlation(self):
+        """At zero loading the stage D is the correlation D, uncorrected."""
+        m, rows = self._sweep()
+        theta, free_fraction, D_app, D_corr = rows[0]
+        assert theta < 1e-3, "first sweep point should be effectively dilute"
+        assert D_app == pytest.approx(D_corr, rel=1e-6), (
+            "a second free-extractant correction is being applied on top of "
+            "the correlation's concentration term (#190)"
+        )
+
+    def test_D_has_no_free_extractant_falloff_at_all(self):
+        """After #190 the stage D carries *no* loading dependence whatsoever.
+
+        The previous version of this test claimed "D falls off as the m-th
+        power of free extractant" and asserted an effective exponent
+        ``p <= m + 0.5 = 6.5`` against a measured ``p ~ 0.03``, a bound 200x
+        looser than the value. Both the claim and the bound were wrong.
+
+        What the code does: the only free-extractant term left is
+        ``n * log10(concentration / C_ref)`` inside ``REEDistribution.get_D``,
+        and ``concentration`` there is the fixed ``extractant_conc`` parameter,
+        so **nothing in D varies with stage loading**. The apparent exponent
+        measured from the outlet split is therefore ~0, not m; the small
+        residual comes from the capacity limiter reshaping the split, not from
+        D. That is the intended state: exactly one depletion mechanism, and it
+        lives in the correlation's calibration rather than in a per-stage
+        factor.
+
+        The assertions below are chosen to fail if the doubled correction
+        returns. Reimplementing the pre-fix path measures ``p = 4.32`` and
+        drives ``D_app / D_corr`` down to 0.121; the fixed path measures
+        ``p = 0.03`` and never goes below 0.66.
+        """
+        m, rows = self._sweep()
+        _, _, D0, D_corr = rows[0]
+
+        # 1. D_app must stay of the same order as the correlation over the
+        #    whole sweep. A doubled (1-theta)^m factor drops it by ~8x here.
+        ratios = [D / D_corr for _, _, D, _ in rows]
+        assert min(ratios) > 0.5, (
+            f"the outlet split implies D fell to {min(ratios):.3g} x the "
+            f"correlation value; the doubled correction (#190) reaches 0.121"
+        )
+        assert max(ratios) <= 1.0 + 1e-9
+
+        # 2. The effective exponent in D_app/D_corr ~ free**p, over the region
+        #    where loading bites, must be ~0 and nowhere near m or 2m.
+        pts = [(fr, D) for theta, fr, D, _ in rows if 0.05 < theta < 0.9]
+        assert len(pts) >= 4, "sweep did not cover the loaded region"
+        xs = np.log(np.array([fr for fr, _ in pts]))
+        ys = np.log(np.array([D / D_corr for _, D in pts]))
+        p = float(np.polyfit(xs, ys, 1)[0])
+        assert abs(p) < 1.0, (
+            f"the stage D shows a free-extractant power law of exponent "
+            f"{p:.3f}; after #190 there is no loading term in D at all, and "
+            f"a single (1-theta)^m factor would give p ~ {m}, a doubled one "
+            f"p ~ {2 * m}"
+        )
+
+        # 3. Directly: the model must be far above the single m-th power
+        #    curve, let alone the doubled one.
+        for theta, free_fraction, D_app, _ in rows:
+            if free_fraction < 0.02 or theta < 1e-6:
+                continue  # power law meaningless this close to saturation
+            single = D_corr * free_fraction ** m
+            assert D_app >= single * (1 - 1e-9), (
+                f"D falls off at least as fast as free**{m} at "
+                f"theta={theta:.4f}: {D_app:.6g} < {single:.6g}"
+            )
+
+    def test_apparent_D_matches_the_explicit_balance(self):
+        """LoadingIsotherm.apparent_D is exactly one m-th power."""
+        iso = get_loading_isotherm("D2EHPA", 0.5)
+        m = iso.m
+        F_extractant = 1.0
+        D_inf = 25.0
+
+        # Stay above the 0.01 floor apparent_D puts on the free fraction
+        for bound_ree in (0.0, 0.01, 0.05, 0.1, 0.15):
+            free = F_extractant - m * bound_ree
+            theta = m * bound_ree / F_extractant
+            assert float(iso.apparent_D(D_inf, theta)) == pytest.approx(
+                D_inf * (free / F_extractant) ** m, rel=1e-12
+            )
+
+    def test_stage_D_carries_no_loading_factor(self):
+        """The reported stage D is the correlation D at every loading."""
+        params = REEExtractorParams(
+            n_stages=3,
+            extractant="D2EHPA",
+            elements=("Nd",),
+            pH=3.0,
+            extractant_conc=0.5,
+        )
+        extractor = REEExtractor(params)
+        D_corr = float(
+            REEDistribution(
+                extractant="D2EHPA", elements=("Nd",), concentration=0.5
+            ).get_D("Nd", pH=3.0)
+        )
+        for feed_nd in (1e-5, 1e-2, 0.5, 5.0):
+            _, _, info = _extract_totals(
+                extractor,
+                {"H2O": 10.0, "Nd": feed_nd},
+                {"D2EHPA": 1.0, "kerosene": 5.0},
+                ("Nd",),
+            )
+            assert float(info["profiles"]["Nd"]["D"]) == pytest.approx(
+                D_corr, rel=1e-12
+            ), "the stage path is still applying a second depletion factor"
+
+
+# =============================================================================
+# #193 (round 2) -- the entering-solvent free fraction is smooth too
+# =============================================================================
+
+def _raffinate_vs_loaded_solvent(nd_org, n_stages=5, sharpness=8):
+    """Nd left in the raffinate as a function of the solvent's Nd loading.
+
+    This is the recycled-solvent path: an extract-strip circuit returns a
+    partly loaded solvent to the extractor, so ``theta_solvent`` is a lever a
+    gradient-based optimizer moves. With ``m = 6`` and 1.0 mol/s of D2EHPA the
+    solvent saturates at ``nd_org = 1/6``.
+    """
+    params = REEExtractorParams(
+        n_stages=n_stages,
+        extractant="D2EHPA",
+        elements=("Nd",),
+        pH=3.0,
+        capacity_sharpness=sharpness,
+    )
+    extractor = REEExtractor(params)
+    feed = make_stream({"H2O": 10.0, "Nd": 0.1}, T=298.15, P=101325.0)
+    solvent = make_stream(
+        {"D2EHPA": 1.0, "kerosene": 5.0, "Nd": nd_org}, T=298.15, P=101325.0
+    )
+    raffinate, _, _ = extractor(feed, solvent)
+    return get_flows(raffinate)["Nd"]
+
+
+class TestIssue193_SmoothEnteringSolventLoading:
+    """#193's own complaint, on the loaded-solvent path.
+
+    ``free_fraction_in = jnp.maximum(1.0 - theta_solvent, 0.0)`` was a hard
+    kink with a *dead lever* beyond it -- exactly the pathology #193 was filed
+    about and exactly the dead column ``difflow.planning.health`` warns about.
+    Measured against that code, at ``nd_org = 0.1666`` (theta = 0.9996) the
+    gradient was 0.1959 and at ``nd_org = 0.1667`` (theta = 1.0002) it was
+    identically 0.0, and stayed 0.0 forever after. Because ``theta_solvent`` is
+    computed against ``F_extractant / m`` rather than ``max_ree_conc * F_org``,
+    the wall sat about 6x lower in solvent loading than the code it replaced,
+    so it bit earlier.
+    """
+
+    SATURATION = 1.0 / 6.0  # nd_org where theta_solvent == 1
+
+    def test_gradient_at_the_saturation_point(self):
+        """check_grads on the raffinate w.r.t. solvent loading, at theta = 1."""
+        check_grads(
+            _raffinate_vs_loaded_solvent,
+            (self.SATURATION,),
+            order=1,
+            modes=["rev"],
+        )
+
+    def test_gradient_is_continuous_across_saturation(self):
+        """No jump in the derivative at theta_solvent == 1."""
+        d = jax.grad(_raffinate_vs_loaded_solvent)
+        eps = 1e-7
+        g_left = float(d(self.SATURATION - eps))
+        g_right = float(d(self.SATURATION + eps))
+        assert g_left == pytest.approx(g_right, rel=1e-4), (
+            f"gradient jumps at solvent saturation: {g_left} vs {g_right}"
+        )
+
+    @pytest.mark.parametrize("nd_org", [0.1667, 0.2, 0.5, 1.0, 2.0])
+    def test_gradient_is_non_zero_past_saturation(self, nd_org):
+        """The lever must stay alive beyond saturation, not go dead.
+
+        The clipped version returned exactly 0.0 at every one of these points.
+        """
+        g = float(jax.grad(_raffinate_vs_loaded_solvent)(nd_org))
+        assert g != 0.0, (
+            f"dead lever at nd_org={nd_org} (theta={6 * nd_org:.2f}): the "
+            f"gradient is identically zero, so no optimizer can move it"
+        )
+        assert np.isfinite(g)
+        # More REE already in the solvent must leave more REE behind.
+        assert g > 0.0
+
+    def test_free_fraction_is_positive_and_monotone(self):
+        """The smooth free fraction never reaches zero and never increases."""
+        thetas = np.concatenate([
+            np.linspace(0.0, 2.0, 41), np.geomspace(2.0, 1e3, 20),
+        ])
+        values = [float(_smooth_free_fraction(t, 8.0)) for t in thetas]
+        assert values[0] == pytest.approx(1.0)
+        for t, v in zip(thetas, values):
+            assert v > 0.0, f"free fraction hit zero at theta={t}"
+        for a, b in zip(values, values[1:]):
+            assert b <= a + 1e-15, "free fraction is not monotone decreasing"
+
+    def test_free_fraction_matches_the_hard_clamp_when_far_below_capacity(self):
+        """Well below saturation the smooth form is the hard one to 1e-6."""
+        for theta in (0.0, 0.05, 0.1, 0.2):
+            assert float(_smooth_free_fraction(theta, 8.0)) == pytest.approx(
+                1.0 - theta, abs=1e-6
+            )
+
+    def test_free_fraction_at_saturation_is_the_stated_value(self):
+        """At theta = 1 the free fraction is exactly 1 - 2**(-1/k)."""
+        for k in (2.0, 4.0, 8.0, 16.0):
+            assert float(_smooth_free_fraction(1.0, k)) == pytest.approx(
+                1.0 - 2.0 ** (-1.0 / k), rel=1e-12
+            )
+
+    def test_free_fraction_is_reported(self):
+        """The entering-solvent free fraction is observable in info."""
+        params = REEExtractorParams(
+            n_stages=5, extractant="D2EHPA", elements=("Nd",), pH=3.0
+        )
+        _, _, info = _extract_totals(
+            REEExtractor(params),
+            {"H2O": 10.0, "Nd": 0.1},
+            {"D2EHPA": 1.0, "kerosene": 5.0, "Nd": 0.05},
+            ("Nd",),
+        )
+        assert float(info["theta_solvent"]) == pytest.approx(0.3, rel=1e-12)
+        assert float(info["free_fraction_in"]) == pytest.approx(
+            float(_smooth_free_fraction(0.3, 8.0)), rel=1e-12
+        )
+
+    def test_soft_saturation_degenerate_inputs_are_finite(self):
+        """capacity == 0 and total == capacity == 0 must not produce nan."""
+        assert float(_soft_saturation(1.0, 0.0, 8.0)) == 0.0
+        assert float(_soft_saturation(0.0, 0.0, 8.0)) == 1.0
+        assert float(_soft_saturation(0.0, 1.0, 8.0)) == pytest.approx(1.0)
+        assert float(_soft_saturation(1.0, 1.0, 8.0)) == pytest.approx(
+            2.0 ** (-1.0 / 8.0)
+        )
+        # No overflow even where total**k would be inf
+        assert float(_soft_saturation(1e60, 1.0, 16.0)) == pytest.approx(
+            1e-60, rel=1e-9
+        )
+        for args in ((1.0, 0.0), (0.0, 0.0), (2.0, 1.0)):
+            g = float(jax.grad(lambda t, c=args[1]: _soft_saturation(t, c, 8.0))(
+                args[0]
+            ))
+            assert np.isfinite(g), f"non-finite gradient at {args}"
+
+
+# =============================================================================
+# Zero-flow phases and missing extractant (round 2)
+# =============================================================================
+
+class TestZeroFlowPhases:
+    """A declared-but-empty phase must fail loudly, not be floored.
+
+    ``_phase_flows`` used to check key *presence* only, so
+    ``{"H2O": 0.0, "D2EHPA": 1.0, "kerosene": 5.0}`` passed, ``F_aq`` was
+    floored at a magic ``1e-10`` and the extraction factor came out around
+    3.3e10. That is the same defect class as the ``1.0`` default #192 objected
+    to: a mis-specified stream hidden behind a plausible-looking number.
+    """
+
+    def test_zero_aqueous_flow_raises(self):
+        with pytest.raises(ValueError, match="total flow is 0.0"):
+            _phase_flows(
+                {"H2O": 0.0, "D2EHPA": 1.0, "kerosene": 5.0},
+                "D2EHPA", "kerosene",
+            )
+
+    def test_zero_organic_flow_raises(self):
+        with pytest.raises(ValueError, match="total flow is 0.0"):
+            _phase_flows(
+                {"H2O": 10.0, "Nd": 0.1, "D2EHPA": 0.0, "kerosene": 0.0},
+                "D2EHPA", "kerosene", require=("organic",),
+            )
+
+    def test_extractor_raises_on_an_empty_aqueous_feed(self):
+        params = REEExtractorParams(
+            n_stages=5, extractant="D2EHPA", elements=("Nd",), pH=3.0
+        )
+        feed = make_stream({"H2O": 0.0, "Nd": 0.0}, T=298.15, P=101325.0)
+        solvent = make_stream(
+            {"D2EHPA": 1.0, "kerosene": 5.0}, T=298.15, P=101325.0
+        )
+        with pytest.raises(ValueError, match="total flow is"):
+            REEExtractor(params)(feed, solvent)
+
+    def test_mixer_settler_raises_on_an_empty_aqueous_inlet(self):
+        params = MixerSettlerParams(
+            extractant="D2EHPA", elements=("Nd",), pH=3.0
+        )
+        aq = make_stream({"H2O": 0.0, "Nd": 0.0}, T=298.15, P=101325.0)
+        org = make_stream(
+            {"D2EHPA": 1.0, "kerosene": 5.0}, T=298.15, P=101325.0
+        )
+        with pytest.raises(ValueError, match="total flow is"):
+            REEMixerSettler(params)(aq, org)
+
+    def test_a_tiny_but_real_aqueous_flow_is_accepted(self):
+        """The guard is on zero, not on smallness: 1e-200 mol/s still runs."""
+        F_aq, F_org = _phase_flows(
+            {"H2O": 1e-200, "D2EHPA": 1e-200, "kerosene": 5e-200},
+            "D2EHPA", "kerosene",
+        )
+        assert float(F_aq) == pytest.approx(1e-200)
+        assert float(F_org) == pytest.approx(6e-200)
+
+    def test_mixer_settler_third_phase_needs_the_extractant_flow(self):
+        """#192/#193: loading is mol REE per mol extractant, so say how much.
+
+        Without this, a solvent of pure diluent reported an organic loading of
+        9.85e+28 and no error at all.
+        """
+        params = MixerSettlerParams(
+            extractant="D2EHPA",
+            elements=("Nd",),
+            pH=3.0,
+            third_phase_loading_limit=0.1,
+        )
+        aq = make_stream({"H2O": 10.0, "Nd": 0.5}, T=298.15, P=101325.0)
+        org = make_stream({"kerosene": 5.0}, T=298.15, P=101325.0)
+        with pytest.raises(ValueError, match="does not declare a flow"):
+            REEMixerSettler(params)(aq, org)
+
+    def test_mixer_settler_without_the_limit_still_accepts_pure_diluent(self):
+        """No loading-dependent quantity requested, no extractant required."""
+        params = MixerSettlerParams(
+            extractant="D2EHPA", elements=("Nd",), pH=3.0
+        )
+        aq = make_stream({"H2O": 10.0, "Nd": 0.5}, T=298.15, P=101325.0)
+        org = make_stream({"kerosene": 5.0}, T=298.15, P=101325.0)
+        aq_out, org_out, info = REEMixerSettler(params)(aq, org)
+        assert "organic_loading" not in info
+        total = float(get_flows(aq_out)["Nd"]) + float(get_flows(org_out)["Nd"])
+        assert total == pytest.approx(0.5, rel=1e-12)
+
+    def test_reported_loading_is_finite_and_physical(self):
+        """With the extractant declared, the loading is order 1, not 1e29."""
+        params = MixerSettlerParams(
+            extractant="D2EHPA",
+            elements=("Nd",),
+            pH=3.0,
+            third_phase_loading_limit=0.1,
+        )
+        aq = make_stream({"H2O": 10.0, "Nd": 0.5}, T=298.15, P=101325.0)
+        org = make_stream(
+            {"D2EHPA": 1.0, "kerosene": 5.0}, T=298.15, P=101325.0
+        )
+        _, org_out, info = REEMixerSettler(params)(aq, org)
+        loading = float(info["organic_loading"])
+        assert 0.0 < loading < 1.0, f"unphysical organic loading {loading}"
+        assert loading == pytest.approx(
+            float(get_flows(org_out)["Nd"]) / 1.0, rel=1e-12
+        )
+
+
+# =============================================================================
+# #191 / #189 -- public API that changed shape (D10)
+# =============================================================================
+
+class TestChangedPublicAPI:
+    """The #191 fix broke exported API. Pin the new contract."""
+
+    def test_max_loading_is_no_longer_a_constructor_field(self):
+        """LoadingIsotherm(max_loading=0.33) now raises; m=3.0 replaces it."""
+        with pytest.raises(TypeError):
+            LoadingIsotherm(max_loading=0.33)
+        assert LoadingIsotherm(m=3.0).max_loading == pytest.approx(1.0 / 3.0)
+        with pytest.raises(AttributeError):
+            LoadingIsotherm(m=3.0).max_loading = 0.5
+
+    def test_extractant_capacities_no_longer_carries_capacity(self):
+        """The public dict holds Langmuir constants only."""
+        for name, record in EXTRACTANT_CAPACITIES.items():
+            assert set(record) == {"typical_K_L"}, (
+                f"{name} still carries {sorted(set(record) - {'typical_K_L'})}"
+            )
+
+    def test_loading_correction_uses_the_isotherm_exponent(self):
+        """loading_correction is (1 - theta_total)**isotherm.m, not **3.
+
+        Untested and unused in-tree before this, while #191 silently changed
+        both its exponent (3 -> m = 6 for the acidic extractants) and its theta
+        basis (max_ree_conc halved), moving its output by a factor of 25.6 at
+        the point below.
+        """
+        iso = get_loading_isotherm("D2EHPA", 0.5)
+        assert iso.m == 6.0
+        assert iso.max_ree_conc == pytest.approx(0.5 / 6.0)
+
+        c_org = {"Nd": 0.0413}
+        theta = 0.0413 / iso.max_ree_conc
+        expected = 10.0 * (1.0 - theta) ** iso.m
+        out = loading_correction({"Nd": 10.0}, c_org, iso)
+        assert float(out["Nd"]) == pytest.approx(expected, rel=1e-12)
+        # The pre-#191 form, for the record: (1 - 0.0413/0.165)**3 * 10
+        old = 10.0 * (1.0 - 0.0413 / (0.33 * 0.5)) ** 3
+        assert old / float(out["Nd"]) == pytest.approx(25.59, rel=1e-3)
+
+    def test_loading_correction_is_multiplicative_and_shared(self):
+        """Total loading, one factor, applied to every element's D."""
+        iso = get_loading_isotherm("D2EHPA", 0.5)
+        D_in = {"Nd": 10.0, "Dy": 200.0}
+        c_org = {"Nd": 0.02, "Dy": 0.01}
+        out = loading_correction(D_in, c_org, iso)
+        assert set(out) == set(D_in)
+        theta = (0.02 + 0.01) / iso.max_ree_conc
+        factor = (1.0 - theta) ** iso.m
+        for elem, D in D_in.items():
+            assert float(out[elem]) == pytest.approx(D * factor, rel=1e-12)
+        # One shared factor: the ratio of D values is untouched.
+        assert float(out["Dy"]) / float(out["Nd"]) == pytest.approx(20.0)
+
+    def test_loading_correction_floors_the_free_fraction(self):
+        """Beyond saturation the correction saturates at 0.01**m, not 0."""
+        iso = get_loading_isotherm("D2EHPA", 0.5)
+        out = loading_correction({"Nd": 10.0}, {"Nd": 10.0}, iso)
+        assert float(out["Nd"]) == pytest.approx(10.0 * 0.01 ** iso.m)
+
+    def test_loading_correction_is_differentiable(self):
+        """It is a model term, so grad must work through it.
+
+        Checked against the analytic derivative rather than ``check_grads``:
+        ``(1 - theta)**6`` is steep enough that the finite-difference estimate
+        is only good to about 3e-5 relative, and the exact derivative is a
+        stronger statement anyway.
+        """
+        iso = get_loading_isotherm("D2EHPA", 0.5)
+
+        def corrected(c):
+            return loading_correction({"Nd": 10.0}, {"Nd": c}, iso)["Nd"]
+
+        c0 = 0.02
+        theta = c0 / iso.max_ree_conc
+        expected = (
+            -10.0 * iso.m * (1.0 - theta) ** (iso.m - 1) / iso.max_ree_conc
+        )
+        g = float(jax.grad(corrected)(c0))
+        assert g < 0.0, "more loading must lower D"
+        assert g == pytest.approx(expected, rel=1e-12)

--- a/tests/ree/test_ree_mass_conservation.py
+++ b/tests/ree/test_ree_mass_conservation.py
@@ -27,10 +27,16 @@ def feed():
 
 @pytest.fixture
 def solvent():
-    """Organic solvent with an inert diluent species (n-Heptane)."""
+    """Organic solvent: D2EHPA extractant in an n-Heptane diluent.
+
+    The carriers are named after the extractant and the diluent the
+    extractor is configured with. A stream whose organic carrier is called
+    something else ("Organic") no longer silently contributes a default
+    organic flow of 1.0 -- it raises (#192).
+    """
     return make_stream(
         flows={
-            "Organic": 10.0,
+            "D2EHPA": 10.0,
             "n-Heptane": 20.0,
             "Nd": 0.0,
             "Dy": 0.0,
@@ -69,6 +75,7 @@ class TestREEExtractorMassConservation:
         params = REEExtractorParams(
             n_stages=1,
             extractant="D2EHPA",
+            diluent="n-Heptane",  # names the solvent fixture's carrier (#192)
             elements=("Dy", "Nd"),
             pH=1.6,
         )
@@ -91,6 +98,7 @@ class TestREEExtractorMassConservation:
         params = REEExtractorParams(
             n_stages=1,
             extractant="D2EHPA",
+            diluent="n-Heptane",  # names the solvent fixture's carrier (#192)
             elements=("Dy", "Nd"),
             pH=1.6,
         )
@@ -103,6 +111,7 @@ class TestREEExtractorMassConservation:
         params = REEExtractorParams(
             n_stages=5,
             extractant="D2EHPA",
+            diluent="n-Heptane",  # names the solvent fixture's carrier (#192)
             elements=("Dy", "Nd"),
             pH=3.0,
         )

--- a/tests/ree/test_ree_mechanism_activity.py
+++ b/tests/ree/test_ree_mechanism_activity.py
@@ -1,0 +1,1127 @@
+"""Tests for REE extraction mechanism dispatch (#195) and the activity
+correction convention / validity range (#194).
+
+Issue #195: `data/extractants.yaml` encoded a solvating mechanism for TBP
+(nitrate coefficients, zero protons released, requires_nitrate) that no code
+read; TBP was modelled with a pH slope, i.e. as a weak cation exchanger.
+
+Issue #194: the ionic-strength correction multiplied D by the rare-earth
+activity coefficient alone, on an unstated pH scale, and Davies was applied far
+outside its documented validity range.
+"""
+
+import warnings
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from difflow_ree.database import (
+    EXTRACTION_MECHANISMS,
+    create_custom_extractant,
+    get_extractant,
+    normalize_mechanism,
+)
+from difflow_ree.equilibrium.distribution import REEDistribution
+from difflow_ree.equilibrium.speciation import (
+    AQUEOUS_MEDIA,
+    DAVIES_MAX_IONIC_STRENGTH,
+    DAVIES_SIGN_CHANGE_IONIC_STRENGTH,
+    NITRATE_BEARING_MEDIA,
+)
+from difflow.streams import make_stream
+from difflow_ree.flowsheets.extract_scrub_strip import (
+    ExtractScrubStripCircuit,
+    ExtractScrubStripParams,
+)
+from difflow_ree.flowsheets.extract_strip import (
+    ExtractStripCircuit,
+    ExtractStripParams,
+)
+from difflow_ree.flowsheets.full_train import (
+    FullSeparationTrain,
+    SeparationTrainParams,
+)
+from difflow_ree.flowsheets.split_shell import SplitShellCascade, SplitShellParams
+
+
+# =============================================================================
+# Independent reference implementations (deliberately NOT the library's)
+# =============================================================================
+
+def davies_gamma(z: int, ionic_strength: float) -> float:
+    """Davies activity coefficient, written out independently of difflow_ree."""
+    A = 0.509
+    sqrt_I = np.sqrt(ionic_strength)
+    log_gamma = -A * z**2 * (sqrt_I / (1.0 + sqrt_I) - 0.3 * ionic_strength)
+    return float(10.0**log_gamma)
+
+
+# =============================================================================
+# #195 - mechanism is a property of the data
+# =============================================================================
+
+class TestMechanismIsData:
+    """Issue #195: dispatch on the declared extraction mechanism."""
+
+    def test_195_extractant_record_exposes_nitrate_data(self):
+        """nitrate_coefficients / reference_nitrate / requires_nitrate are
+        reachable from the Extractant record rather than dead YAML."""
+        tbp = get_extractant("TBP")
+        assert tbp.nitrate_coefficients is not None
+        assert set(tbp.nitrate_coefficients) >= {"La", "Nd", "Dy", "Y"}
+        # b is now the stoichiometric 3.0 of RE(NO3)3 + 3 TBP for every
+        # element; the old per-element 2.50-2.85 trend had no support.
+        assert tbp.nitrate_coefficients["Nd"].b == pytest.approx(3.0)
+        assert tbp.reference_nitrate == pytest.approx(3.0)
+        assert tbp.requires_nitrate is True
+        # protons_released was loaded but never read before #194/#195
+        assert tbp.stoichiometry_protons == 0
+
+    def test_195_mechanism_normalized_from_type(self):
+        """`type` normalizes to one of the declared mechanisms."""
+        assert normalize_mechanism("acidic_phosphoric") == "cation_exchange"
+        assert normalize_mechanism("acidic_phosphonic") == "cation_exchange"
+        assert normalize_mechanism("acidic_phosphinic") == "cation_exchange"
+        assert normalize_mechanism("solvating_neutral") == "solvating"
+        assert set(EXTRACTION_MECHANISMS) == {"cation_exchange", "solvating"}
+
+    def test_195_records_declare_their_mechanism(self):
+        assert get_extractant("TBP").mechanism == "solvating"
+        for name in ("D2EHPA", "PC88A", "Cyanex272"):
+            assert get_extractant(name).mechanism == "cation_exchange"
+
+    def test_195_tbp_responds_to_nitrate_with_declared_slope(self):
+        """log10(D) vs log10([NO3-]) has exactly the slope `b` from the record.
+
+        The YAML says the coefficients are referenced to 3 M nitrate, so
+        `a` is log10(D) at the reference and `b` is d log10(D) / d log10([NO3-]).
+        """
+        rec = get_extractant("TBP").nitrate_coefficients["Nd"]
+        dist = REEDistribution(
+            extractant="TBP", elements=("Nd",), nitrate_conc=3.0
+        )
+
+        D_lo = float(dist.get_D("Nd", nitrate_conc=1.5))
+        D_hi = float(dist.get_D("Nd", nitrate_conc=6.0))
+        slope = (np.log10(D_hi) - np.log10(D_lo)) / (
+            np.log10(6.0) - np.log10(1.5)
+        )
+        assert slope == pytest.approx(rec.b, rel=1e-10)
+        # ...and D rises with nitrate, the qualitative signature of solvating
+        # extraction that the pH model got backwards.
+        assert D_hi > D_lo
+
+    def test_195_reference_nitrate_is_the_reference(self):
+        """At [NO3-] = reference_nitrate, log10(D) is `a` plus only the
+        (temperature and extractant-concentration) corrections."""
+        ext = get_extractant("TBP")
+        rec = ext.nitrate_coefficients["Nd"]
+        # Use the reference extractant concentration so the [S]^n term is zero.
+        dist = REEDistribution(
+            extractant="TBP",
+            elements=("Nd",),
+            concentration=ext.reference_concentration,
+            nitrate_conc=ext.reference_nitrate,
+        )
+        assert float(jnp.log10(dist.get_D("Nd"))) == pytest.approx(
+            rec.a, rel=1e-10
+        )
+
+    def test_195_tbp_is_flat_in_ph_unlike_an_acidic_extractant(self):
+        """The qualitative contrast #195 is about: a solvating extractant's D
+        does not move with pH, a cation exchanger's moves by orders of
+        magnitude over the same span."""
+        tbp = REEDistribution(
+            extractant="TBP", elements=("Nd",), nitrate_conc=3.0
+        )
+        acidic = REEDistribution(extractant="D2EHPA", elements=("Nd",))
+
+        pH_lo, pH_hi = 1.5, 4.0
+        tbp_ratio = float(tbp.get_D("Nd", pH=pH_hi)) / float(
+            tbp.get_D("Nd", pH=pH_lo)
+        )
+        acid_ratio = float(acidic.get_D("Nd", pH=pH_hi)) / float(
+            acidic.get_D("Nd", pH=pH_lo)
+        )
+        assert tbp_ratio == pytest.approx(1.0, rel=1e-12)
+        assert acid_ratio > 100.0
+
+    def test_195_no_nitrate_fails_loudly(self):
+        """TBP with no nitrate concentration must fail, not silently fall back
+        to its ph_coefficients block. This is the behaviour change of #195."""
+        with pytest.raises(ValueError, match=r"TBP.*requires a nitrate"):
+            REEDistribution(extractant="TBP", elements=("Nd",))
+
+    def test_195_zero_nitrate_fails_on_the_driving_ion_not_on_prose(self):
+        """nitrate_conc <= 0 means the salting anion that drives the
+        correlation has no concentration. Asserted on the parameter, not on the
+        word 'chloride' appearing in the message (D10b)."""
+        with pytest.raises(ValueError, match=r"nitrate_conc=0"):
+            REEDistribution(
+                extractant="TBP", elements=("Nd",), nitrate_conc=0.0
+            )
+
+    def test_195_zero_in_a_nitrate_profile_is_caught(self):
+        """The driving-ion check inspects a concrete array at its minimum, so a
+        per-stage nitrate profile containing a zero is rejected."""
+        with pytest.raises(ValueError, match=r"nitrate_conc=0"):
+            REEDistribution(
+                extractant="TBP",
+                elements=("Nd",),
+                nitrate_conc=jnp.array([3.0, 1.0, 0.0]),
+            )
+
+
+class TestMediumIsDetectedNotDescribed:
+    """D10b: #195 asked for a raise "when used in a medium its coefficients do
+    not cover". The data supports exactly one medium constraint --
+    ``stoichiometry.requires_nitrate`` -- so that is what is detected, and the
+    tests assert the detection rather than the wording of an error."""
+
+    def test_declared_medium_is_checked_against_requires_nitrate(self):
+        """TBP declared in a chloride liquor raises even though a perfectly
+        good nitrate concentration was supplied: it is the *medium* that is
+        wrong, and it is detected from the record's flag."""
+        assert get_extractant("TBP").requires_nitrate is True
+        for bad in ("chloride", "sulfate"):
+            with pytest.raises(ValueError) as exc:
+                REEDistribution(
+                    extractant="TBP",
+                    elements=("Nd",),
+                    nitrate_conc=3.0,
+                    medium=bad,
+                )
+            assert f"medium={bad!r}" in str(exc.value)
+            assert "requires_nitrate" in str(exc.value)
+
+    def test_nitrate_bearing_media_are_accepted(self):
+        for good in NITRATE_BEARING_MEDIA:
+            dist = REEDistribution(
+                extractant="TBP",
+                elements=("Nd",),
+                nitrate_conc=3.0,
+                medium=good,
+            )
+            assert float(dist.get_D("Nd")) > 0.0
+
+    def test_medium_check_survives_the_mechanism_override(self):
+        """The medium check runs before the mechanism's coefficient block is
+        resolved, so a chloride medium is rejected on the record's
+        requires_nitrate flag even when the caller asked for the (now deleted,
+        and separately refused) cation-exchange path."""
+        with pytest.raises(ValueError, match="requires a nitrate medium"):
+            REEDistribution(
+                extractant="TBP",
+                elements=("Nd",),
+                mechanism="cation_exchange",
+                medium="chloride",
+            )
+
+    def test_no_record_forbids_a_medium_for_a_cation_exchanger(self):
+        """The honest contract: nothing in the data declares a chloride or
+        sulfate incompatibility, so nothing else is rejected. A test that
+        expected D2EHPA to be refused in some medium would be asserting a
+        constraint the database does not carry."""
+        for name in ("D2EHPA", "PC88A", "Cyanex272"):
+            assert get_extractant(name).requires_nitrate is False
+            for medium in AQUEOUS_MEDIA:
+                dist = REEDistribution(
+                    extractant=name, elements=("Nd",), medium=medium
+                )
+                assert float(dist.get_D("Nd", pH=3.0)) > 0.0
+
+    def test_unknown_medium_rejected(self):
+        with pytest.raises(ValueError, match="Unknown medium"):
+            REEDistribution(
+                extractant="D2EHPA", elements=("Nd",), medium="brine"
+            )
+
+    def test_unstated_medium_is_not_guessed(self):
+        """medium=None leaves the medium unstated; only the driving-ion check
+        applies."""
+        dist = REEDistribution(
+            extractant="TBP", elements=("Nd",), nitrate_conc=3.0
+        )
+        assert dist.medium is None
+        assert float(dist.get_D("Nd")) > 0.0
+
+
+class TestMechanismIsDataContinued:
+    """Remainder of the #195 dispatch tests."""
+
+    def test_195_error_names_the_extractant_and_the_way_out(self):
+        """The way out is nitrate_conc, and -- now that TBP's pH block is
+        deleted -- the message must say that mechanism='cation_exchange' is
+        NOT a second way out, rather than advertising a path that raises."""
+        with pytest.raises(ValueError) as exc:
+            REEDistribution(extractant="TBP", elements=("Nd",))
+        msg = str(exc.value)
+        assert "TBP" in msg
+        assert "nitrate_conc" in msg
+        assert "mechanism='cation_exchange'" in msg
+        assert "raises" in msg
+        assert "only path" in msg
+
+    def test_tbp_cation_exchange_opt_in_now_raises(self):
+        """TBP's ph_coefficients block was DELETED, so the opt-in that used to
+        reach it must now raise -- loudly, naming TBP, and pointing at the
+        nitrate path. No silent fall-back to nitrate_coefficients, and no
+        AttributeError/KeyError leaking out of a later get_D.
+
+        The block modelled a neutral extractant (pKa null, protons_released 0)
+        as a weak cation exchanger: there is no proton to exchange, no source
+        reported a pH slope for TBP, and it carried the same refuted 100x
+        La-to-Dy spread as the old nitrate block."""
+        with pytest.raises(ValueError) as exc:
+            REEDistribution(
+                extractant="TBP", elements=("Nd",), mechanism="cation_exchange"
+            )
+        msg = str(exc.value)
+        assert "TBP" in msg
+        assert "ph_coefficients" in msg
+        assert "nitrate_conc" in msg  # points at the path that does exist
+
+    def test_tbp_record_carries_no_ph_block_at_all(self):
+        """The field is None, not an empty dict: there is no pH-driven
+        correlation for TBP to be found, mutated or fallen back to."""
+        assert get_extractant("TBP").ph_coefficients is None
+
+    def test_the_nitrate_path_is_unaffected_by_the_deletion(self):
+        nitrate_path = REEDistribution(
+            extractant="TBP", elements=("Nd",), nitrate_conc=3.0
+        )
+        assert nitrate_path.mechanism == "solvating"
+        assert float(nitrate_path.get_D("Nd")) > 0.0
+
+    def test_195_cation_exchange_requires_ph(self):
+        acidic = REEDistribution(extractant="D2EHPA", elements=("Nd",))
+        with pytest.raises(ValueError, match="requires pH"):
+            acidic.get_D("Nd")
+
+    def test_195_unknown_mechanism_rejected(self):
+        with pytest.raises(ValueError, match="unknown mechanism"):
+            REEDistribution(
+                extractant="D2EHPA", elements=("Nd",), mechanism="anion_exchange"
+            )
+
+    def test_195_missing_element_names_the_block(self):
+        dist = REEDistribution(
+            extractant="TBP", elements=("Nd",), nitrate_conc=3.0
+        )
+        with pytest.raises(KeyError, match="nitrate_coefficients"):
+            dist.get_D("Lu")
+
+
+# =============================================================================
+# #194 - activity correction convention and validity range
+# =============================================================================
+
+class TestActivityConvention:
+    """Issue #194: gamma_RE / gamma_H**p, and the Davies validity range."""
+
+    def test_194_correction_is_gamma_re_over_gamma_h_to_the_p(self):
+        """Compare against an independently computed Davies value, not against
+        the implementation."""
+        I = 0.2
+        ext = get_extractant("D2EHPA")
+        p = ext.stoichiometry_protons
+        assert p == 3  # sanity: the record actually carries it
+
+        dist = REEDistribution(extractant="D2EHPA", elements=("Nd",))
+        D_plain = float(dist.get_D("Nd", pH=3.0))
+        D_corr = float(dist.get_D("Nd", pH=3.0, ionic_strength=I))
+
+        expected = davies_gamma(3, I) / davies_gamma(1, I) ** p
+        assert D_corr / D_plain == pytest.approx(expected, rel=1e-10)
+
+        # And it is NOT gamma_RE alone - the pre-#194 behaviour.
+        assert D_corr / D_plain != pytest.approx(davies_gamma(3, I), rel=1e-3)
+
+    def test_194_proton_term_uses_p_from_the_record(self):
+        """Every cation exchanger in the database carries p = 3, and the
+        correction tracks it rather than a hard-coded charge."""
+        I = 0.15
+        for name in ("D2EHPA", "PC88A", "Cyanex272"):
+            p = get_extractant(name).stoichiometry_protons
+            dist = REEDistribution(extractant=name, elements=("Nd",))
+            ratio = float(
+                dist.get_D("Nd", pH=3.0, ionic_strength=I)
+            ) / float(dist.get_D("Nd", pH=3.0))
+            expected = davies_gamma(3, I) / davies_gamma(1, I) ** p
+            assert ratio == pytest.approx(expected, rel=1e-10)
+
+    def test_194_solvating_extractant_gets_no_proton_term(self):
+        """p = 0 for TBP, so the correction carries gamma_RE and nothing else."""
+        I = 0.2
+        assert get_extractant("TBP").stoichiometry_protons == 0
+        dist = REEDistribution(
+            extractant="TBP",
+            elements=("Nd",),
+            nitrate_conc=3.0,
+            on_out_of_range="ignore",
+        )
+        ratio = float(dist.get_D("Nd", ionic_strength=I)) / float(
+            dist.get_D("Nd")
+        )
+        assert ratio == pytest.approx(davies_gamma(3, I), rel=1e-10)
+
+    def test_194_solvating_warns_that_salting_is_not_this_correction(self):
+        dist = REEDistribution(
+            extractant="TBP", elements=("Nd",), nitrate_conc=3.0
+        )
+        with pytest.warns(UserWarning, match="salting"):
+            dist.get_D("Nd", ionic_strength=0.2)
+
+    def test_194_out_of_davies_range_warns(self):
+        """A 2-4 M chloride liquor is an order of magnitude outside Davies."""
+        dist = REEDistribution(extractant="D2EHPA", elements=("Nd",))
+        with pytest.warns(UserWarning, match="validity range"):
+            dist.get_D("Nd", pH=3.0, ionic_strength=3.0)
+
+    def test_194_in_range_does_not_warn(self):
+        dist = REEDistribution(extractant="D2EHPA", elements=("Nd",))
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            dist.get_D("Nd", pH=3.0, ionic_strength=0.4)
+
+    def test_194_out_of_range_can_be_escalated_to_an_error(self):
+        dist = REEDistribution(
+            extractant="D2EHPA", elements=("Nd",), on_out_of_range="raise"
+        )
+        with pytest.raises(ValueError, match="validity range"):
+            dist.get_D("Nd", pH=3.0, ionic_strength=3.0)
+
+    def test_194_out_of_range_can_be_silenced(self):
+        dist = REEDistribution(
+            extractant="D2EHPA", elements=("Nd",), on_out_of_range="ignore"
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            D = float(dist.get_D("Nd", pH=3.0, ionic_strength=3.0))
+        assert np.isfinite(D)
+
+    def test_194_warning_does_not_spam_a_stage_loop(self):
+        """The check is parameter-time: repeated calls report once."""
+        dist = REEDistribution(extractant="D2EHPA", elements=("Nd",))
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            for _ in range(25):
+                dist.get_D("Nd", pH=3.0, ionic_strength=3.0)
+        assert len(caught) == 1
+
+    def test_194_ionic_strength_none_reproduces_the_correlation_exactly(self):
+        """The honest high-ionic-strength option: a conditional constant, with
+        no activity correction at all."""
+        dist = REEDistribution(extractant="D2EHPA", elements=("Nd",))
+        ext = get_extractant("D2EHPA")
+        c = ext.ph_coefficients["Nd"]
+        n = ext.concentration_exponent
+        expected_log = (
+            c.a
+            + c.b * 3.0
+            + c.c * 3.0**2
+            + n * np.log10(dist.concentration / ext.reference_concentration)
+        )
+        D_none = float(dist.get_D("Nd", pH=3.0, ionic_strength=None))
+        assert np.log10(D_none) == pytest.approx(expected_log, rel=1e-12)
+        assert D_none == pytest.approx(float(dist.get_D("Nd", pH=3.0)), rel=0)
+
+    def test_194_activity_model_none_is_uncorrected_at_any_i(self):
+        dist = REEDistribution(
+            extractant="D2EHPA", elements=("Nd",), activity_model="none"
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            D_corr = float(dist.get_D("Nd", pH=3.0, ionic_strength=4.0))
+        assert D_corr == pytest.approx(float(dist.get_D("Nd", pH=3.0)), rel=0)
+
+    def test_194_unimplemented_activity_models_are_refused(self):
+        """Bromley / SIT parameters are not carried, so they are not offered."""
+        for model in ("bromley", "sit", "pitzer"):
+            with pytest.raises(ValueError, match="Unknown activity_model"):
+                REEDistribution(
+                    extractant="D2EHPA",
+                    elements=("Nd",),
+                    activity_model=model,
+                )
+
+    def test_194_bad_on_out_of_range_rejected(self):
+        with pytest.raises(ValueError, match="on_out_of_range"):
+            REEDistribution(
+                extractant="D2EHPA", elements=("Nd",), on_out_of_range="explode"
+            )
+
+    def test_194_get_D_all_threads_the_correction(self):
+        dist = REEDistribution(
+            extractant="D2EHPA", elements=("Nd", "Dy"), on_out_of_range="ignore"
+        )
+        plain = dist.get_D_all(pH=3.0)
+        corr = dist.get_D_all(pH=3.0, ionic_strength=0.3)
+        for e in ("Nd", "Dy"):
+            assert float(corr[e]) < float(plain[e])
+
+
+# =============================================================================
+# #194 - the Davies sign inversion (the defect the range guard exists for)
+# =============================================================================
+
+class TestDaviesSignInversion:
+    """Davies' bracket f(I) = sqrt(I)/(1+sqrt(I)) - 0.3 I changes sign, so the
+    correction gamma_RE/gamma_H**3 = 10**(-6 A f) crosses 1 and starts
+    MULTIPLYING D -- in exactly the 2-4 M chloride regime #194 was filed
+    about. These tests pin both the arithmetic fact and the guard."""
+
+    def test_the_documented_sign_change_is_the_actual_root(self):
+        """Solved, not guessed: f(I) = 0 for x = sqrt(I) at
+        0.3 x^2 + 0.3 x - 1 = 0."""
+        I_flip = DAVIES_SIGN_CHANGE_IONIC_STRENGTH
+        f = lambda I: np.sqrt(I) / (1.0 + np.sqrt(I)) - 0.3 * I
+        assert f(I_flip) == pytest.approx(0.0, abs=1e-12)
+        assert f(I_flip - 1e-3) > 0.0
+        assert f(I_flip + 1e-3) < 0.0
+        x = (-1.0 + np.sqrt(1.0 + 40.0 / 3.0)) / 2.0
+        assert I_flip == pytest.approx(x**2, rel=1e-15)
+
+    def test_raw_davies_really_does_invert(self):
+        """The trap, stated independently of difflow_ree: above ~1.94 M the
+        uncorrected ratio exceeds 1."""
+        assert davies_gamma(3, 0.1) / davies_gamma(1, 0.1) ** 3 < 1.0
+        assert davies_gamma(3, 1.0) / davies_gamma(1, 1.0) ** 3 < 1.0
+        assert davies_gamma(3, 3.0) / davies_gamma(1, 3.0) ** 3 == pytest.approx(
+            6.492942892894, rel=1e-9
+        )
+        assert davies_gamma(3, 4.0) / davies_gamma(1, 4.0) ** 3 > 40.0
+
+    def test_D_is_never_multiplied_by_the_activity_correction(self):
+        """The guard: for no ionic strength, however large, does the default
+        path return a correction greater than 1."""
+        dist = REEDistribution(
+            extractant="D2EHPA", elements=("Nd",), on_out_of_range="ignore"
+        )
+        D_plain = float(dist.get_D("Nd", pH=3.0))
+        for I in (0.1, 0.5, 1.0, 1.9, 2.0, 2.5, 3.0, 4.0, 10.0, 100.0):
+            ratio = float(dist.get_D("Nd", pH=3.0, ionic_strength=I)) / D_plain
+            assert ratio < 1.0, f"correction inverted at I={I}: ratio={ratio}"
+
+    def test_out_of_range_correction_saturates_at_the_range_limit(self):
+        dist = REEDistribution(
+            extractant="D2EHPA", elements=("Nd",), on_out_of_range="ignore"
+        )
+        limit = float(dist.get_D("Nd", pH=3.0, ionic_strength=DAVIES_MAX_IONIC_STRENGTH))
+        for I in (0.6, 2.0, 3.0, 4.0):
+            assert float(
+                dist.get_D("Nd", pH=3.0, ionic_strength=I)
+            ) == pytest.approx(limit, rel=1e-12)
+
+    def test_in_range_values_are_untouched_by_the_clamp(self):
+        """The guard must not perturb anything Davies is actually valid for."""
+        dist = REEDistribution(
+            extractant="D2EHPA", elements=("Nd",), on_out_of_range="ignore"
+        )
+        D_plain = float(dist.get_D("Nd", pH=3.0))
+        for I in (0.01, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5):
+            ratio = float(dist.get_D("Nd", pH=3.0, ionic_strength=I)) / D_plain
+            expected = davies_gamma(3, I) / davies_gamma(1, I) ** 3
+            assert ratio == pytest.approx(expected, rel=1e-10)
+
+    def test_inversion_requires_an_explicit_opt_in(self):
+        """It is still reachable -- but only by asking for it, and the number
+        you get is exactly the raw Davies one."""
+        opted_in = REEDistribution(
+            extractant="D2EHPA",
+            elements=("Nd",),
+            on_out_of_range="ignore",
+            extrapolate_activity_model=True,
+        )
+        D_plain = float(opted_in.get_D("Nd", pH=3.0))
+        ratio = float(opted_in.get_D("Nd", pH=3.0, ionic_strength=3.0)) / D_plain
+        assert ratio > 1.0
+        assert ratio == pytest.approx(
+            davies_gamma(3, 3.0) / davies_gamma(1, 3.0) ** 3, rel=1e-10
+        )
+
+    def test_a_concrete_array_is_range_checked_at_its_maximum(self):
+        """A concrete jnp.array is inspectable; only float() refuses it. The
+        pre-fix code treated it like a tracer and warned 0 times (#194)."""
+        dist = REEDistribution(extractant="D2EHPA", elements=("Nd",))
+        with pytest.warns(UserWarning, match="validity range"):
+            dist.get_D("Nd", pH=3.0, ionic_strength=jnp.array([0.1, 3.0, 4.0]))
+
+    def test_a_concrete_in_range_array_does_not_warn(self):
+        dist = REEDistribution(extractant="D2EHPA", elements=("Nd",))
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            dist.get_D(
+                "Nd", pH=3.0, ionic_strength=jnp.array([0.05, 0.2, 0.45])
+            )
+
+    def test_an_out_of_range_array_can_be_escalated_to_an_error(self):
+        dist = REEDistribution(
+            extractant="D2EHPA", elements=("Nd",), on_out_of_range="raise"
+        )
+        with pytest.raises(ValueError, match="validity range"):
+            dist.get_D("Nd", pH=3.0, ionic_strength=np.array([0.1, 3.0]))
+
+    def test_the_report_names_the_sign_change_when_it_is_crossed(self):
+        dist = REEDistribution(
+            extractant="D2EHPA", elements=("Nd",), on_out_of_range="raise"
+        )
+        with pytest.raises(ValueError, match="changes sign"):
+            dist.get_D("Nd", pH=3.0, ionic_strength=3.0)
+        # Out of range but below the sign change: no inversion claim.
+        mild = REEDistribution(
+            extractant="D2EHPA", elements=("Nd",), on_out_of_range="raise"
+        )
+        with pytest.raises(ValueError) as exc:
+            mild.get_D("Nd", pH=3.0, ionic_strength=1.0)
+        assert "validity range" in str(exc.value)
+        assert "changes sign" not in str(exc.value)
+
+    def test_array_of_D_values_is_corrected_elementwise(self):
+        """An array ionic strength still produces an elementwise correction,
+        clamped where it is out of range."""
+        dist = REEDistribution(
+            extractant="D2EHPA", elements=("Nd",), on_out_of_range="ignore"
+        )
+        D_plain = float(dist.get_D("Nd", pH=3.0))
+        I = jnp.array([0.1, 0.5, 3.0])
+        D = np.asarray(dist.get_D("Nd", pH=3.0, ionic_strength=I))
+        assert D.shape == (3,)
+        assert np.all(D / D_plain < 1.0)
+        assert D[1] == pytest.approx(D[2], rel=1e-12)  # both clamped at 0.5
+
+
+# =============================================================================
+# Differentiability (#194, #195)
+# =============================================================================
+
+class TestGradients:
+    """get_D stays grad- and jit-safe through both mechanisms."""
+
+    def test_grad_wrt_ph_matches_finite_difference(self):
+        dist = REEDistribution(extractant="D2EHPA", elements=("Nd",))
+        f = lambda pH: dist.get_D("Nd", pH=pH)
+        pH0, h = 3.0, 1e-5
+        g = float(jax.grad(f)(pH0))
+        fd = (float(f(pH0 + h)) - float(f(pH0 - h))) / (2 * h)
+        assert np.isfinite(g)
+        assert g == pytest.approx(fd, rel=1e-5)
+
+    def test_grad_wrt_nitrate_matches_finite_difference(self):
+        dist = REEDistribution(
+            extractant="TBP", elements=("Nd",), nitrate_conc=3.0
+        )
+        f = lambda c: dist.get_D("Nd", nitrate_conc=c)
+        c0, h = 3.0, 1e-5
+        g = float(jax.grad(f)(c0))
+        fd = (float(f(c0 + h)) - float(f(c0 - h))) / (2 * h)
+        assert np.isfinite(g)
+        assert g > 0.0  # D rises with nitrate
+        assert g == pytest.approx(fd, rel=1e-5)
+
+    def test_grad_wrt_ionic_strength_is_finite_and_negative(self):
+        """In range the correction reduces D, so dD/dI < 0 and matches a finite
+        difference. Probed across the whole Davies range and, critically, ALSO
+        above the sign-change ionic strength, where the pre-fix code returned a
+        POSITIVE gradient (the correction was increasing D). Probing only
+        I = 0.1 M never sees that (#194)."""
+        dist = REEDistribution(
+            extractant="D2EHPA", elements=("Nd",), on_out_of_range="ignore"
+        )
+        f = lambda I: dist.get_D("Nd", pH=3.0, ionic_strength=I)
+
+        # In range: negative, and equal to a central difference.
+        for I0 in (0.05, 0.1, 0.2):
+            h = 1e-6
+            g = float(jax.grad(f)(I0))
+            fd = (float(f(I0 + h)) - float(f(I0 - h))) / (2 * h)
+            assert np.isfinite(g)
+            assert g < 0.0, f"dD/dI should be negative at I={I0}"
+            assert g == pytest.approx(fd, rel=1e-4)
+
+        # Above the range, and above the sign change: the correction is
+        # saturated, so the gradient is exactly zero. It is emphatically NOT
+        # positive, which is what an inverted correction would give.
+        for I0 in (0.6, 1.0, 3.0, 4.0):
+            g = float(jax.grad(f)(I0))
+            assert np.isfinite(g)
+            assert g == 0.0, f"dD/dI should be flat past the range at I={I0}"
+
+    def test_grad_is_positive_only_when_extrapolation_is_requested(self):
+        """The inverted branch still exists, and still has the sign the bug
+        report measured -- but only for a caller who asked for it (#194)."""
+        opted_in = REEDistribution(
+            extractant="D2EHPA",
+            elements=("Nd",),
+            on_out_of_range="ignore",
+            extrapolate_activity_model=True,
+        )
+        g = float(
+            jax.grad(lambda I: opted_in.get_D("Nd", pH=3.0, ionic_strength=I))(
+                3.0
+            )
+        )
+        assert np.isfinite(g)
+        assert g > 0.0
+
+    def test_traced_ionic_strength_cannot_silently_invert_D(self):
+        """A tracer cannot be range-checked, so the guard is arithmetic rather
+        than a check: the ionic strength fed to the activity model is clamped
+        at the model's documented limit. grad still works, and the result is
+        identical to the concrete clamped value -- never the inverted one
+        (#194)."""
+        dist = REEDistribution(
+            extractant="D2EHPA", elements=("Nd",), on_out_of_range="ignore"
+        )
+        f = lambda I: dist.get_D("Nd", pH=3.0, ionic_strength=I)
+
+        g = jax.grad(f)(3.0)
+        assert jnp.isfinite(g)
+
+        D_plain = float(dist.get_D("Nd", pH=3.0))
+        traced = float(jax.jit(f)(3.0))
+        clamped = float(f(DAVIES_MAX_IONIC_STRENGTH))
+        assert traced == pytest.approx(clamped, rel=1e-12)
+        assert traced / D_plain < 1.0
+
+    def test_traced_ionic_strength_is_reported_as_unverifiable(self):
+        """The old behaviour was a *silent* skip: on_out_of_range='raise' with
+        a traced I produced no raise at all. A tracer is now reported as
+        exactly what it is -- a value whose range could not be checked (#194).
+        """
+        strict = REEDistribution(
+            extractant="D2EHPA", elements=("Nd",), on_out_of_range="raise"
+        )
+        with pytest.raises(ValueError, match="tracer"):
+            jax.grad(
+                lambda I: strict.get_D("Nd", pH=3.0, ionic_strength=I)
+            )(3.0)
+
+        warning_mode = REEDistribution(extractant="D2EHPA", elements=("Nd",))
+        with pytest.warns(UserWarning, match="cannot be range-checked"):
+            jax.jit(
+                lambda I: warning_mode.get_D("Nd", pH=3.0, ionic_strength=I)
+            )(3.0)
+
+        quiet = REEDistribution(
+            extractant="D2EHPA", elements=("Nd",), on_out_of_range="ignore"
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            jax.jit(
+                lambda I: quiet.get_D("Nd", pH=3.0, ionic_strength=I)
+            )(3.0)
+
+    def test_jit_of_both_mechanisms(self):
+        acidic = REEDistribution(extractant="D2EHPA", elements=("Nd",))
+        tbp = REEDistribution(
+            extractant="TBP", elements=("Nd",), nitrate_conc=3.0
+        )
+        f_acid = jax.jit(lambda pH: acidic.get_D("Nd", pH=pH))
+        f_tbp = jax.jit(lambda c: tbp.get_D("Nd", nitrate_conc=c))
+        assert float(f_acid(3.0)) == pytest.approx(
+            float(acidic.get_D("Nd", pH=3.0)), rel=1e-10
+        )
+        assert float(f_tbp(4.0)) == pytest.approx(
+            float(tbp.get_D("Nd", nitrate_conc=4.0)), rel=1e-10
+        )
+
+
+# =============================================================================
+# D8 - every flowsheet that takes an extractant can take a solvating one
+# =============================================================================
+
+class TestSolvatingExtractantInFlowsheets:
+    """#195 made TBP raise unless a nitrate concentration reaches
+    REEDistribution. Two flowsheets were not threaded, which left TBP
+    constructible only through the other two -- with no escape hatch, because
+    their Params classes had no nitrate_conc field at all."""
+
+    @staticmethod
+    def _feed():
+        return make_stream(
+            {"H2O": 1000.0, "Nd": 1.0, "Dy": 0.5}, 298.15, 101325.0
+        )
+
+    def test_extract_scrub_strip_params_carry_the_solvating_fields(self):
+        p = ExtractScrubStripParams(
+            extractant="TBP",
+            elements=("Nd", "Dy"),
+            target_elements=("Dy",),
+        )
+        assert p.nitrate_conc is None
+        assert p.mechanism is None
+
+    def test_extract_scrub_strip_constructs_and_runs_with_TBP(self):
+        p = ExtractScrubStripParams(
+            extractant="TBP",
+            elements=("Nd", "Dy"),
+            target_elements=("Dy",),
+            nitrate_conc=3.0,
+            extractant_conc=1.1,  # ~30% v/v, see extractants.yaml
+        )
+        circuit = ExtractScrubStripCircuit(p)
+        results = circuit(self._feed())
+        assert np.isfinite(float(results["target_purity"]))
+        for elem in ("Nd", "Dy"):
+            assert np.isfinite(float(results["product_purity"][elem]))
+
+    def test_extract_scrub_strip_still_refuses_TBP_without_nitrate(self):
+        """Threading the parameter must not reintroduce the silent pH fallback."""
+        with pytest.raises(ValueError, match=r"TBP.*requires a nitrate"):
+            ExtractScrubStripCircuit(
+                ExtractScrubStripParams(
+                    extractant="TBP",
+                    elements=("Nd", "Dy"),
+                    target_elements=("Dy",),
+                )
+            )
+
+    def test_separation_train_params_carry_the_solvating_fields(self):
+        p = SeparationTrainParams(elements=("La", "Nd", "Dy"), extractant="TBP")
+        assert p.nitrate_conc is None
+        assert p.mechanism is None
+
+    def test_full_train_constructs_and_runs_with_TBP(self):
+        p = SeparationTrainParams(
+            elements=("La", "Nd", "Dy"),
+            extractant="TBP",
+            include_ce_removal=False,
+            nitrate_conc=3.0,
+        )
+        train = FullSeparationTrain(p)
+        results = train(
+            make_stream(
+                {"H2O": 1000.0, "La": 1.0, "Nd": 1.0, "Dy": 0.5},
+                298.15,
+                101325.0,
+            )
+        )
+        assert set(results["products"]) >= {"light_REE", "heavy_REE"}
+
+    def test_full_train_still_refuses_TBP_without_nitrate(self):
+        with pytest.raises(ValueError, match=r"TBP.*requires a nitrate"):
+            FullSeparationTrain(
+                SeparationTrainParams(
+                    elements=("La", "Nd", "Dy"),
+                    extractant="TBP",
+                    include_ce_removal=False,
+                )
+            )
+
+    def test_mechanism_override_reaches_every_section(self):
+        """The override must reach all three sections, or a circuit silently
+        runs mixed mechanisms: the scrubber and stripper on cation exchange
+        while the extractor stays solvating. REEExtractorParams and
+        MixerSettlerParams carry a `mechanism` field for this (#195).
+
+        TBP can no longer serve as the subject unaided -- its ph_coefficients
+        block was DELETED, so overriding it to cation_exchange now raises (see
+        ``test_tbp_cation_exchange_opt_in_now_raises``, and the companion test
+        below that the flowsheet refuses it too). To keep testing the
+        *threading* rather than the deletion, a pH block is temporarily grafted
+        back onto the loaded record and removed again afterwards. The grafted
+        numbers are arbitrary; only the mechanism plumbing is under test."""
+        tbp = get_extractant("TBP")
+        assert tbp.ph_coefficients is None  # the deletion, restated here
+        from difflow_ree.database import PHCoefficients
+
+        tbp.ph_coefficients = {
+            "Nd": PHCoefficients(a=-1.40, b=0.60, c=0.0, d=0.0),
+            "Dy": PHCoefficients(a=0.00, b=0.85, c=0.0, d=0.0),
+        }
+        try:
+            circuit = ExtractScrubStripCircuit(
+                ExtractScrubStripParams(
+                    extractant="TBP",
+                    elements=("Nd", "Dy"),
+                    target_elements=("Dy",),
+                    nitrate_conc=3.0,
+                    mechanism="cation_exchange",
+                )
+            )
+            assert circuit._scrubber._distribution.mechanism == "cation_exchange"
+            assert circuit._stripper._distribution.mechanism == "cation_exchange"
+            assert circuit._extractor._distribution.mechanism == "cation_exchange"
+            assert circuit._extractor.params.mechanism == "cation_exchange"
+        finally:
+            tbp.ph_coefficients = None
+
+    def test_mechanism_override_on_tbp_is_refused_by_the_flowsheet_too(self):
+        """The deletion is not bypassable through a flowsheet: the same
+        ValueError surfaces from circuit construction."""
+        with pytest.raises(ValueError, match="ph_coefficients"):
+            ExtractScrubStripCircuit(
+                ExtractScrubStripParams(
+                    extractant="TBP",
+                    elements=("Nd", "Dy"),
+                    target_elements=("Dy",),
+                    nitrate_conc=3.0,
+                    mechanism="cation_exchange",
+                )
+            )
+
+    def test_the_two_already_threaded_flowsheets_still_work(self):
+        """Regression guard on the pair that #195 did thread."""
+        strip = ExtractStripCircuit(
+            ExtractStripParams(
+                extractant="TBP",
+                elements=("Nd", "Dy"),
+                nitrate_conc=3.0,
+                extractant_conc=1.1,
+            )
+        )
+        assert strip is not None
+        shell = SplitShellCascade(
+            SplitShellParams(
+                extractant="TBP",
+                elements=("Nd", "Dy"),
+                nitrate_conc=3.0,
+                extractant_conc=1.1,
+            )
+        )
+        assert shell._distribution.mechanism == "solvating"
+
+
+# =============================================================================
+# D10 - the custom-extractant path must not lose the dimer basis (#191)
+# =============================================================================
+
+class TestCustomExtractantStoichiometryBasis:
+    """create_custom_extractant gained the #195 mechanism fields but not
+    stoichiometry_basis, so a custom dimeric extractant silently reported
+    m = 3 while every built-in acidic extractant reports 6 -- the factor-of-two
+    capacity error of #191, reintroduced through the custom path."""
+
+    @staticmethod
+    def _make(**kw):
+        return create_custom_extractant(
+            name="MyDimer",
+            full_name="My Dimeric Phosphoric Acid",
+            formula="C10H20O4P",
+            molecular_weight=250.0,
+            ph_coefficients={"Nd": {"a": -7.5, "b": 2.4, "c": 0.01, "d": 0.0}},
+            temperature_coefficients={"Nd": -1700},
+            **kw,
+        )
+
+    def test_custom_dimeric_extractant_reports_six_monomers_per_ree(self):
+        ext = self._make(stoichiometry_basis="dimer")
+        assert ext.stoichiometry_basis == "dimer"
+        assert ext.monomers_per_ree == 6
+        assert ext.max_loading == pytest.approx(1.0 / 6.0)
+
+    def test_it_agrees_with_the_built_in_acidic_extractants(self):
+        """The whole point: a custom D2EHPA-like record must not disagree with
+        the real one about capacity."""
+        custom = self._make(
+            stoichiometry_basis="dimer",
+            stoichiometry_protons=3,
+            stoichiometry_extractant=3,
+        )
+        for name in ("D2EHPA", "PC88A", "Cyanex272"):
+            builtin = get_extractant(name)
+            assert builtin.stoichiometry_basis == "dimer"
+            assert custom.monomers_per_ree == builtin.monomers_per_ree
+            assert custom.max_loading == pytest.approx(builtin.max_loading)
+
+    def test_monomer_basis_is_the_default_and_gives_three(self):
+        ext = self._make()
+        assert ext.stoichiometry_basis == "monomer"
+        assert ext.monomers_per_ree == 3
+        assert get_extractant("TBP").stoichiometry_basis == "monomer"
+
+    def test_bad_basis_is_rejected(self):
+        with pytest.raises(ValueError, match="stoichiometry_basis"):
+            self._make(stoichiometry_basis="trimer")
+
+
+# =============================================================================
+# D9 - the TBP coefficients mean what the YAML now says they mean
+# =============================================================================
+
+class TestTBPCoefficientInterpretation:
+    """TBP's nitrate coefficients are now REFITTED FROM PRIMARY LITERATURE, not
+    hand-tuned. Fit basis: Kraikaew, Srinuttrakul & Chayavadhanakur (2005),
+    J. Metals, Materials and Minerals 15(2), 89-95, Table 1 (1.0 M TBP in
+    kerosene, 0.2001 N free acid, 35 C), corrected to the record's reference
+    (3.0 M NO3-, 1.0 M TBP, 298.15 K); heat of extraction from Ganesh & Pandey
+    (2019), J. Rad. Nucl. Appl. 4(2), 109-115, dH_Sm = -43.3 kJ/mol.
+
+    `a` is still log10(D) AT reference_nitrate and reference_concentration --
+    that reading is unchanged; what changed is that the numbers are now
+    measured. These tests pin the three defects that were fixed."""
+
+    def test_a_is_log10_D_at_the_reference_nitrate_and_concentration(self):
+        ext = get_extractant("TBP")
+        dist = REEDistribution(
+            extractant="TBP",
+            elements=("La", "Ce", "Pr", "Nd", "Sm", "Eu", "Gd", "Tb", "Dy", "Y"),
+            concentration=ext.reference_concentration,
+            nitrate_conc=ext.reference_nitrate,
+        )
+        # The exact numbers written into data/extractants.yaml.
+        expected = {
+            "La": 0.0234, "Ce": 0.0324, "Pr": 0.0603, "Nd": 0.0724,
+            "Sm": 0.1202, "Eu": 0.1380, "Gd": 0.1738, "Tb": 0.2042,
+            "Dy": 0.2399, "Y": 0.2138,
+        }
+        for elem, D in expected.items():
+            assert float(dist.get_D(elem)) == pytest.approx(D, rel=5e-3)
+        # Every one is below 1: TBP is a weak extractant and the data now
+        # says so. The old block put D_Gd at 1.0 and D_Dy at 3.16.
+        assert all(D < 1.0 for D in expected.values())
+
+    def test_D_Dy_at_the_reference_is_the_measured_024_not_the_old_316(self):
+        """Defect 2 of 3. The old record said D_Dy = 3.16 at the reference --
+        a distribution ratio TBP only reaches with a strong salting agent.
+        Corrected from Kraikaew et al. Table 1 it is 0.24, a 13x overstatement
+        removed."""
+        ext = get_extractant("TBP")
+        dist = REEDistribution(
+            extractant="TBP",
+            elements=("Dy",),
+            concentration=ext.reference_concentration,
+            nitrate_conc=ext.reference_nitrate,
+        )
+        assert float(dist.get_D("Dy")) == pytest.approx(0.24, abs=0.005)
+
+    def test_temperature_coefficients_are_positive_so_extraction_is_exothermic(
+        self,
+    ):
+        """Defect 3 of 3. Under log10 D = ... + d*(1/T - 1/Tref) with
+        d = -dH/(2.303 R), a NEGATIVE d means an ENDOTHERMIC dH. Every TBP `d`
+        used to be negative, which asserted that TBP extraction of REE nitrates
+        is endothermic. It is exothermic (Ganesh & Pandey 2019, dH_Sm = -43.3
+        kJ/mol; corroborated by Jorjani & Shahbazi 2016, extraction falling
+        from 25 to 55 C). Every `d` must therefore be positive, and D must FALL
+        as T rises."""
+        ext = get_extractant("TBP")
+        elements = (
+            "La", "Ce", "Pr", "Nd", "Sm", "Eu", "Gd", "Tb", "Dy", "Y",
+        )
+        for elem in elements:
+            d = ext.temperature_coefficients[elem]
+            assert d > 0, f"TBP d for {elem} is {d}: that is endothermic"
+            # dH = -2.303 R d; must be exothermic and of the measured size.
+            dH_kJ = -2.303 * 8.314 * d / 1000.0
+            assert dH_kJ < 0
+            assert dH_kJ == pytest.approx(-44.1, abs=1.5)
+
+        # And the observable consequence: D falls with temperature.
+        dist = REEDistribution(
+            extractant="TBP",
+            elements=("Nd",),
+            concentration=ext.reference_concentration,
+            nitrate_conc=ext.reference_nitrate,
+        )
+        assert float(dist.get_D("Nd", T=323.15)) < float(
+            dist.get_D("Nd", T=298.15)
+        )
+
+    def test_d_sits_inside_the_documented_ambiguity_range(self):
+        """Ganesh & Pandey's Table 1 appears to have its dH and slope columns
+        transposed between its two rows, so dH_TBP is either -43.3 or -61.2
+        kJ/mol, i.e. d = +2261 or +3197 K -- a +/-40% ambiguity that cannot be
+        resolved from the paper. The YAML documents the range; the value used
+        must lie in it."""
+        for d in get_extractant("TBP").temperature_coefficients.values():
+            assert 2260.0 <= d <= 3200.0
+
+    def test_the_default_extractant_conc_knocks_TBP_down_eightfold(self):
+        """The 0.5 M default every Params class carries is a cation-exchange
+        default; for TBP (reference 1.0 M, n = 3) it is an 8x reduction, and
+        0.5 M is well below the ~1.1 M of the usual 30% v/v."""
+        ext = get_extractant("TBP")
+        assert ext.reference_concentration == pytest.approx(1.0)
+        assert ext.concentration_exponent == pytest.approx(3.0)
+
+        default = REEDistribution(
+            extractant="TBP", elements=("Nd",), nitrate_conc=3.0
+        )  # concentration=0.5, the shared default
+        assert default.concentration == pytest.approx(0.5)
+        at_ref = REEDistribution(
+            extractant="TBP",
+            elements=("Nd",),
+            concentration=1.0,
+            nitrate_conc=3.0,
+        )
+        assert float(default.get_D("Nd")) / float(at_ref.get_D("Nd")) == (
+            pytest.approx(0.125, rel=1e-10)
+        )
+
+        # 30% v/v of neat TBP, from the density and MW on the record.
+        neat = 1000.0 * ext.density / ext.molecular_weight
+        assert 0.30 * neat == pytest.approx(1.10, abs=0.02)
+
+    def test_the_selectivity_spread_is_the_measured_10x_not_the_old_100x(self):
+        """Defect 1 of 3, and the most important one. The old record implied
+        D_Dy/D_La = 100 at the reference -- an acidic-organophosphorus
+        selectivity pattern that looks carried over from a cation-exchange
+        record. Kraikaew et al. Table 1 measures 10.2. TBP's REE selectivity is
+        genuinely small, which is why a TBP separation needs very many
+        stages."""
+        ext = get_extractant("TBP")
+        nc = ext.nitrate_coefficients
+        ratio = 10.0 ** (nc["Dy"].a - nc["La"].a)
+        assert ratio == pytest.approx(10.2, rel=5e-3)  # 2 s.f.
+
+        # Same thing through the public path, not just the raw record.
+        dist = REEDistribution(
+            extractant="TBP",
+            elements=("La", "Dy"),
+            concentration=ext.reference_concentration,
+            nitrate_conc=ext.reference_nitrate,
+        )
+        assert float(dist.get_D("Dy")) / float(dist.get_D("La")) == (
+            pytest.approx(10.2, rel=5e-3)
+        )
+
+    def test_mean_adjacent_pair_separation_factor_is_about_1_3(self):
+        """The consequence of the 10x spread: a mean adjacent-pair separation
+        factor of 1.29, inside the 1.1-1.5 reported for TBP. Acidic
+        organophosphorus extractants sit at 1.5-4 per pair; TBP does not, and
+        the old 100x spread wrongly put it there (it implied 1.67 per pair).
+
+        "Adjacent pair" means adjacent in the lanthanide series, i.e. per unit
+        atomic number, so La -> Dy is 9 steps and NOT the 8 gaps in the tracked
+        element tuple: Pm (Z = 61) is a real lanthanide that this package does
+        not track. Counting tuple gaps would inflate the per-pair factor to
+        1.34 and make it look worse against the literature range than it is.
+        """
+        nc = get_extractant("TBP").nitrate_coefficients
+        Z = {"La": 57, "Ce": 58, "Pr": 59, "Nd": 60, "Sm": 62,
+             "Eu": 63, "Gd": 64, "Tb": 65, "Dy": 66}
+        series = ("La", "Ce", "Pr", "Nd", "Sm", "Eu", "Gd", "Tb", "Dy")
+        # Per-atomic-number factor for each consecutive tracked pair, so the
+        # Nd -> Sm gap is spread over its two steps rather than counted as one.
+        per_step = [
+            10.0 ** ((nc[hi].a - nc[lo].a) / (Z[hi] - Z[lo]))
+            for lo, hi in zip(series[:-1], series[1:])
+        ]
+        assert all(sf > 1.0 for sf in per_step)  # monotone across the series
+        n_steps = Z["Dy"] - Z["La"]
+        assert n_steps == 9
+        spread = 10.0 ** (nc["Dy"].a - nc["La"].a)
+        geo_mean = spread ** (1.0 / n_steps)
+        assert geo_mean == pytest.approx(1.29, abs=0.01)
+        # Inside the 1.1-1.5 reported for TBP, and well below the 1.5-4 of the
+        # acidic extractants. The old record implied 1.67, above both.
+        assert 1.1 <= geo_mean <= 1.5
+        assert 10.0 ** (2.00 / n_steps) == pytest.approx(1.67, abs=0.01)
+        assert geo_mean**n_steps == pytest.approx(10.2, rel=5e-3)
+
+    def test_nitrate_slope_is_the_stoichiometric_three_for_every_element(self):
+        """b = 3.0 is the stoichiometric 3 of RE(NO3)3 + 3 TBP, NOT a fitted
+        nitrate slope: no measured d log D / d log[NO3-] in a neutral-salt
+        system was found. The only corroboration is indirect -- Ganesh & Pandey
+        Fig. 1 measured the TBP order as 2.81 (R^2 = 0.992). The old
+        per-element 2.50-2.85 trend had no support and is removed, so all ten
+        elements share one value."""
+        recs = get_extractant("TBP").nitrate_coefficients
+        for rec in recs.values():
+            assert rec.b == 3.0
+            assert rec.c == 0.0  # no curvature is claimed
+        assert len({rec.b for rec in recs.values()}) == 1

--- a/tests/ree/test_ree_moderate_bugs.py
+++ b/tests/ree/test_ree_moderate_bugs.py
@@ -129,13 +129,19 @@ class TestBug112_ExtractantLoadingCapacity:
             for elem in ("La", "Ce", "Nd", "Dy")
         )
 
-        # Get maximum capacity
+        # Get maximum capacity. Updated for #191/#193: the capacity is the
+        # molar flow F_extractant / m, not `max_ree_conc * F_org`, which
+        # multiplied a concentration by a flow and counted the diluent as if
+        # it were extractant. m comes from the declared stoichiometry (6
+        # monomer equivalents per REE for D2EHPA), so this bound is a factor
+        # of ~12 tighter than the one it replaces.
         isotherm = get_loading_isotherm("D2EHPA", 0.5)
-        F_org = 1.0 + 5.0  # D2EHPA + kerosene
-        max_capacity = isotherm.max_ree_conc * F_org
+        F_extractant = 1.0  # D2EHPA in the solvent stream
+        max_capacity = F_extractant / isotherm.m
 
-        # Total extracted should not exceed capacity
-        assert total_extracted <= max_capacity + 1e-6, (
+        # Total extracted should not exceed capacity. The smooth limiter
+        # (#193) enforces this strictly, so no tolerance is needed.
+        assert total_extracted <= max_capacity, (
             f"Total extracted ({total_extracted:.4f}) exceeds capacity "
             f"({max_capacity:.4f})"
         )


### PR DESCRIPTION
Fixes #189, #190, #191, #192, #193, #194, #195, plus a literature refit of the TBP record that the #195 mechanism work exposed.

## Summary

| Issue | Fix |
|---|---|
| #189 | `apparent_D` takes a dimensionless `theta`; the stage computes `m*F_REE_org/F_extractant`, invariant to flow units |
| #190 | Free-extractant depletion applied exactly once instead of twice |
| #191 | `m` and `max_loading = 1/m` derived from a declared stoichiometry basis; the acidic extractants are dimeric, `m = 6` |
| #192 | One `_phase_flows` helper for both units; silent `F = 1.0` defaults replaced by errors |
| #193 | Hard capacity clamp replaced by a smooth C-infinity saturation, reported through `info[]` |
| #194 | `gamma_RE/gamma_H^p` on a stated pH scale, with the Davies range guarded rather than extrapolated |
| #195 | Extraction mechanism carried by the data and dispatched on; TBP is nitrate-driven |

Tests: **116 -> 260** in the REE suites. Full suite 1831 passed / 2 skipped.

## Three things worth a reviewer's attention

**1. #190 removes loading dependence from `D` entirely.** The issue's interim fix was "apply exactly one of the two corrections". The one kept is the correlation's `n*log10([HA]/C_ref)`, which uses a fixed parameter, so nothing in `D` now varies with stage loading; capacity is enforced solely by the smooth limiter. That follows the issue's letter, but may not be its intent. The real resolution is the mass-action closure of #196.

**2. Davies inverts sign in exactly the regime #194 is about.** The bracket `sqrt(I)/(1+sqrt(I)) - 0.3I` goes negative at **I = 1.9404 M**, so above that the raw correction *multiplies* `D` — 6.5x at 3 M, 42x at 4 M — rather than reducing it. The guard that should have caught this did not run under `jit`, under `grad`, or on a concrete array. Ionic strength fed to the model is now clamped at the validity limit unless extrapolation is requested explicitly, because a clamp is arithmetic and so holds identically for tracers, where no Python-level check can see the value.

**3. The TBP refit is an anchor, not design data.** Three defects confirmed against retrieved primary sources: `D_Dy/D_La` was 100 (measured 10.2), `D_Dy` was 3.16 (corrected 0.24), and every temperature coefficient had the wrong sign (extraction is exothermic, so `d = +2300 K`). But: only Sm's temperature coefficient is measured, Tb is interpolated, and the `a` values rest on one 2005 paper at a single nitrate level whose 6.06 M concentration was *derived* from a ppm feed table rather than reported. If that feed were nearer 3 M, the values should be ~0.9 log units higher. All of this is recorded in the YAML rather than smoothed over.

Sources used (all verified to resolve): Kraikaew et al., *J. Met. Mater. Miner.* **15**(2), 89 (2005); Topp & Weaver, ORNL-1811, doi:10.2172/4398970; Poos & Wilhelm, ISC-695, OSTI 4332475; Ganesh & Pandey, *J. Rad. Nucl. Appl.* **4**(2), 109 (2019) (printed DOI unregistered in Crossref, cited as the retrieved PDF); Jorjani & Shahbazi, doi:10.1016/j.arabjc.2012.04.002. The one paper that would settle the whole temperature series — Fidelis, *JINC* **32**, 997 (1970), doi:10.1016/0022-1902(70)80079-3 — is paywalled with no OA copy and was **not** used.

## Breaking changes

- `REEDistribution` for TBP requires `nitrate_conc`; the TBP cation-exchange opt-in raises (its `ph_coefficients` block is deleted as mechanistically unsupported)
- `LoadingIsotherm.max_loading` is a derived property, not a constructor field
- `EXTRACTANT_CAPACITIES` no longer carries `stoichiometry`/`max_loading`
- **Default `REEExtractor` results move**, because capacity is now `F_extractant/m` rather than `max_ree_conc*F_org`

## Notebooks

Four examples built their solvent with an `"Organic"` carrier matching neither extractant nor diluent, so their organic flow was silently 1.0 regardless of the total declared; `09_ree_ndfeb_magnet` declared the extractant at zero flow, which under the corrected capacity gives zero extraction. All four are repaired and execute clean. `24_custom_ree_elements` gains its outputs, having been committed output-free and, given the bug, likely never run.

## Known, not addressed here

- `tests/test_catalog.py` has 2 failures on `main` and on this branch alike, because the installed editable metadata lacks a `difflow_gas` entry point. Environment, not code; `pip install -e .` fixes it.
- `create_custom_extractant` still requires `ph_coefficients` even for a solvating mechanism, while the YAML loader now permits its absence — so a custom solvating extractant cannot be defined the way TBP now is. Documented, worth a follow-up issue.
- `D2EHPA`/`PC88A`/`Cyanex272` temperature coefficients are also negative, implying +25 to +46 kJ/mol endothermic. Genuinely contested for acidic organophosphorus extractants and no data was in hand, so **no numbers were changed** there — only a comment noting the open question.
- #196 (mass-action closure) is out of scope and was not started.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A4QHy5pYxpjuNsoJUFqSKE
