### PR TITLE
Run the distillation columns on a cubic EOS, and fix what that exposed

### DIFF
--- a/docs/thermodynamics.md
+++ b/docs/thermodynamics.md
@@ -461,7 +461,7 @@ correctly reporting a single phase, but it makes $\sum_i K_i x_i - 1$ a flat
 zero, which a root finder reads as converged wherever it is standing. A
 bubble-point solve on these K-values therefore needs to start inside the window
 and be able to retreat if a step leaves it; see the two-pass solve in
-`DistillationColumn._bubble_point_T`.
+`difflow.units.distillation._bubble_T`.
 
 With no composition at all, `CubicThermo` returns the wrapped `IdealThermo`'s
 Raoult K-values rather than the EOS's own Wilson estimate. Both are

--- a/docs/thermodynamics.md
+++ b/docs/thermodynamics.md
@@ -210,6 +210,15 @@ $$K_i = \frac{y_i}{x_i} = \frac{P_i^{sat}(T)}{P}$$
 - Ideal gas phase (fugacity coefficient = 1)
 - Valid for low pressures and similar molecules
 
+`K_values` and `K_values_array` also accept the liquid and vapor compositions
+`x` and `y` and ignore them — Raoult K-values are a function of $(T, P)$ alone.
+They are in the signature so that a unit written against this interface (the
+rigorous [`DistillationColumn`](unit-operations-chemical.md), for one) can pass
+its stage compositions unconditionally and run unchanged on a
+[`CubicThermo`](#cubic-thermo-k-values), whose K-values do depend on them.
+`IdealThermo.K_depends_on_composition` is `False` and `CubicThermo`'s is `True`,
+for callers that want to skip a composition iteration they do not need.
+
 #### Bubble Point and Dew Point
 
 ```python
@@ -411,6 +420,55 @@ print(f"Vapor composition: {y}")
    $$K_i^{new} = \frac{\phi_i^L}{\phi_i^V}$$
 
 5. **Iterate** until convergence
+
+---
+
+(cubic-thermo-k-values)=
+### CubicThermo K-Values
+
+`CubicThermo` exposes the same K-value interface as `IdealThermo`, built from
+the EOS fugacity coefficients rather than from Raoult's law:
+
+$$K_i = \frac{\hat\phi_i^L(T, P, x)}{\hat\phi_i^V(T, P, y)}$$
+
+```python
+thermo = CubicThermo(IdealThermo(sp), PengRobinson(crit))
+
+K = thermo.K_values_array(T=380.0, P=10e5, x=x, y=y)  # both compositions known
+K = thermo.K_values_array(T=380.0, P=10e5, x=x)       # bubble-point K at x
+K = thermo.K_values_array(T=380.0, P=10e5)            # no composition: Raoult
+K = thermo.K_values(T=380.0, P=10e5, x=x)             # same, as a dict
+```
+
+That is what lets a unit written against `IdealThermo`'s interface — the
+rigorous [`DistillationColumn`](unit-operations-chemical.md) — run on
+Peng-Robinson without changing the unit.
+
+Two properties of these K-values shape how they are used:
+
+**They depend on composition.** $K_i$ is a fixed point, not a formula. Pass
+whichever compositions you have; whichever you omit is filled in by a bounded
+successive substitution ($y = Kx$ renormalised, or $x = y/K$) from a
+composition-free starting estimate, which is the standard bubble- or dew-point
+K calculation. Pass both when you already have a consistent pair — that is a
+single evaluation with no inner loop.
+
+**They only exist inside the two-root window.** The EOS gives a two-phase K
+only where its cubic has two distinct roots at this $(T, P, x)$. Away from the
+bubble point — a subcooled liquid, a superheated vapor — there is one root,
+both phases take it, and $K_i$ comes back identically 1. That is the EOS
+correctly reporting a single phase, but it makes $\sum_i K_i x_i - 1$ a flat
+zero, which a root finder reads as converged wherever it is standing. A
+bubble-point solve on these K-values therefore needs to start inside the window
+and be able to retreat if a step leaves it; see the two-pass solve in
+`DistillationColumn._bubble_point_T`.
+
+With no composition at all, `CubicThermo` returns the wrapped `IdealThermo`'s
+Raoult K-values rather than the EOS's own Wilson estimate. Both are
+composition-free, but Antoine coefficients are fitted vapor-pressure data,
+while Wilson is a two-constant fit off the critical point that for a heavy
+hydrocarbon can be a hundred degrees out — far enough to start the EOS
+iteration outside the window.
 
 ---
 

--- a/docs/unit-operations-chemical.md
+++ b/docs/unit-operations-chemical.md
@@ -679,6 +679,22 @@ $$\alpha_{ij} = \frac{K_i}{K_j} = \frac{P_i^{sat}}{P_j^{sat}}$$
 
 $$\bar{\alpha} = (\alpha_{top} \cdot \alpha_{bottom})^{0.5}$$
 
+The two ends are the column's actual ends, not estimates around the feed: the
+top is a total condenser, so $T_{top}$ is the **bubble point of the
+distillate**, and $T_{bot}$ is the **bubble point of the bottoms** in the
+reboiler. Those are the temperatures the product streams come out at, reported
+as `info["T_condenser"]` and `info["T_reboiler"]`.
+
+They also make the design a small fixed point, since $\bar\alpha$ sets the
+product split through Hengstebeck-Geddes and the split sets the bubble points
+in turn. The column sweeps it a few times from the feed's own bubble point;
+it settles to under a hundredth of a degree by the third sweep, and the whole
+loop is unrolled, so `jax.grad` runs through it.
+
+Two consequences worth knowing, because the old estimate had neither: the end
+temperatures no longer move when you feed the same mixture in hotter, and they
+do move with column pressure.
+
 **Fenske Equation** (minimum stages):
 
 $$N_{min} = \frac{\ln\left[\frac{x_{D,LK}}{x_{B,LK}} \cdot \frac{x_{B,HK}}{x_{D,HK}}\right]}{\ln \bar{\alpha}_{LK/HK}}$$
@@ -709,8 +725,10 @@ $$\frac{N_R}{N_S} = \left[\frac{B}{D} \cdot \frac{x_{F,HK}}{x_{F,LK}} \cdot \lef
 
 | Parameter | Type | Units | Description |
 |-----------|------|-------|-------------|
-| `distillate` | Stream | - | Overhead product |
-| `bottoms` | Stream | - | Bottom product |
+| `distillate` | Stream | - | Overhead product, at the condenser temperature |
+| `bottoms` | Stream | - | Bottom product, at the reboiler temperature |
+| `info['T_condenser']` | float | K | Condenser temperature = bubble point of $x_D$ (also `T_top`) |
+| `info['T_reboiler']` | float | K | Reboiler temperature = bubble point of $x_B$ (also `T_bot`) |
 | `info['N_min']` | float | - | Minimum stages |
 | `info['N_actual']` | float | - | Actual stages |
 | `info['R_min']` | float | - | Minimum reflux ratio |
@@ -870,6 +888,16 @@ Two things about the EOS path are worth knowing:
   land inside the two-root window, then a step-capped Newton on the EOS
   K-values that bisects back if a step leaves it. Nothing about this is visible
   in the API, but it is why the bubble point is not one `optimistix` call.
+
+The ideal pass is itself in two parts, for a reason that has nothing to do with
+the EOS. Vapor pressure is exponential in $-1/T$, so a couple of hundred degrees
+below the bubble point both $\sum_i K_i x_i$ and its slope are round-off away
+from zero, and a Newton step there divides one tiny number by another and lands
+tens of thousands of degrees away. So the solve first takes a few damped steps
+on $\log \sum_i K_i x_i$ -- nearly linear in $1/T$, and well scaled over the
+whole range -- and only then runs Newton on the residual itself. This is why a
+column can be handed a feed far below its own boiling point and still find its
+ends.
 
 ---
 

--- a/docs/unit-operations-chemical.md
+++ b/docs/unit-operations-chemical.md
@@ -799,6 +799,28 @@ $$\sum_i y_{i,j} = 1$$
 **Enthalpy Balance**:
 $$L_{j-1} H^L_{j-1} + V_{j+1} H^V_{j+1} + F_j H^F_j = L_j H^L_j + V_j H^V_j + Q_j$$
 
+#### Product temperatures
+
+The bottoms leaves the reboiler, which is a stage, so it is at
+`info["T_profile"][0]`. The distillate does not leave a stage — it leaves the
+condenser. A total condenser condenses the whole of the top stage's vapor, so
+the distillate (and the reflux returned with it) is a **saturated liquid of
+composition $x_D$ at its own bubble point**, reported as `info["T_condenser"]`.
+
+That is not the top stage temperature. The top stage sits at the bubble point
+of its liquid $x_{top}$, equivalently the dew point of the vapor $y_{top} = x_D$
+it sends up, and a mixture's dew point is above its bubble point. The gap is
+the boiling range of the distillate itself:
+
+| distillate | top stage $T$ | condenser $T$ | gap |
+|---|---|---|---|
+| 99.6 % benzene / toluene, 1 atm | 369.1 K | 368.7 K | 0.3 K |
+| C3-C8 cut, 10 bar (Peng-Robinson) | 401.7 K | 363.3 K | 38 K |
+
+The same distinction runs through the energy balance: $Q_{cond}$ takes the top
+stage vapor down to that condensed state, and the reflux re-enters the top
+stage subcooled, at the condenser temperature rather than the tray's.
+
 #### Thermodynamics: ideal K-values or a cubic EOS
 
 The column takes either an `IdealThermo` or a

--- a/docs/unit-operations-chemical.md
+++ b/docs/unit-operations-chemical.md
@@ -799,6 +799,56 @@ $$\sum_i y_{i,j} = 1$$
 **Enthalpy Balance**:
 $$L_{j-1} H^L_{j-1} + V_{j+1} H^V_{j+1} + F_j H^F_j = L_j H^L_j + V_j H^V_j + Q_j$$
 
+#### Thermodynamics: ideal K-values or a cubic EOS
+
+The column takes either an `IdealThermo` or a
+[`CubicThermo`](thermodynamics.md), and the choice is the whole of the
+difference between a near-ideal separation and a hydrocarbon one:
+
+| | `IdealThermo` | `CubicThermo` |
+|---|---|---|
+| $K_i$ | $P^{sat}_i(T)/P$ (Raoult) | $\hat\phi^L_i(T,P,x)\,/\,\hat\phi^V_i(T,P,y)$ (PR or SRK) |
+| stage enthalpy | ideal-gas $C_p$ + Watson $H_{vap}$ | ideal-gas $C_p$ + EOS departure |
+| $K_i$ depends on composition | no | yes |
+
+```python
+from difflow import IdealThermo, CubicThermo, PengRobinson
+from difflow.database import get_critical_props, get_species_data
+from difflow.units.distillation import DistillationColumn, DistillationColumnParams
+
+names = ["propane", "isobutane", "n_butane", "isopentane",
+         "n_pentane", "n_hexane", "n_heptane", "n_octane"]
+ideal = IdealThermo({s: get_species_data(s) for s in names})
+eos = PengRobinson({s: get_critical_props(s) for s in names})
+
+column = DistillationColumn(
+    DistillationColumnParams(species_order=names, n_stages=20, feed_stage=10,
+                             condenser_type="total", P=10e5),
+    thermo=CubicThermo(ideal, eos),      # Peng-Robinson K-values and enthalpies
+)
+distillate, bottoms, info = column(feed, R=2.0, B_spec=40.0)
+```
+
+Use the EOS for light hydrocarbons at pressure. Raoult's law fails there in a
+one-sided way: a C3-C8 cut at 10 bar puts its heavy end within a degree of the
+EOS answer and its light end tens of degrees off, so an ideal-K column looks
+plausible at the reboiler and is wrong at the condenser.
+
+Two things about the EOS path are worth knowing:
+
+- **The K-values depend on composition**, so they are a fixed point rather than
+  a formula. `CubicThermo.K_values_array(T, P, x)` runs a short successive
+  substitution on $y$ internally to close it at the stage's own composition;
+  pass both `x` and `y` if you already have a consistent pair.
+- **They only exist where the cubic has two roots.** Away from the bubble point
+  -- a subcooled liquid, a superheated vapor -- there is one root, both phases
+  take it, and $K_i$ comes back identically 1. That is the EOS reporting a
+  single phase, but it makes $\sum_i K_i x_i - 1$ flat, so the column solves
+  each stage's bubble point in two passes: a Newton solve on ideal K-values to
+  land inside the two-root window, then a step-capped Newton on the EOS
+  K-values that bisects back if a step leaves it. Nothing about this is visible
+  in the API, but it is why the bubble point is not one `optimistix` call.
+
 ---
 
 ## Heat Exchangers

--- a/docs/unit-operations-chemical.md
+++ b/docs/unit-operations-chemical.md
@@ -662,18 +662,34 @@ Shortcut methods are used for:
 ```python
 @dataclass
 class ShortcutColumnParams:
-    light_key: int         # Index of light key component
-    heavy_key: int         # Index of heavy key component
-    x_D_lk: float         # Light key recovery in distillate
-    x_B_hk: float         # Heavy key recovery in bottoms
-    reflux_ratio: float   # Actual reflux ratio (R/R_min multiplier)
+    species_order: list[str]   # Species names; sets array ordering
+    light_key: str             # Name of the light key component
+    heavy_key: str             # Name of the heavy key component
+    x_D_LK: float = 0.99       # Fractional recovery of LK in the distillate
+    x_B_HK: float = 0.99       # Fractional recovery of HK in the bottoms
+```
+
+`x_D_LK` and `x_B_HK` are **recoveries**, not mole fractions, despite the
+names: `x_D_LK=0.99` sends 99 % of the feed's light key overhead. The
+distillate's actual light-key mole fraction comes back in `info["x_D"]`.
+
+The reflux ratio is not a parameter — it is an argument to the call, along with
+the column pressure and the feed quality:
+
+```python
+distillate, bottoms, info = column(feed, R=3.0, P=101325.0, q=1.0)
 ```
 
 #### Governing Equations
 
 **Relative Volatility**:
 
-$$\alpha_{ij} = \frac{K_i}{K_j} = \frac{P_i^{sat}}{P_j^{sat}}$$
+$$\alpha_{ij} = \frac{K_i}{K_j}$$
+
+The second equality usually written here, $\alpha_{ij} = P_i^{sat}/P_j^{sat}$,
+holds only under Raoult's law. On a `CubicThermo` the K-values are fugacity
+coefficient ratios and the vapor pressures cancel out of nothing — which is the
+whole reason the volatilities differ between the two packages.
 
 **Average Relative Volatility** (geometric mean):
 
@@ -723,59 +739,89 @@ $$\frac{N_R}{N_S} = \left[\frac{B}{D} \cdot \frac{x_{F,HK}}{x_{F,LK}} \cdot \lef
 
 #### Outputs
 
-| Parameter | Type | Units | Description |
-|-----------|------|-------|-------------|
+| Key | Type | Units | Description |
+|-----|------|-------|-------------|
 | `distillate` | Stream | - | Overhead product, at the condenser temperature |
 | `bottoms` | Stream | - | Bottom product, at the reboiler temperature |
-| `info['T_condenser']` | float | K | Condenser temperature = bubble point of $x_D$ (also `T_top`) |
-| `info['T_reboiler']` | float | K | Reboiler temperature = bubble point of $x_B$ (also `T_bot`) |
-| `info['N_min']` | float | - | Minimum stages |
-| `info['N_actual']` | float | - | Actual stages |
-| `info['R_min']` | float | - | Minimum reflux ratio |
-| `info['feed_stage']` | int | - | Optimal feed stage |
-| `info['condenser_duty']` | float | W | Condenser heat duty |
-| `info['reboiler_duty']` | float | W | Reboiler heat duty |
+| `info['N_min']` | float | - | Minimum stages (Fenske) |
+| `info['R_min']` | float | - | Minimum reflux ratio (Underwood) |
+| `info['N']` | float | - | Actual stages (Gilliland) |
+| `info['N_feed']` | float | - | Feed stage (Kirkbride) |
+| `info['D']`, `info['B']` | float | mol/s | Distillate and bottoms flow |
+| `info['x_D']`, `info['x_B']` | dict | - | Product compositions by species |
+| `info['T_condenser']` / `info['T_top']` | float | K | Condenser temperature = bubble point of $x_D$ |
+| `info['T_reboiler']` / `info['T_bot']` | float | K | Reboiler temperature = bubble point of $x_B$ |
+| `info['Q_condenser']` | float | W | Condenser duty (negative: heat removed) |
+| `info['Q_reboiler']` | float | W | Reboiler duty (positive: heat added) |
+| `info['alpha']` | dict | - | Relative volatilities vs the heavy key |
+| `info['alpha_LK']` | float | - | Light key's relative volatility |
+| `info['alpha_top']`, `info['alpha_bot']` | dict | - | Volatilities at each column end |
+| `info['alpha_variation']` | dict | - | Relative spread between the two ends |
+| `info['alpha_varies_significantly']` | bool | - | True if that spread exceeds 0.3 |
+| `info['theta']` | float | - | Underwood root |
+| `info['close_boiling']` | bool | - | True if $\bar\alpha \approx 1$ capped $N_{min}$ |
+| `info['near_min_reflux']` | bool | - | True if $R \approx R_{min}$ |
+| `info['negative_flows_detected']` | bool | - | True if the split produced a negative flow |
+| `info['feasible']` | bool | - | All three checks above passed |
 
 #### Example Usage
 
 ```python
+from difflow import IdealThermo, make_stream
+from difflow.database import get_species_data
 from difflow.units.distillation import ShortcutColumn, ShortcutColumnParams
 
+names = ['benzene', 'toluene', 'ethylbenzene']
+thermo = IdealThermo({s: get_species_data(s) for s in names})
+
 params = ShortcutColumnParams(
-    light_key=0,    # benzene
-    heavy_key=1,    # toluene
-    x_D_lk=0.99,    # 99% benzene recovery in distillate
-    x_B_hk=0.99,    # 99% toluene recovery in bottoms
-    reflux_ratio=1.3  # 1.3 × R_min
+    species_order=names,
+    light_key='benzene',
+    heavy_key='toluene',
+    x_D_LK=0.99,    # 99 % of the benzene recovered overhead
+    x_B_HK=0.99,    # 99 % of the toluene recovered in the bottoms
 )
 
-column = ShortcutColumn(params, thermo, species_order=['benzene', 'toluene', 'xylene'])
-feed = make_stream({'benzene': 0.4, 'toluene': 0.35, 'xylene': 0.25}, T=370.0, P=101325.0)
+column = ShortcutColumn(params, thermo)
+feed = make_stream({'benzene': 40.0, 'toluene': 35.0, 'ethylbenzene': 25.0},
+                   T=370.0, P=101325.0)
 
-distillate, bottoms, info = column(feed)
-print(f"Minimum stages: {info['N_min']:.1f}")
-print(f"Actual stages: {info['N_actual']:.1f}")
-print(f"Condenser duty: {info['condenser_duty']/1e6:.2f} MW")
+distillate, bottoms, info = column(feed, R=3.0, P=101325.0, q=1.0)
+print(f"Minimum stages:  {float(info['N_min']):.1f}")
+print(f"Minimum reflux:  {float(info['R_min']):.2f}")
+print(f"Actual stages:   {float(info['N']):.1f}")
+print(f"Feed stage:      {float(info['N_feed']):.1f}")
+print(f"Condenser:       {float(info['T_condenser']):.1f} K, "
+      f"{float(info['Q_condenser'])/1e6:.2f} MW")
+print(f"Reboiler:        {float(info['T_reboiler']):.1f} K, "
+      f"{float(info['Q_reboiler'])/1e6:.2f} MW")
 ```
 
 #### Utility Functions
 
+The design correlations are also available on their own, taking plain numbers
+rather than a column object. Note the argument order — each takes the
+quantities in the order the correlation is written, not the order the column
+computes them:
+
 ```python
 from difflow.units.distillation import (
-    relative_volatility,
-    fenske_stages,
-    minimum_reflux_ratio,
-    gilliland_stages,
-    column_diameter
+    fenske_stages,        # (x_D_LK, x_B_LK, alpha)
+    minimum_reflux_ratio, # (z_LK, z_HK, x_D_LK, alpha, q=1.0)
+    gilliland_stages,     # (R, R_min, N_min)
+    column_diameter,      # (V, rho_V, rho_L, sigma=0.02, tray_spacing=0.6)
 )
 
-# Calculate individual parameters
-alpha = relative_volatility(thermo, T=373.0, P=101325.0)
-N_min = fenske_stages(x_D, x_B, alpha)
-R_min = minimum_reflux_ratio(alpha, x_F, x_D, q=1.0)
-N = gilliland_stages(N_min, R, R_min)
-D = column_diameter(V_max, rho_V, rho_L, sigma)
+N_min = fenske_stages(x_D_LK=0.98, x_B_LK=0.02, alpha=2.4)
+R_min = minimum_reflux_ratio(z_LK=0.45, z_HK=0.55, x_D_LK=0.98, alpha=2.4, q=1.0)
+N = gilliland_stages(R=1.3 * R_min, R_min=R_min, N_min=N_min)
+diameter = column_diameter(V=50.0, rho_V=3.0, rho_L=800.0)   # mol/s, kg/m^3
 ```
+
+Relative volatility is a method on the column, not a free function
+(`column.relative_volatility(T, P, x=None)`), because it needs the key
+components from the column's parameters — and, on a `CubicThermo`, the phase
+composition.
 
 ---
 
@@ -792,12 +838,32 @@ D = column_diameter(V_max, rho_V, rho_L, sigma)
 ```python
 @dataclass
 class DistillationColumnParams:
-    n_stages: int          # Number of theoretical stages
-    feed_stage: int        # Feed stage number (from top)
-    reflux_ratio: float    # Reflux ratio (L/D)
-    condenser_type: str    # 'total' or 'partial'
-    P_top: float           # Top pressure (Pa)
-    P_bottom: float        # Bottom pressure (Pa)
+    species_order: list[str]     # Species names; sets array ordering
+    n_stages: int                # Equilibrium stages: the trays plus the reboiler
+    feed_stage: int              # Zero-based stage index from the bottom
+    condenser_type: str = 'total'  # Only 'total' is implemented
+    P: float = 101325.0          # One pressure for the whole column
+    q: float = 1.0               # Feed quality (1 = saturated liquid)
+```
+
+**Stage numbering is zero-based from the bottom**: stage 0 is the reboiler,
+stage `n_stages - 1` is the top tray, and every profile in `info` is in that
+order. The condenser is *not* a stage — it sits outside the cascade — so
+`n_stages` counts the trays plus the reboiler, and `feed_stage=10` in a
+20-stage column puts the feed halfway up. Stages below the feed stage are the
+stripping section and stages above it the rectifying section; the boundary
+stage itself is counted on different sides by the CMO sweep and the MESH flow
+initialisation, so do not read anything into it. There is one column pressure:
+no tray pressure drop.
+
+`condenser_type='partial'` raises `NotImplementedError` rather than being
+silently solved as a total condenser.
+
+The reflux ratio and the product split are arguments to the call, not
+parameters — give exactly one of `D_spec` or `B_spec`:
+
+```python
+distillate, bottoms, info = column(feed, R=2.0, B_spec=40.0)
 ```
 
 #### Governing Equations (MESH)
@@ -852,7 +918,7 @@ difference between a near-ideal separation and a hydrocarbon one:
 | $K_i$ depends on composition | no | yes |
 
 ```python
-from difflow import IdealThermo, CubicThermo, PengRobinson
+from difflow import IdealThermo, CubicThermo, PengRobinson, make_stream
 from difflow.database import get_critical_props, get_species_data
 from difflow.units.distillation import DistillationColumn, DistillationColumnParams
 
@@ -865,6 +931,10 @@ column = DistillationColumn(
     DistillationColumnParams(species_order=names, n_stages=20, feed_stage=10,
                              condenser_type="total", P=10e5),
     thermo=CubicThermo(ideal, eos),      # Peng-Robinson K-values and enthalpies
+)
+feed = make_stream(
+    dict(zip(names, [10.0, 7.0, 7.0, 8.0, 8.0, 20.0, 10.0, 30.0])),
+    T=380.0, P=10e5,
 )
 distillate, bottoms, info = column(feed, R=2.0, B_spec=40.0)
 ```
@@ -898,6 +968,58 @@ on $\log \sum_i K_i x_i$ -- nearly linear in $1/T$, and well scaled over the
 whole range -- and only then runs Newton on the residual itself. This is why a
 column can be handed a feed far below its own boiling point and still find its
 ends.
+
+#### Outputs
+
+| Key | Type | Units | Description |
+|-----|------|-------|-------------|
+| `distillate` | Stream | - | Overhead product, at the condenser temperature |
+| `bottoms` | Stream | - | Bottom product, at the reboiler temperature |
+| `info['T_profile']` | (n,) array | K | Stage temperatures, reboiler first |
+| `info['x_profile']` | (n, nc) array | - | Liquid compositions per stage |
+| `info['y_profile']` | (n, nc) array | - | Vapor compositions per stage |
+| `info['T_condenser']` | float | K | Condenser temperature = distillate T |
+| `info['T_reboiler']` | float | K | Reboiler temperature = bottoms T = `T_profile[0]` |
+| `info['D']`, `info['B']` | float | mol/s | Distillate and bottoms flow |
+| `info['Q_condenser']` | float | W | Condenser duty (negative: heat removed) |
+| `info['Q_reboiler']` | float | W | Reboiler duty (positive: heat added) |
+| `info['L_profile']`, `info['V_profile']` | (n,) array | mol/s | Internal flows — `use_mesh=True` only |
+| `info['L_rect']`, `info['V_rect']` | float | mol/s | Rectifying flows — `use_mesh=False` only |
+
+#### Example Usage
+
+```python
+from difflow import IdealThermo, make_stream
+from difflow.database import get_species_data
+from difflow.units.distillation import DistillationColumn, DistillationColumnParams
+
+names = ['n_pentane', 'n_hexane', 'n_heptane']
+thermo = IdealThermo({s: get_species_data(s) for s in names})
+
+column = DistillationColumn(
+    DistillationColumnParams(
+        species_order=names,
+        n_stages=20,      # 19 trays plus the reboiler
+        feed_stage=10,    # halfway up, counting from the reboiler at 0
+        P=101325.0,
+    ),
+    thermo=thermo,
+)
+
+feed = make_stream({'n_pentane': 30.0, 'n_hexane': 40.0, 'n_heptane': 30.0},
+                   T=360.0, P=101325.0)
+
+distillate, bottoms, info = column(feed, R=2.0, B_spec=40.0)
+print(f"Distillate: {float(distillate['T']):.1f} K, "
+      f"{float(distillate['F_n_pentane']):.1f} mol/s n-pentane")
+print(f"Bottoms:    {float(bottoms['T']):.1f} K, "
+      f"{float(bottoms['F_n_heptane']):.1f} mol/s n-heptane")
+print(f"Duties:     {float(info['Q_condenser'])/1e6:.2f} / "
+      f"{float(info['Q_reboiler'])/1e6:.2f} MW")
+```
+
+Pass `use_mesh=False` for the faster constant-molar-overflow solution, which
+skips the energy-balance correction to the internal flows.
 
 ---
 

--- a/src/difflow/constants.py
+++ b/src/difflow/constants.py
@@ -62,8 +62,11 @@ CR_BLEND_WIDTH = 0.05
 # Smaller = sharper transitions, larger = smoother gradients
 PHASE_TRANSITION_WIDTH = 0.02
 
-# Temperature profile scaling for distillation
-# Column ΔT ≈ TEMP_SCALE_FACTOR * T_feed for typical systems
+# Temperature profile scaling for distillation.
+# Column ΔT ≈ DEFAULT_TEMP_SCALE * T_feed for typical systems. No longer used
+# by ShortcutColumn, which now takes its column-end temperatures from the
+# product bubble points rather than from a spread around the feed; kept as a
+# rough ΔT for callers that want one.
 DEFAULT_TEMP_SCALE = 0.05
 
 

--- a/src/difflow/thermo.py
+++ b/src/difflow/thermo.py
@@ -326,16 +326,30 @@ class IdealThermo:
         Psat = self.Psat(species, T)
         return Psat / jnp.asarray(P)
 
+    #: Raoult K-values are a function of (T, P) alone. Callers that solve a
+    #: composition fixed point (a column's MESH loop, a flash) read this to
+    #: skip the composition iteration entirely; see
+    #: :attr:`CubicThermo.K_depends_on_composition` for the other case.
+    K_depends_on_composition = False
+
     def K_values(
         self,
         T: Array | float,
         P: Array | float,
+        x: Array | None = None,
+        y: Array | None = None,
     ) -> dict[str, Array]:
         """Calculate K-values for all species.
 
         Args:
             T: Temperature (K)
             P: Pressure (Pa)
+            x: Liquid mole fractions. Ignored -- Raoult K-values are
+               composition independent. Accepted only so IdealThermo is
+               call-compatible with CubicThermo (whose K-values come from
+               fugacity coefficients and do depend on composition), letting
+               callers pass the phase compositions unconditionally.
+            y: Vapor mole fractions. Ignored, as for ``x``.
 
         Returns:
             Dictionary of K-values by species name
@@ -349,12 +363,16 @@ class IdealThermo:
         self,
         T: Array | float,
         P: Array | float,
+        x: Array | None = None,
+        y: Array | None = None,
     ) -> Array:
         """Calculate K-values as an array in species order.
 
         Args:
             T: Temperature (K)
             P: Pressure (Pa)
+            x: Liquid mole fractions. Ignored (see :meth:`K_values`).
+            y: Vapor mole fractions. Ignored (see :meth:`K_values`).
 
         Returns:
             Array of K-values in species_order
@@ -480,6 +498,137 @@ class CubicThermo:
         Cp therefore does not need to appear here.
         """
         return self.ideal.Cp_mix(mole_fracs, T)
+
+    # ------------------------------------------------------------------
+    # VLE K-values
+    # ------------------------------------------------------------------
+
+    #: EOS K-values are ratios of fugacity coefficients, so they depend on the
+    #: liquid and vapor compositions as well as on (T, P). Callers solve that
+    #: fixed point in their own outer loop; see :meth:`K_values_array`.
+    K_depends_on_composition = True
+
+    def K_values_array(
+        self,
+        T: Array | float,
+        P: Array | float,
+        x: Array | None = None,
+        y: Array | None = None,
+        n_inner: int = 3,
+    ) -> Array:
+        """EOS K-values as an array in species order.
+
+        The rigorous VLE ratio built from the EOS fugacity coefficients::
+
+            K_i = phi_i^L(T, P, x) / phi_i^V(T, P, y)
+
+        This is the same K-value :class:`~difflow.eos.PengRobinson` uses in its
+        own flash, exposed under ``IdealThermo``'s interface so that units
+        written against ``K_values_array`` (the rigorous ``DistillationColumn``,
+        for one) run on a cubic EOS instead of Raoult's law. For light
+        hydrocarbons at pressure that is not a small correction: the difference
+        shows up as tens of degrees in a condenser temperature.
+
+        Unlike Raoult K-values these depend on the phase compositions, so they
+        are a fixed point rather than a closed form. Pass whichever
+        compositions you have; whatever is missing is filled in by a bounded
+        successive substitution from a composition-free estimate, which is the
+        standard bubble- or dew-point K calculation.
+
+        Note the trivial solution. The EOS gives a two-phase K only over the
+        temperature window where its cubic has two distinct roots for this
+        (T, P, composition). Outside that window -- a subcooled liquid, a
+        superheated vapor -- there is one root, both phases take it, and K
+        comes back identically 1. That is the EOS reporting a single phase, but
+        it makes ``sum(K x) - 1`` a flat zero, so a bubble-point solve built on
+        this method needs an initial temperature inside the window and a step
+        that can retreat when it leaves (see
+        ``DistillationColumn._bubble_point_T``).
+
+        Args:
+            T: Temperature (K).
+            P: Pressure (Pa).
+            x: Liquid mole fractions in species order. If None it is taken
+               from ``y`` and the current K-values (``x = y / K``).
+            y: Vapor mole fractions in species order. If None it is taken from
+               ``x`` and the current K-values (``y = K x``) -- the bubble-point
+               K at composition ``x``, which is what a column stage wants.
+            n_inner: Successive-substitution steps used to fill in a missing
+               composition. Ignored when both ``x`` and ``y`` are given.
+
+        Returns:
+            Array of K-values in the EOS's species order (``eos.species_order``),
+            which is also the order ``x`` and ``y`` are read in.
+
+        Example:
+            >>> thermo = CubicThermo(ideal, PengRobinson(props))
+            >>> K = thermo.K_values_array(300.0, 10e5, x=x, y=y)
+        """
+        T = jnp.asarray(T)
+        P = jnp.asarray(P)
+
+        def _norm(v: Array) -> Array:
+            v = jnp.maximum(jnp.asarray(v), 0.0)
+            return v / jnp.maximum(jnp.sum(v), 1e-30)
+
+        if x is None and y is None:
+            # No composition to build a fugacity coefficient from. Fall back on
+            # the wrapped ideal model's Raoult K-values rather than the EOS's
+            # own Wilson correlation: both are composition-free estimates, but
+            # Antoine coefficients are fitted vapor-pressure data while Wilson
+            # is a two-constant fit off the critical point, and for the heavy
+            # ends of a hydrocarbon cut Wilson is far enough out to land a
+            # subsequent EOS iteration outside the temperature window where the
+            # cubic has two roots at all (outside it the liquid and vapor roots
+            # coincide and K collapses identically to 1).
+            return self.ideal.K_values_array(T, P)
+
+        # The successive substitutions below start from Wilson, as the EOS's
+        # own flash does. Its job here is only to be in the basin of a
+        # contraction that converges in two or three steps, which is a much
+        # weaker requirement than the one that ruled it out above.
+        if x is None:
+            y = _norm(y)
+            K = self.eos.K_values_wilson(T, P)
+            for _ in range(n_inner):
+                K = self.eos.K_values(T, P, _norm(y / jnp.maximum(K, 1e-30)), y)
+            return K
+
+        x = _norm(x)
+
+        if y is None:
+            K = self.eos.K_values_wilson(T, P)
+            for _ in range(n_inner):
+                K = self.eos.K_values(T, P, x, _norm(K * x))
+            return K
+
+        return self.eos.K_values(T, P, x, _norm(y))
+
+    def K_values(
+        self,
+        T: Array | float,
+        P: Array | float,
+        x: Array | None = None,
+        y: Array | None = None,
+        n_inner: int = 3,
+    ) -> dict[str, Array]:
+        """EOS K-values for all species, keyed by species name.
+
+        The dictionary form of :meth:`K_values_array`; see it for the meaning
+        of ``x``, ``y`` and ``n_inner``.
+
+        Args:
+            T: Temperature (K).
+            P: Pressure (Pa).
+            x: Liquid mole fractions in species order (optional).
+            y: Vapor mole fractions in species order (optional).
+            n_inner: Successive-substitution steps for a missing composition.
+
+        Returns:
+            Dictionary of K-values by species name.
+        """
+        K = self.K_values_array(T, P, x, y, n_inner)
+        return {s: K[i] for i, s in enumerate(self.eos.species_order)}
 
     def stream_enthalpy(
         self,

--- a/src/difflow/thermo.py
+++ b/src/difflow/thermo.py
@@ -543,7 +543,7 @@ class CubicThermo:
         it makes ``sum(K x) - 1`` a flat zero, so a bubble-point solve built on
         this method needs an initial temperature inside the window and a step
         that can retreat when it leaves (see
-        ``DistillationColumn._bubble_point_T``).
+        ``difflow.units.distillation._bubble_T``).
 
         Args:
             T: Temperature (K).

--- a/src/difflow/units/distillation.py
+++ b/src/difflow/units/distillation.py
@@ -813,6 +813,37 @@ class DistillationColumn:
 
         return T, y
 
+    def _condenser_T(
+        self,
+        x_D: Array,
+        P: Array,
+        T_guess: Array | None = None,
+    ) -> Array:
+        """Temperature of a total condenser's outlet (K).
+
+        A total condenser condenses the whole of the top stage's vapor, so its
+        outlet -- the distillate, and the reflux returned to the top stage --
+        is a saturated liquid of composition ``x_D`` at the column pressure.
+        Its temperature is therefore the bubble point of ``x_D``, which is
+        **not** the top stage temperature: the top stage sits at the bubble
+        point of its own liquid ``x_top``, equivalently the dew point of the
+        vapor ``y_top = x_D`` it sends to the condenser, and a mixture's dew
+        point is above its bubble point. The gap is the width of the cut --
+        small for a sharp binary split, tens of degrees for a wide-boiling
+        multicomponent distillate.
+
+        Args:
+            x_D: Distillate mole fractions (= the top stage vapor, for a total
+                condenser).
+            P: Column pressure (Pa).
+            T_guess: Initial temperature guess (K); the top stage temperature
+                is a reasonable one, being an upper bound.
+
+        Returns:
+            Condenser temperature (K).
+        """
+        return self._bubble_point_T(x_D, P, T_guess=T_guess)[0]
+
     def _solve_constant_molar_overflow(
         self,
         feed_flows: dict[str, Array],
@@ -1032,6 +1063,7 @@ class DistillationColumn:
         B: Array,
         V_top: Array | None = None,
         V_bot: Array | None = None,
+        T_condenser: Array | None = None,
     ) -> tuple[Array, Array]:
         """Compute condenser and reboiler duties including latent heat.
 
@@ -1041,8 +1073,12 @@ class DistillationColumn:
         calculations.
 
         For total condenser:
-            Q_cond = V_top * (H_vapor_top - h_liquid_top)
-            where H_vapor includes latent heat of vaporization.
+            Q_cond = V_top * (h_D - H_vapor_top)
+            where H_vapor_top is the top stage vapor (latent heat included)
+            and h_D is the condensed product: the same composition as that
+            vapor, as a saturated liquid at the condenser temperature (see
+            :meth:`_condenser_T`), not the top stage liquid at the top stage
+            temperature.
 
         For reboiler (from overall energy balance):
             Q_reb = D * h_D + B * h_B - F * h_F + Q_cond
@@ -1059,14 +1095,20 @@ class DistillationColumn:
             B: Bottoms flow rate (mol/s)
             V_top: Vapor flow leaving top stage (mol/s).
                    If None, uses (R+1)*D (CMO assumption).
-            V_bot: Vapor flow leaving bottom stage (mol/s).
-                   If None, uses (R+1)*D (CMO assumption).
+            V_bot: Vapor flow leaving bottom stage (mol/s). Not used: the
+                   reboiler duty comes from the overall energy balance, which
+                   never needs it. Accepted so callers can pass the profile
+                   they have.
+            T_condenser: Condenser temperature (K). If None it is computed
+                   here as the bubble point of the distillate; pass it when
+                   the caller has already solved for it.
 
         Returns:
             Q_condenser: Condenser duty (J/s, negative = heat removed)
             Q_reboiler: Reboiler duty (J/s, positive = heat added)
         """
         p = self.params
+        P = jnp.asarray(p.P)
 
         # Compute stage enthalpies (includes latent heat for vapor)
         h_all, H_all = self._compute_stage_enthalpies(
@@ -1075,26 +1117,27 @@ class DistillationColumn:
 
         # Top stage enthalpies
         H_vapor_top = H_all[-1]   # Vapor enthalpy at top (includes Hvap)
-        h_liquid_top = h_all[-1]  # Liquid enthalpy at top
 
         # Bottom stage enthalpies
-        H_vapor_bot = H_all[0]    # Vapor enthalpy at bottom (includes Hvap)
         h_liquid_bot = h_all[0]   # Liquid enthalpy at bottom
 
         # Vapor flows (use provided or CMO estimates)
         V_top_flow = V_top if V_top is not None else (R + 1) * D
-        V_bot_flow = V_bot if V_bot is not None else (R + 1) * D
 
-        # Condenser duty: condense all vapor from top stage to liquid
-        # Q_cond = V_top * (h_liquid_top - H_vapor_top) < 0 (heat removed)
-        Q_condenser = V_top_flow * (h_liquid_top - H_vapor_top)
+        # The condensed product: the top stage vapor, as a saturated liquid at
+        # the condenser's own temperature.
+        x_D = y_profile[-1]
+        if T_condenser is None:
+            T_condenser = self._condenser_T(x_D, P, T_guess=T_profile[-1])
+        h_D = self._molar_enthalpy(x_D, T_condenser, 'liquid')
+
+        # Condenser duty: condense all vapor from the top stage to liquid
+        # Q_cond = V_top * (h_D - H_vapor_top) < 0 (heat removed)
+        Q_condenser = V_top_flow * (h_D - H_vapor_top)
 
         # Feed enthalpy (saturated liquid, q=1)
         z_arr = jnp.array([z[s] for s in p.species_order])
         h_F = self._molar_enthalpy(z_arr, jnp.asarray(T_feed), 'liquid')
-
-        # Distillate enthalpy (liquid at top T for total condenser)
-        h_D = h_liquid_top
 
         # Bottoms enthalpy (liquid at bottom T)
         h_B = h_liquid_bot
@@ -1289,8 +1332,14 @@ class DistillationColumn:
             # Feed enthalpy (saturated liquid, q=1)
             h_F = self._molar_enthalpy(z, jnp.asarray(T_feed), 'liquid')
 
-            # Reflux enthalpy (total condenser: liquid at top stage T)
-            h_reflux = self._molar_enthalpy(y_new[-1], T_new[-1], 'liquid')
+            # Reflux enthalpy. A total condenser returns saturated liquid of
+            # the distillate's composition at the condenser temperature, which
+            # is below the top stage temperature -- so the reflux enters the
+            # top stage subcooled, and the top stage has to boil some of it.
+            # Evaluating it at the top stage temperature instead would credit
+            # the balance with heat the condenser has already removed.
+            T_cond = self._condenser_T(y_new[-1], P, T_guess=T_new[-1])
+            h_reflux = self._molar_enthalpy(y_new[-1], T_cond, 'liquid')
 
             # Top-down energy balance sweep from stage n-1 down to stage 1
             def eb_step(carry, stage_j):
@@ -1378,12 +1427,16 @@ class DistillationColumn:
             mesh_iter: Number of MESH iterations when use_mesh=True.
 
         Returns:
-            distillate: Distillate stream
-            bottoms: Bottoms stream
+            distillate: Distillate stream, at the condenser temperature --
+                the bubble point of the distillate, which is below the top
+                stage temperature (see :meth:`_condenser_T`)
+            bottoms: Bottoms stream, at the reboiler temperature
             info: Dictionary with:
                 - 'T_profile': Stage temperatures
                 - 'x_profile': Liquid composition profiles
                 - 'y_profile': Vapor composition profiles
+                - 'T_condenser': Condenser temperature (K), = distillate T
+                - 'T_reboiler': Reboiler temperature (K), = bottoms T
                 - 'L_rect': Rectifying liquid flow rate (CMO) or 'L_profile'
                 - 'V_rect': Rectifying vapor flow rate (CMO) or 'V_profile'
                 - 'D': Distillate flow rate
@@ -1430,7 +1483,14 @@ class DistillationColumn:
             distillate_flows = {s: D * x_D[s] for s in p.species_order}
             bottoms_flows = {s: B * x_B[s] for s in p.species_order}
 
-            distillate = make_stream(distillate_flows, T_profile[-1], p.P)
+            # A total condenser delivers the distillate as a saturated liquid
+            # at its own bubble point, which is below the top stage
+            # temperature (see _condenser_T).
+            T_condenser = self._condenser_T(
+                y_profile[-1], jnp.asarray(p.P), T_guess=T_profile[-1]
+            )
+
+            distillate = make_stream(distillate_flows, T_condenser, p.P)
             bottoms = make_stream(bottoms_flows, T_profile[0], p.P)
 
             # Compute duties with actual V profile from MESH
@@ -1438,6 +1498,7 @@ class DistillationColumn:
                 x_profile, y_profile, T_profile,
                 F_total, z, T_feed, R, D, B,
                 V_top=V_profile[-1], V_bot=V_profile[0],
+                T_condenser=T_condenser,
             )
 
             info = {
@@ -1448,6 +1509,8 @@ class DistillationColumn:
                 "V_profile": V_profile,
                 "D": D,
                 "B": B,
+                "T_condenser": T_condenser,
+                "T_reboiler": T_profile[0],
                 "Q_condenser": Q_condenser,
                 "Q_reboiler": Q_reboiler,
             }
@@ -1466,13 +1529,18 @@ class DistillationColumn:
             distillate_flows = {s: D * x_D[s] for s in p.species_order}
             bottoms_flows = {s: B * x_B[s] for s in p.species_order}
 
-            distillate = make_stream(distillate_flows, T_profile[-1], p.P)
+            T_condenser = self._condenser_T(
+                y_profile[-1], jnp.asarray(p.P), T_guess=T_profile[-1]
+            )
+
+            distillate = make_stream(distillate_flows, T_condenser, p.P)
             bottoms = make_stream(bottoms_flows, T_profile[0], p.P)
 
             # Compute duties with CMO vapor flow estimates
             Q_condenser, Q_reboiler = self._compute_duties(
                 x_profile, y_profile, T_profile,
                 F_total, z, T_feed, R, D, B,
+                T_condenser=T_condenser,
             )
 
             info = {
@@ -1483,6 +1551,8 @@ class DistillationColumn:
                 "V_rect": (R + 1) * D,
                 "D": D,
                 "B": B,
+                "T_condenser": T_condenser,
+                "T_reboiler": T_profile[0],
                 "Q_condenser": Q_condenser,
                 "Q_reboiler": Q_reboiler,
             }

--- a/src/difflow/units/distillation.py
+++ b/src/difflow/units/distillation.py
@@ -239,8 +239,12 @@ class ShortcutColumnParams(ParamsMixin):
         species_order: List of species names for array ordering
         light_key: Name of light key component
         heavy_key: Name of heavy key component
-        x_D_LK: Desired mole fraction of LK in distillate
-        x_B_HK: Desired mole fraction of HK in bottoms
+        x_D_LK: Fractional **recovery** of the light key in the distillate --
+            0.99 sends 99 % of the feed's light key overhead. Despite the
+            name, which is historical, it is not a mole fraction; the
+            distillate's actual light-key mole fraction comes out in
+            ``info["x_D"]``.
+        x_B_HK: Fractional recovery of the heavy key in the bottoms, likewise.
     """
     species_order: list[str]
     light_key: str
@@ -904,12 +908,29 @@ class ShortcutColumn:
 class DistillationColumnParams(ParamsMixin):
     """Parameters for rigorous distillation column.
 
+    Stages are indexed from the bottom, zero-based: stage 0 is the reboiler,
+    stage ``n_stages - 1`` is the top tray. The condenser is not a stage -- it
+    sits outside the cascade and is what ``condenser_type`` describes -- so
+    ``n_stages`` counts the trays plus the reboiler, and every profile in
+    ``info`` is in that same order (``T_profile[0]`` is the reboiler,
+    ``T_profile[-1]`` the top tray).
+
     Attributes:
-        species_order: List of species names
-        n_stages: Total number of stages (including condenser/reboiler)
-        feed_stage: Feed stage number (1 = bottom)
-        condenser_type: 'total' or 'partial'
-        P: Column pressure (Pa)
+        species_order: List of species names. Sets the column order of every
+            array in ``info``, and must match the thermo package's species.
+        n_stages: Number of equilibrium stages: the trays plus the reboiler.
+        feed_stage: Stage the feed enters, as a zero-based index from the
+            bottom (0 = reboiler). Stages below it are the stripping section
+            and stages above it the rectifying section. Which side the feed
+            stage itself is counted on differs between the CMO sweep and the
+            MESH flow initialisation, so do not read anything into the
+            boundary stage.
+        condenser_type: 'total' or 'partial'. Only 'total' is implemented;
+            'partial' is rejected rather than silently treated as total.
+        P: Column pressure (Pa). One pressure for the whole column -- there is
+            no tray pressure drop.
+        q: Feed thermal condition (1.0 = saturated liquid, 0.0 = saturated
+            vapor).
     """
     species_order: list[str]
     n_stages: int
@@ -918,6 +939,16 @@ class DistillationColumnParams(ParamsMixin):
     P: float = 101325.0
     q: float = 1.0  # Feed thermal condition (1.0 = saturated liquid, 0.0 = saturated vapor)
 
+    def __post_init__(self):
+        if self.condenser_type != "total":
+            raise NotImplementedError(
+                f"condenser_type={self.condenser_type!r} is not implemented; "
+                "the MESH solver models a total condenser (the distillate has "
+                "the composition of the top tray's vapor and leaves as a "
+                "saturated liquid). A partial condenser would be an extra "
+                "equilibrium stage with a vapor product."
+            )
+
 
 class DistillationColumn:
     """Rigorous stage-by-stage distillation column.
@@ -925,12 +956,16 @@ class DistillationColumn:
     Solves MESH equations (Material, Equilibrium, Summation, Heat balance)
     for each stage using the bubble-point method.
 
-    Stage numbering: 1 = reboiler (bottom), n_stages = condenser (top)
+    Stage numbering: zero-based from the bottom -- stage 0 is the reboiler,
+    stage ``n_stages - 1`` is the top tray. The total condenser is outside the
+    cascade, so the distillate is not a stage's product (see
+    :meth:`_condenser_T`).
 
     Assumptions:
     - Equilibrium stages
     - No pressure drop between stages
-    - Constant molar overflow (CMO) for initial solution
+    - Total condenser
+    - Constant molar overflow (CMO) for the initial solution
 
     All calculations are JAX-compatible for automatic differentiation.
     """

--- a/src/difflow/units/distillation.py
+++ b/src/difflow/units/distillation.py
@@ -27,7 +27,7 @@ from jax import Array, lax
 from difflow.streams import Stream, get_flows, make_stream
 from difflow.thermo import CubicThermo, IdealThermo
 from difflow.params_mixin import ParamsMixin
-from difflow.constants import MIN_ALPHA_DIFF, MAX_STAGES, MAX_GILLILAND_Y, DEFAULT_TEMP_SCALE, EPS_DIVISION
+from difflow.constants import MIN_ALPHA_DIFF, MAX_STAGES, MAX_GILLILAND_Y, EPS_DIVISION
 from difflow.numerics import safe_divide, safe_log
 import optimistix as optx
 
@@ -42,6 +42,193 @@ _BUBBLE_T_MAX_STEP = 25.0
 # Below this the bubble-point residual is flat, i.e. the EOS is reporting one
 # phase rather than two, and a Newton step there is 0/0.
 _BUBBLE_T_FLAT_DR = 1e-8
+
+# First pass of the bubble-point solve: damped Newton on log(sum(K x)), which
+# is well scaled where the residual itself is exponentially flat.
+_SEED_T_STEPS = 10
+_SEED_T_MAX_STEP = 100.0
+_SEED_T_FLOOR = 20.0
+
+# Sweeps of the shortcut column's end-temperature fixed point: the relative
+# volatilities are evaluated at the product bubble points, and the products
+# come from the volatilities.
+_SHORTCUT_END_T_ITERS = 3
+
+
+def _mixture_molar_enthalpy(
+    thermo: "IdealThermo | CubicThermo",
+    species_order: list[str],
+    mole_fracs: Array,
+    T: Array,
+    phase: str,
+    P: Array,
+) -> Array:
+    """Molar enthalpy (J/mol) of one phase of a mixture.
+
+    Goes through ``thermo.stream_enthalpy`` on a one-mole basis rather than
+    summing ``H_pure`` so that a column is not tied to one thermodynamic model:
+    for an :class:`~difflow.thermo.IdealThermo` this is exactly
+    ``sum_i z_i H_pure_i`` (its enthalpy is a mole-fraction-weighted sum of
+    pure-component enthalpies and it ignores ``P``), while for a
+    :class:`~difflow.thermo.CubicThermo` it is the ideal-gas sensible enthalpy
+    plus the EOS departure for this phase at the column pressure, so the latent
+    heat comes from the same EOS as the K-values.
+
+    Args:
+        thermo: Thermodynamic property calculator.
+        species_order: Species names, in the order ``mole_fracs`` is given.
+        mole_fracs: (nc,) mole fractions of the phase.
+        T: Temperature (K).
+        phase: 'liquid' or 'vapor'.
+        P: Pressure (Pa).
+
+    Returns:
+        Molar enthalpy (J/mol).
+    """
+    flows = {s: mole_fracs[i] for i, s in enumerate(species_order)}
+    return thermo.stream_enthalpy(flows, T, phase=phase, P=jnp.asarray(P))
+
+
+def _bubble_T(
+    thermo: "IdealThermo | CubicThermo",
+    x: Array,
+    P: Array,
+    T_guess: Array | None = None,
+) -> tuple[Array, Array]:
+    """Bubble-point temperature of a liquid mixture, and its incipient vapor.
+
+    Solves ``sum(K_i x_i) = 1`` for T.
+
+    With an ideal thermo package that is one Newton solve on Raoult K-values.
+    With an EOS package it is that solve followed by a safeguarded refinement
+    on the EOS K-values, which are a function of composition as well as of T;
+    see the comments below for why the refinement is written by hand rather
+    than handed to a root finder.
+
+    Args:
+        thermo: Thermodynamic property calculator.
+        x: Liquid mole fractions.
+        P: Pressure (Pa).
+        T_guess: Initial temperature guess (K). If None, a pressure-scaled
+            default is used.
+
+    Returns:
+        (T, y): The bubble temperature and the vapor in equilibrium with it.
+    """
+    x = jnp.asarray(x)
+
+    def residual_from_K(K: Array) -> Array:
+        return jnp.sum(K * x) - 1.0
+
+    def K_at(T: Array) -> Array:
+        """K-values at the composition this bubble point is posed at."""
+        return thermo.K_values_array(T, P, x)
+
+    # Initial guess: use provided guess or estimate from pressure
+    # At higher pressures, boiling points are higher. Rough correlation:
+    # T_bp ≈ T_nbp * (P / 101325)^0.1 for many organics
+    # Use 350K as baseline for 1 atm, scale with pressure
+    if T_guess is not None:
+        T_init = T_guess
+    else:
+        # Pressure-scaled initial guess
+        # 350K is reasonable for many organics at 1 atm
+        # For cryogenic: would need lower base, but user should provide T_guess
+        T_base = 350.0
+        P_ref = 101325.0
+        T_init = T_base * (P / P_ref) ** 0.08
+        T_init = jnp.clip(T_init, 100.0, 800.0)  # Reasonable bounds
+
+    # Pass 1: composition-free K-values -- Raoult's law either way, since a
+    # CubicThermo hands this call back to the IdealThermo it wraps. They are
+    # smooth and monotone in T, with a single root, so this pass owns getting
+    # into the right neighbourhood from a cold start. That is also what pass 2
+    # needs: away from the bubble point the EOS cubic has a single real root,
+    # both phases then take that same root, and K collapses identically to 1 --
+    # a flat-zero residual a Newton step cannot recover from. Pass 1 lands
+    # inside the window where the EOS has two roots, so pass 2 never starts
+    # outside it.
+    def estimate_residual(T, args):
+        return residual_from_K(thermo.K_values_array(T, P))
+
+    # Pass 1a: a few damped Newton steps on log(sum(K x)) rather than on
+    # sum(K x) - 1. Vapor pressure is exponential in -1/T, so far below the
+    # bubble point sum(K x) is ~0 and so is its slope: Newton on the plain
+    # residual divides one tiny number by another and steps tens of thousands
+    # of degrees, into the region where the Antoine exponent overflows. Its
+    # logarithm has a slope that stays O(1/K) over the whole range -- it is
+    # nearly linear in 1/T -- so the same step is a sane one. Capped and
+    # floored on top of that, because "nearly" is not "exactly".
+    def log_residual(T):
+        # Not safe_log: its 1e-15 floor is inside the range this pass has to
+        # work over. Two hundred degrees under the bubble point sum(K x) is
+        # ~1e-42 -- an ordinary float64 -- and clipping it there would flatten
+        # the very slope the step is derived from, stalling the seed at its
+        # starting point. Float64 goes down to ~1e-308, so the floor here only
+        # has to stop a true underflow producing -inf.
+        return jnp.log(jnp.maximum(jnp.sum(thermo.K_values_array(T, P) * x), 1e-300))
+
+    def seed_step(T_k, _):
+        r, dr = jax.value_and_grad(log_residual)(T_k)
+        ok = jnp.isfinite(r) & jnp.isfinite(dr) & (jnp.abs(dr) > 1e-12)
+        r_safe = jnp.where(ok, r, 0.0)
+        dr_safe = jnp.where(ok, dr, 1.0)
+        dT = jnp.clip(-r_safe / dr_safe, -_SEED_T_MAX_STEP, _SEED_T_MAX_STEP)
+        T_next = jnp.maximum(T_k + dT, _SEED_T_FLOOR)
+        return jnp.where(jnp.isfinite(T_next), T_next, T_k), None
+
+    T_seed, _ = lax.scan(seed_step, T_init, None, length=_SEED_T_STEPS)
+
+    # Pass 1b: finish on the residual itself. Seeded this close it converges in
+    # a step or two, and optimistix differentiates it implicitly, so the seed
+    # above never appears in the gradient.
+    solver = optx.Newton(rtol=1e-10, atol=1e-10)
+    sol = optx.root_find(
+        estimate_residual, solver, T_seed, args=None, max_steps=50, throw=False,
+    )
+    T = sol.value
+
+    # Pass 2: refine against the composition-dependent K-values. Skipped when
+    # the thermo package's K-values are a function of (T, P) alone, where pass
+    # 1 already solved the real residual.
+    if getattr(thermo, "K_depends_on_composition", True):
+        def refined_residual(T):
+            return residual_from_K(K_at(T))
+
+        # A safeguarded Newton written out rather than handed to a root finder.
+        # An EOS K-value only means anything over the temperature window where
+        # its cubic has two roots at this composition; outside it both phases
+        # take the one root, K is identically 1, and the residual is a flat
+        # zero that a root finder reads as converged wherever it happens to be
+        # standing. So: cap the step, and when a step lands somewhere flat
+        # (dr = 0), bisect back toward the last temperature that was not,
+        # instead of taking 0/0. The pass-1 estimate is the first such
+        # temperature, which makes the worst case "return the ideal-K bubble
+        # point", never a NaN.
+        def newton_step(carry, _):
+            T_k, T_ok = carry
+            r, dr = jax.value_and_grad(refined_residual)(T_k)
+            in_window = (
+                jnp.isfinite(r) & jnp.isfinite(dr)
+                & (jnp.abs(dr) > _BUBBLE_T_FLAT_DR)
+            )
+            # Sanitise before the divide, not after: a NaN that has already
+            # been formed is something a later jnp.where can hide from the
+            # value but not from the derivative.
+            r_safe = jnp.where(in_window, r, 0.0)
+            dr_safe = jnp.where(in_window, dr, 1.0)
+            dT = jnp.clip(
+                -r_safe / dr_safe, -_BUBBLE_T_MAX_STEP, _BUBBLE_T_MAX_STEP
+            )
+            T_next = jnp.where(in_window, T_k + dT, 0.5 * (T_k + T_ok))
+            return (T_next, jnp.where(in_window, T_k, T_ok)), None
+
+        (T, _), _ = lax.scan(
+            newton_step, (T, T), None, length=_BUBBLE_T_REFINE_STEPS
+        )
+
+    y = K_at(T) * x
+    return T, y / jnp.sum(y)
 
 
 @dataclass(repr=False)
@@ -108,12 +295,21 @@ class ShortcutColumn:
     def __init__(
         self,
         params: ShortcutColumnParams,
-        thermo: IdealThermo,
+        thermo: IdealThermo | CubicThermo,
     ):
         """Initialize shortcut column.
 
         Args:
-            params: Column parameters
+            params: Column parameters. Supplies the K-values the relative
+                volatilities are built from and the enthalpies the duties are
+                built from, so it sets what the whole
+                Fenske-Underwood-Gilliland chain is worth: an
+                :class:`~difflow.thermo.IdealThermo` gives Raoult
+                volatilities, a :class:`~difflow.thermo.CubicThermo` gives EOS
+                ones. For light hydrocarbons at pressure the difference runs
+                through to the answer -- on a C3-C8 cut at 10 bar the light
+                key's alpha is 2.32 on Raoult against 1.81 on Peng-Robinson,
+                which is 3.7 minimum stages against 5.6.
             thermo: Thermodynamic property calculator for K-values
         """
         self.params = params
@@ -123,6 +319,7 @@ class ShortcutColumn:
         self,
         T: Array,
         P: Array,
+        x: Array | None = None,
     ) -> dict[str, Array]:
         """Calculate relative volatilities with respect to heavy key.
 
@@ -131,11 +328,18 @@ class ShortcutColumn:
         Args:
             T: Temperature (K)
             P: Pressure (Pa)
+            x: Liquid mole fractions in species order, for a thermo package
+               whose K-values depend on composition (a
+               :class:`~difflow.thermo.CubicThermo`). Ignored by Raoult
+               K-values, which are a function of (T, P) alone. Omitting it on
+               an EOS package falls back to that package's composition-free
+               estimate, which is a worse relative volatility than one
+               evaluated at the composition the column end actually has.
 
         Returns:
             Dictionary of relative volatilities by species
         """
-        K = self.thermo.K_values(T, P)
+        K = self.thermo.K_values(T, P, x)
         K_HK = K[self.params.heavy_key]
 
         return {s: K[s] / K_HK for s in self.params.species_order}
@@ -145,21 +349,28 @@ class ShortcutColumn:
         T_top: Array,
         T_bot: Array,
         P: Array,
+        x_top: Array | None = None,
+        x_bot: Array | None = None,
     ) -> dict[str, Array]:
         """Calculate geometric mean relative volatility.
 
         alpha_avg = sqrt(alpha_top * alpha_bottom)
 
         Args:
-            T_top: Top temperature (K)
-            T_bot: Bottom temperature (K)
+            T_top: Top temperature (K) -- the condenser, i.e. the bubble point
+                of the distillate
+            T_bot: Bottom temperature (K) -- the reboiler, i.e. the bubble
+                point of the bottoms
             P: Column pressure (Pa)
+            x_top: Distillate mole fractions, for a composition-dependent
+                thermo package (see :meth:`relative_volatility`)
+            x_bot: Bottoms mole fractions, likewise
 
         Returns:
             Dictionary of average relative volatilities
         """
-        alpha_top = self.relative_volatility(T_top, P)
-        alpha_bot = self.relative_volatility(T_bot, P)
+        alpha_top = self.relative_volatility(T_top, P, x_top)
+        alpha_bot = self.relative_volatility(T_bot, P, x_bot)
 
         return {
             s: jnp.sqrt(alpha_top[s] * alpha_bot[s])
@@ -360,100 +571,33 @@ class ShortcutColumn:
 
         return N, near_min_reflux
 
-    def feed_stage_kirkbride(
+    def _split_products(
         self,
-        N: Array,
-        z_LK: Array,
-        z_HK: Array,
-        x_B_LK: Array,
-        x_D_HK: Array,
-        B_over_D: Array,
-    ) -> Array:
-        """Estimate optimal feed stage using Kirkbride equation.
+        feed_flows: dict[str, Array],
+        F_total: Array,
+        z: dict[str, Array],
+        alpha: dict[str, Array],
+    ) -> tuple[dict, dict, Array, Array, dict, dict]:
+        """Distribute the feed between the products at a given volatility set.
 
-        log(N_R/N_S) = 0.206 * log[(z_HK/z_LK) * (x_B_LK/x_D_HK)^2 * (B/D)]
-
-        where N_R = rectifying stages, N_S = stripping stages
+        The keys are placed by their specified recoveries; every other species
+        is distributed by the Hengstebeck-Geddes equation,
+        ``log(d_i/b_i) = A + C log(alpha_i)``, with A and C fixed by the keys.
+        Split out of :meth:`__call__` because it has to be re-evaluated as the
+        column-end temperatures converge: the split depends on ``alpha``, and
+        ``alpha`` is evaluated at the ends, which are the bubble points of the
+        products this returns.
 
         Args:
-            N: Total stages
-            z_LK: Feed mole fraction of LK
-            z_HK: Feed mole fraction of HK
-            x_B_LK: Bottoms mole fraction of LK
-            x_D_HK: Distillate mole fraction of HK
-            B_over_D: Bottoms to distillate molar flow ratio
+            feed_flows: Feed molar flows by species (mol/s).
+            F_total: Total feed flow (mol/s).
+            z: Feed mole fractions by species.
+            alpha: Relative volatilities by species (vs the heavy key).
 
         Returns:
-            Feed stage number (from bottom)
-        """
-        ratio_arg = safe_divide(z_HK, z_LK) * \
-                    safe_divide(x_B_LK, x_D_HK)**2 * \
-                    B_over_D
-
-        log_ratio = 0.206 * safe_log(ratio_arg)
-        NR_over_NS = jnp.exp(log_ratio)
-
-        # N = N_R + N_S, NR/NS = ratio
-        # N_S = N / (1 + ratio)
-        N_S = N / (1 + NR_over_NS)
-
-        return jnp.maximum(jnp.round(N_S), 1.0)
-
-    def __call__(
-        self,
-        feed: Stream,
-        R: Array | float,
-        P: Array | float = 101325.0,
-        q: Array | float = 1.0,
-    ) -> tuple[Stream, Stream, dict[str, Array]]:
-        """Perform shortcut distillation calculation.
-
-        Args:
-            feed: Feed stream
-            R: Reflux ratio (L/D)
-            P: Column pressure (Pa)
-            q: Feed quality (1 = saturated liquid)
-
-        Returns:
-            distillate: Distillate stream
-            bottoms: Bottoms stream
-            info: Dictionary with design information:
-                - 'N_min': Minimum stages
-                - 'R_min': Minimum reflux ratio
-                - 'N': Actual stages
-                - 'N_feed': Feed stage
-                - 'alpha': Relative volatilities
-                - 'close_boiling': True if α ≈ 1 (hard separation)
-                - 'near_min_reflux': True if R ≈ R_min
+            (distillate_flows, bottoms_flows, D_total, B_total, x_D, x_B)
         """
         p = self.params
-        R = jnp.asarray(R)
-        P = jnp.asarray(P)
-        q = jnp.asarray(q)
-
-        # Get feed composition
-        feed_flows = get_flows(feed)
-        F_total = sum(feed_flows.values())
-        z = {s: feed_flows[s] / F_total for s in p.species_order}
-
-        # Estimate column temperatures scaled relative to feed T
-        # Instead of hard-coded ±20K which fails for cryogenic/high-T systems,
-        # use a percentage of feed temperature. This scales appropriately:
-        # - Cryogenic (90K feed): ΔT ≈ ±4.5K
-        # - Ambient (350K feed): ΔT ≈ ±17.5K
-        # - High-T (600K feed): ΔT ≈ ±30K
-        T_feed = feed["T"]
-        T_half_range = T_feed * DEFAULT_TEMP_SCALE
-        T_top = T_feed - T_half_range
-        T_bot = T_feed + T_half_range
-
-        # Get relative volatilities (average and per-end for variation diagnostics)
-        alpha_top = self.relative_volatility(T_top, P)
-        alpha_bot = self.relative_volatility(T_bot, P)
-        alpha = {
-            s: jnp.sqrt(alpha_top[s] * alpha_bot[s])
-            for s in p.species_order
-        }
         alpha_LK = alpha[p.light_key]
 
         # Recovery calculations
@@ -509,6 +653,139 @@ class ShortcutColumn:
         x_D = {s: safe_divide(distillate_flows[s], D_total) for s in p.species_order}
         x_B = {s: safe_divide(bottoms_flows[s], B_total) for s in p.species_order}
 
+        return distillate_flows, bottoms_flows, D_total, B_total, x_D, x_B
+
+    def feed_stage_kirkbride(
+        self,
+        N: Array,
+        z_LK: Array,
+        z_HK: Array,
+        x_B_LK: Array,
+        x_D_HK: Array,
+        B_over_D: Array,
+    ) -> Array:
+        """Estimate optimal feed stage using Kirkbride equation.
+
+        log(N_R/N_S) = 0.206 * log[(z_HK/z_LK) * (x_B_LK/x_D_HK)^2 * (B/D)]
+
+        where N_R = rectifying stages, N_S = stripping stages
+
+        Args:
+            N: Total stages
+            z_LK: Feed mole fraction of LK
+            z_HK: Feed mole fraction of HK
+            x_B_LK: Bottoms mole fraction of LK
+            x_D_HK: Distillate mole fraction of HK
+            B_over_D: Bottoms to distillate molar flow ratio
+
+        Returns:
+            Feed stage number (from bottom)
+        """
+        ratio_arg = safe_divide(z_HK, z_LK) * \
+                    safe_divide(x_B_LK, x_D_HK)**2 * \
+                    B_over_D
+
+        log_ratio = 0.206 * safe_log(ratio_arg)
+        NR_over_NS = jnp.exp(log_ratio)
+
+        # N = N_R + N_S, NR/NS = ratio
+        # N_S = N / (1 + ratio)
+        N_S = N / (1 + NR_over_NS)
+
+        return jnp.maximum(jnp.round(N_S), 1.0)
+
+    def __call__(
+        self,
+        feed: Stream,
+        R: Array | float,
+        P: Array | float = 101325.0,
+        q: Array | float = 1.0,
+    ) -> tuple[Stream, Stream, dict[str, Array]]:
+        """Perform shortcut distillation calculation.
+
+        Args:
+            feed: Feed stream
+            R: Reflux ratio (L/D)
+            P: Column pressure (Pa)
+            q: Feed quality (1 = saturated liquid)
+
+        Returns:
+            distillate: Distillate stream, at the condenser temperature --
+                a total condenser delivers saturated liquid, so this is the
+                bubble point of the distillate
+            bottoms: Bottoms stream, at the reboiler temperature -- the
+                bubble point of the bottoms
+            info: Dictionary with design information:
+                - 'N_min': Minimum stages
+                - 'R_min': Minimum reflux ratio
+                - 'N': Actual stages
+                - 'N_feed': Feed stage
+                - 'alpha': Relative volatilities, the geometric mean of the
+                  values at the two column ends
+                - 'T_top'/'T_condenser': Condenser temperature (K)
+                - 'T_bot'/'T_reboiler': Reboiler temperature (K)
+                - 'close_boiling': True if α ≈ 1 (hard separation)
+                - 'near_min_reflux': True if R ≈ R_min
+        """
+        p = self.params
+        R = jnp.asarray(R)
+        P = jnp.asarray(P)
+        q = jnp.asarray(q)
+
+        # Get feed composition
+        feed_flows = get_flows(feed)
+        F_total = sum(feed_flows.values())
+        z = {s: feed_flows[s] / F_total for s in p.species_order}
+
+        # Column-end temperatures. These are not free estimates: the top of the
+        # column is a total condenser, so it sits at the bubble point of the
+        # distillate, and the bottom is the reboiler, at the bubble point of
+        # the bottoms. Fenske-Underwood-Gilliland wants the relative
+        # volatilities at those two states -- which makes them a small fixed
+        # point, since the products' compositions come from the volatilities
+        # in turn. Seed it from the feed's own bubble point and sweep a few
+        # times; the products separate on the first pass and the temperatures
+        # settle within a fraction of a degree after that.
+        T_feed = feed["T"]
+        z_arr = jnp.array([z[s] for s in p.species_order])
+        T_end, _ = _bubble_T(self.thermo, z_arr, P, T_guess=T_feed)
+        T_top = T_end
+        T_bot = T_end
+        x_D_arr = z_arr
+        x_B_arr = z_arr
+
+        def alpha_and_split(T_top, T_bot, x_D_arr, x_B_arr):
+            """One sweep: volatilities at the ends, then the product split."""
+            alpha_top = self.relative_volatility(T_top, P, x_D_arr)
+            alpha_bot = self.relative_volatility(T_bot, P, x_B_arr)
+            alpha = {
+                s: jnp.sqrt(alpha_top[s] * alpha_bot[s])
+                for s in p.species_order
+            }
+            split = self._split_products(feed_flows, F_total, z, alpha)
+            return alpha_top, alpha_bot, alpha, split
+
+        for _ in range(_SHORTCUT_END_T_ITERS):
+            *_, (_, _, _, _, x_D, x_B) = alpha_and_split(
+                T_top, T_bot, x_D_arr, x_B_arr
+            )
+            x_D_arr = jnp.array([x_D[s] for s in p.species_order])
+            x_B_arr = jnp.array([x_B[s] for s in p.species_order])
+            T_top, _ = _bubble_T(self.thermo, x_D_arr, P, T_guess=T_top)
+            T_bot, _ = _bubble_T(self.thermo, x_B_arr, P, T_guess=T_bot)
+
+        # A last sweep so the volatilities and the split that get reported are
+        # the ones belonging to the converged end temperatures.
+        alpha_top, alpha_bot, alpha, split = alpha_and_split(
+            T_top, T_bot, x_D_arr, x_B_arr
+        )
+        distillate_flows, bottoms_flows, D_total, B_total, x_D, x_B = split
+        x_D_arr = jnp.array([x_D[s] for s in p.species_order])
+        x_B_arr = jnp.array([x_B[s] for s in p.species_order])
+        alpha_LK = alpha[p.light_key]
+        z_LK = z[p.light_key]
+        z_HK = z[p.heavy_key]
+
         # Fenske minimum stages
         x_D_LK = x_D[p.light_key]
         x_B_LK = x_B[p.light_key]
@@ -526,44 +803,49 @@ class ShortcutColumn:
         x_D_HK = x_D[p.heavy_key]
         N_feed = self.feed_stage_kirkbride(N, z_LK, z_HK, x_B_LK, x_D_HK, B_over_D)
 
-        # Create output streams
+        # Create output streams. The distillate leaves the condenser as a
+        # saturated liquid (T_top is its bubble point); the bottoms leaves the
+        # reboiler at its own bubble point.
         distillate = make_stream(distillate_flows, T_top, P)
         bottoms = make_stream(bottoms_flows, T_bot, P)
 
         # Compute condenser and reboiler duties including latent heat
-        # Condenser: condense all vapor from top stage
+        # Condenser: condense all vapor from the top stage
         V_top = (R + 1) * D_total  # Vapor flow at top stage
 
-        # Compute mixture enthalpies at top and bottom using full model
-        # (sensible + latent heat via Hvap)
-        x_D_arr = jnp.array([x_D[s] for s in p.species_order])
-        x_B_arr = jnp.array([x_B[s] for s in p.species_order])
+        def h_mix(mole_fracs, T, phase):
+            return _mixture_molar_enthalpy(
+                self.thermo, p.species_order, mole_fracs, T, phase, P
+            )
 
-        # Vapor enthalpy at top (includes latent heat)
-        H_vapor_top = jnp.zeros(())
-        h_liquid_top = jnp.zeros(())
-        for i, s in enumerate(p.species_order):
-            H_vapor_top = H_vapor_top + x_D_arr[i] * self.thermo.H_pure(s, T_top, 'vapor')
-            h_liquid_top = h_liquid_top + x_D_arr[i] * self.thermo.H_pure(s, T_top, 'liquid')
+        # Condensing vapor of the distillate's composition to liquid of the
+        # same composition, both at the condenser temperature: the latent heat
+        # of the distillate. This is the standard shortcut duty, and it is
+        # where the shortcut and rigorous columns genuinely differ -- the
+        # rigorous column knows its top *tray* temperature and so also charges
+        # the condenser for cooling the vapor from the tray down to the
+        # condenser, while a shortcut method has no tray profile to take that
+        # temperature from. The dew point of x_D would supply one on paper, but
+        # a dew point is set by the heaviest trace in the mixture, and the
+        # heaviest trace in x_D is the least reliable number the
+        # Hengstebeck-Geddes distribution produces.
+        H_vapor_top = h_mix(x_D_arr, T_top, 'vapor')
 
         # Feed enthalpy
-        h_F = jnp.zeros(())
-        for i, s in enumerate(p.species_order):
-            z_arr_i = jnp.asarray(z[s])
-            h_F = h_F + z_arr_i * self.thermo.H_pure(s, T_feed, 'liquid')
+        h_F = h_mix(z_arr, T_feed, 'liquid')
+
+        # Distillate liquid enthalpy (total condenser: saturated liquid)
+        h_D = h_mix(x_D_arr, T_top, 'liquid')
 
         # Bottoms liquid enthalpy
-        h_B = jnp.zeros(())
-        for i, s in enumerate(p.species_order):
-            h_B = h_B + x_B_arr[i] * self.thermo.H_pure(s, T_bot, 'liquid')
+        h_B = h_mix(x_B_arr, T_bot, 'liquid')
 
         # Condenser duty (heat removed, negative)
-        Q_condenser = V_top * (h_liquid_top - H_vapor_top)
+        Q_condenser = V_top * (h_D - H_vapor_top)
 
         # Reboiler duty from overall energy balance
         # F*h_F + Q_reb = D*h_D + B*h_B + |Q_cond|
         # Q_reb = D*h_D + B*h_B - Q_cond - F*h_F  (Q_cond < 0)
-        h_D = h_liquid_top  # total condenser: distillate is liquid at T_top
         Q_reboiler = D_total * h_D + B_total * h_B - Q_condenser - F_total * h_F
 
         # Alpha variation diagnostics (#87)
@@ -598,6 +880,8 @@ class ShortcutColumn:
             "x_B": x_B,
             "T_top": T_top,
             "T_bot": T_bot,
+            "T_condenser": T_top,
+            "T_reboiler": T_bot,
             "close_boiling": close_boiling,
             "near_min_reflux": near_min_reflux,
             "Q_condenser": Q_condenser,
@@ -712,13 +996,8 @@ class DistillationColumn:
     ) -> tuple[Array, Array]:
         """Calculate bubble point temperature and vapor composition.
 
-        Solves: sum(K_i * x_i) = 1 for T
-
-        With an ideal thermo package that is one Newton solve on Raoult
-        K-values. With an EOS package it is that solve followed by a
-        safeguarded refinement on the EOS K-values, which are a function of the
-        stage composition as well as of T; see the code for why the refinement
-        is written by hand rather than handed to a root finder.
+        Solves: sum(K_i * x_i) = 1 for T. A thin wrapper on the module-level
+        :func:`_bubble_T`, which both columns share.
 
         Args:
             x: Liquid mole fractions
@@ -729,89 +1008,7 @@ class DistillationColumn:
         Returns:
             (T, y): Bubble temperature and vapor composition
         """
-        p = self.params
-
-        # Initial guess: use provided guess or estimate from pressure
-        # At higher pressures, boiling points are higher. Rough correlation:
-        # T_bp ≈ T_nbp * (P / 101325)^0.1 for many organics
-        # Use 350K as baseline for 1 atm, scale with pressure
-        if T_guess is not None:
-            T_init = T_guess
-        else:
-            # Pressure-scaled initial guess
-            # 350K is reasonable for many organics at 1 atm
-            # For cryogenic: would need lower base, but user should provide T_guess
-            T_base = 350.0
-            P_ref = 101325.0
-            T_init = T_base * (P / P_ref) ** 0.08
-            T_init = jnp.clip(T_init, 100.0, 800.0)  # Reasonable bounds
-
-        # Pass 1: composition-free K-values -- Raoult's law either way, since
-        # a CubicThermo hands this call back to the IdealThermo it wraps. They
-        # are smooth and monotone in T over the whole range, so Newton reaches
-        # the root from a crude guess. That is what pass 2 needs: away from the
-        # bubble point the EOS cubic has a single real root, both phases then
-        # take that same root, and K collapses identically to 1 -- a flat-zero
-        # residual a Newton step cannot recover from. Pass 1 lands inside the
-        # window where the EOS has two roots, so pass 2 never starts outside
-        # it.
-        def bubble_residual_estimate(T, args):
-            K = self.thermo.K_values_array(T, P)
-            return jnp.sum(K * x) - 1.0
-
-        solver = optx.Newton(rtol=1e-10, atol=1e-10)
-        sol = optx.root_find(
-            bubble_residual_estimate, solver, T_init, args=None,
-            max_steps=50, throw=False,
-        )
-        T = sol.value
-
-        # Pass 2: refine against the composition-dependent K-values. Skipped
-        # when the thermo package's K-values are a function of (T, P) alone,
-        # where pass 1 already solved the real residual.
-        if getattr(self.thermo, "K_depends_on_composition", True):
-            def bubble_residual(T):
-                K = self.thermo.K_values_array(T, P, x)
-                return jnp.sum(K * x) - 1.0
-
-            # A safeguarded Newton written out rather than handed to a root
-            # finder. An EOS K-value only means anything over the temperature
-            # window where its cubic has two roots at this composition; outside
-            # it both phases take the one root, K is identically 1, and the
-            # residual is a flat zero that a root finder reads as converged
-            # wherever it happens to be standing. So: cap the step, and when a
-            # step lands somewhere flat (dr = 0), bisect back toward the last
-            # temperature that was not, instead of taking 0/0. The pass-1
-            # estimate is the first such temperature, which makes the worst
-            # case "return the ideal-K bubble point", never a NaN.
-            def newton_step(carry, _):
-                T_k, T_ok = carry
-                r, dr = jax.value_and_grad(bubble_residual)(T_k)
-                in_window = (
-                    jnp.isfinite(r) & jnp.isfinite(dr)
-                    & (jnp.abs(dr) > _BUBBLE_T_FLAT_DR)
-                )
-                # Sanitise before the divide, not after: a NaN that has already
-                # been formed is something a later jnp.where can hide from the
-                # value but not from the derivative.
-                r_safe = jnp.where(in_window, r, 0.0)
-                dr_safe = jnp.where(in_window, dr, 1.0)
-                dT = jnp.clip(
-                    -r_safe / dr_safe, -_BUBBLE_T_MAX_STEP, _BUBBLE_T_MAX_STEP
-                )
-                T_next = jnp.where(in_window, T_k + dT, 0.5 * (T_k + T_ok))
-                return (T_next, jnp.where(in_window, T_k, T_ok)), None
-
-            (T, _), _ = lax.scan(
-                newton_step, (T, T), None, length=_BUBBLE_T_REFINE_STEPS
-            )
-
-        # Calculate y from K-values
-        K = self.thermo.K_values_array(T, P, x)
-        y = K * x
-        y = y / jnp.sum(y)  # Normalize
-
-        return T, y
+        return _bubble_T(self.thermo, x, P, T_guess)
 
     def _condenser_T(
         self,
@@ -1001,14 +1198,8 @@ class DistillationColumn:
     ) -> Array:
         """Molar enthalpy (J/mol) of one phase at a stage.
 
-        Goes through ``thermo.stream_enthalpy`` on a one-mole basis rather than
-        summing ``H_pure`` so that the column is not tied to one thermodynamic
-        model: for an :class:`~difflow.thermo.IdealThermo` this is exactly the
-        old ``sum_i z_i H_pure_i`` (its enthalpy is a mole-fraction-weighted sum
-        of pure-component enthalpies and it ignores ``P``), while for a
-        :class:`~difflow.thermo.CubicThermo` it is the ideal-gas sensible
-        enthalpy plus the EOS departure for this phase at the column pressure,
-        so the latent heat comes from the same EOS as the K-values.
+        A thin wrapper on the module-level :func:`_mixture_molar_enthalpy`,
+        bound to this column's species order and pressure.
 
         Args:
             mole_fracs: (nc,) mole fractions of the phase, in species order.
@@ -1019,9 +1210,8 @@ class DistillationColumn:
             Molar enthalpy (J/mol).
         """
         p = self.params
-        flows = {s: mole_fracs[i] for i, s in enumerate(p.species_order)}
-        return self.thermo.stream_enthalpy(
-            flows, T, phase=phase, P=jnp.asarray(p.P)
+        return _mixture_molar_enthalpy(
+            self.thermo, p.species_order, mole_fracs, T, phase, jnp.asarray(p.P)
         )
 
     def _compute_stage_enthalpies(

--- a/src/difflow/units/distillation.py
+++ b/src/difflow/units/distillation.py
@@ -25,11 +25,23 @@ import jax.numpy as jnp
 from jax import Array, lax
 
 from difflow.streams import Stream, get_flows, make_stream
-from difflow.thermo import IdealThermo
+from difflow.thermo import CubicThermo, IdealThermo
 from difflow.params_mixin import ParamsMixin
 from difflow.constants import MIN_ALPHA_DIFF, MAX_STAGES, MAX_GILLILAND_Y, DEFAULT_TEMP_SCALE, EPS_DIVISION
 from difflow.numerics import safe_divide, safe_log
 import optimistix as optx
+
+
+# Second pass of the rigorous column's bubble-point solve, used only when the
+# thermo package's K-values depend on composition (an EOS). The step cap keeps
+# an iterate inside the temperature window where the cubic has two real roots
+# -- outside it the liquid and vapor roots coincide, K collapses to 1, and the
+# residual goes flat.
+_BUBBLE_T_REFINE_STEPS = 8
+_BUBBLE_T_MAX_STEP = 25.0
+# Below this the bubble-point residual is flat, i.e. the EOS is reporting one
+# phase rather than two, and a Newton step there is 0/0.
+_BUBBLE_T_FLAT_DR = 1e-8
 
 
 @dataclass(repr=False)
@@ -673,13 +685,20 @@ class DistillationColumn:
     def __init__(
         self,
         params: DistillationColumnParams,
-        thermo: IdealThermo,
+        thermo: IdealThermo | CubicThermo,
     ):
         """Initialize distillation column.
 
         Args:
             params: Column parameters
-            thermo: Thermodynamic property calculator
+            thermo: Thermodynamic property calculator. An
+                :class:`~difflow.thermo.IdealThermo` gives Raoult K-values;
+                a :class:`~difflow.thermo.CubicThermo` gives EOS K-values
+                (``K_i = phi_i^L / phi_i^V``) and EOS enthalpies, which is what
+                a light-hydrocarbon column at pressure needs -- Raoult's law is
+                out by tens of degrees at the condenser there. The column code
+                is the same either way; the composition dependence of the EOS
+                K-values rides along inside the existing MESH iteration.
         """
         self.params = params
         self.thermo = thermo
@@ -695,6 +714,12 @@ class DistillationColumn:
 
         Solves: sum(K_i * x_i) = 1 for T
 
+        With an ideal thermo package that is one Newton solve on Raoult
+        K-values. With an EOS package it is that solve followed by a
+        safeguarded refinement on the EOS K-values, which are a function of the
+        stage composition as well as of T; see the code for why the refinement
+        is written by hand rather than handed to a root finder.
+
         Args:
             x: Liquid mole fractions
             P: Pressure (Pa)
@@ -705,10 +730,6 @@ class DistillationColumn:
             (T, y): Bubble temperature and vapor composition
         """
         p = self.params
-
-        def bubble_residual(T, args):
-            K = self.thermo.K_values_array(T, P)
-            return jnp.sum(K * x) - 1.0
 
         # Initial guess: use provided guess or estimate from pressure
         # At higher pressures, boiling points are higher. Rough correlation:
@@ -725,12 +746,68 @@ class DistillationColumn:
             T_init = T_base * (P / P_ref) ** 0.08
             T_init = jnp.clip(T_init, 100.0, 800.0)  # Reasonable bounds
 
+        # Pass 1: composition-free K-values -- Raoult's law either way, since
+        # a CubicThermo hands this call back to the IdealThermo it wraps. They
+        # are smooth and monotone in T over the whole range, so Newton reaches
+        # the root from a crude guess. That is what pass 2 needs: away from the
+        # bubble point the EOS cubic has a single real root, both phases then
+        # take that same root, and K collapses identically to 1 -- a flat-zero
+        # residual a Newton step cannot recover from. Pass 1 lands inside the
+        # window where the EOS has two roots, so pass 2 never starts outside
+        # it.
+        def bubble_residual_estimate(T, args):
+            K = self.thermo.K_values_array(T, P)
+            return jnp.sum(K * x) - 1.0
+
         solver = optx.Newton(rtol=1e-10, atol=1e-10)
-        sol = optx.root_find(bubble_residual, solver, T_init, args=None, max_steps=50, throw=False)
+        sol = optx.root_find(
+            bubble_residual_estimate, solver, T_init, args=None,
+            max_steps=50, throw=False,
+        )
         T = sol.value
 
+        # Pass 2: refine against the composition-dependent K-values. Skipped
+        # when the thermo package's K-values are a function of (T, P) alone,
+        # where pass 1 already solved the real residual.
+        if getattr(self.thermo, "K_depends_on_composition", True):
+            def bubble_residual(T):
+                K = self.thermo.K_values_array(T, P, x)
+                return jnp.sum(K * x) - 1.0
+
+            # A safeguarded Newton written out rather than handed to a root
+            # finder. An EOS K-value only means anything over the temperature
+            # window where its cubic has two roots at this composition; outside
+            # it both phases take the one root, K is identically 1, and the
+            # residual is a flat zero that a root finder reads as converged
+            # wherever it happens to be standing. So: cap the step, and when a
+            # step lands somewhere flat (dr = 0), bisect back toward the last
+            # temperature that was not, instead of taking 0/0. The pass-1
+            # estimate is the first such temperature, which makes the worst
+            # case "return the ideal-K bubble point", never a NaN.
+            def newton_step(carry, _):
+                T_k, T_ok = carry
+                r, dr = jax.value_and_grad(bubble_residual)(T_k)
+                in_window = (
+                    jnp.isfinite(r) & jnp.isfinite(dr)
+                    & (jnp.abs(dr) > _BUBBLE_T_FLAT_DR)
+                )
+                # Sanitise before the divide, not after: a NaN that has already
+                # been formed is something a later jnp.where can hide from the
+                # value but not from the derivative.
+                r_safe = jnp.where(in_window, r, 0.0)
+                dr_safe = jnp.where(in_window, dr, 1.0)
+                dT = jnp.clip(
+                    -r_safe / dr_safe, -_BUBBLE_T_MAX_STEP, _BUBBLE_T_MAX_STEP
+                )
+                T_next = jnp.where(in_window, T_k + dT, 0.5 * (T_k + T_ok))
+                return (T_next, jnp.where(in_window, T_k, T_ok)), None
+
+            (T, _), _ = lax.scan(
+                newton_step, (T, T), None, length=_BUBBLE_T_REFINE_STEPS
+            )
+
         # Calculate y from K-values
-        K = self.thermo.K_values_array(T, P)
+        K = self.thermo.K_values_array(T, P, x)
         y = K * x
         y = y / jnp.sum(y)  # Normalize
 
@@ -787,10 +864,9 @@ class DistillationColumn:
 
         # Better initial guess: one-stage flash enriches the distillate estimate.
         # Use 350 K as a safe starting T for the feed bubble point.
-        T_bp_feed, _ = self._bubble_point_T(z, P, T_guess=jnp.asarray(350.0))
-        K_feed = self.thermo.K_values_array(T_bp_feed, P)
-        y_flash = K_feed * z
-        y_flash = y_flash / jnp.maximum(jnp.sum(y_flash), 1e-10)
+        T_bp_feed, y_flash = self._bubble_point_T(
+            z, P, T_guess=jnp.asarray(350.0)
+        )
         x_D_init = jnp.clip(y_flash, 1e-6, 1.0 - 1e-6)
         x_D_init = x_D_init / jnp.sum(x_D_init)
 
@@ -809,9 +885,11 @@ class DistillationColumn:
             x, T = carry
 
             # --- Step 1: K values at current stage temperatures ---
+            # The stage's liquid composition goes in too: an EOS K-value
+            # depends on it, a Raoult K-value ignores it.
             def scan_K(_, inputs):
                 x_j, T_j = inputs
-                return None, self.thermo.K_values_array(T_j, P)
+                return None, self.thermo.K_values_array(T_j, P, x_j)
 
             _, K_all = lax.scan(scan_K, None, (x, T))  # (n, nc)
 
@@ -876,13 +954,44 @@ class DistillationColumn:
         # Final equilibrium vapor compositions
         def compute_y(_, inputs):
             x_j, T_j = inputs
-            K_j = self.thermo.K_values_array(T_j, P)
+            K_j = self.thermo.K_values_array(T_j, P, x_j)
             y_j = K_j * x_j
             return None, y_j / jnp.maximum(jnp.sum(y_j), 1e-10)
 
         _, y_final = lax.scan(compute_y, None, (x_final, T_final))
 
         return x_final, y_final, T_final
+
+    def _molar_enthalpy(
+        self,
+        mole_fracs: Array,
+        T: Array,
+        phase: str,
+    ) -> Array:
+        """Molar enthalpy (J/mol) of one phase at a stage.
+
+        Goes through ``thermo.stream_enthalpy`` on a one-mole basis rather than
+        summing ``H_pure`` so that the column is not tied to one thermodynamic
+        model: for an :class:`~difflow.thermo.IdealThermo` this is exactly the
+        old ``sum_i z_i H_pure_i`` (its enthalpy is a mole-fraction-weighted sum
+        of pure-component enthalpies and it ignores ``P``), while for a
+        :class:`~difflow.thermo.CubicThermo` it is the ideal-gas sensible
+        enthalpy plus the EOS departure for this phase at the column pressure,
+        so the latent heat comes from the same EOS as the K-values.
+
+        Args:
+            mole_fracs: (nc,) mole fractions of the phase, in species order.
+            T: Stage temperature (K).
+            phase: 'liquid' or 'vapor'.
+
+        Returns:
+            Molar enthalpy (J/mol).
+        """
+        p = self.params
+        flows = {s: mole_fracs[i] for i, s in enumerate(p.species_order)}
+        return self.thermo.stream_enthalpy(
+            flows, T, phase=phase, P=jnp.asarray(p.P)
+        )
 
     def _compute_stage_enthalpies(
         self,
@@ -901,15 +1010,10 @@ class DistillationColumn:
             h_all: (n,) liquid mixture enthalpies (J/mol)
             H_all: (n,) vapor mixture enthalpies (J/mol)
         """
-        p = self.params
-
         def stage_enthalpies(_, inputs):
             x_j, y_j, T_j = inputs
-            h_j = jnp.zeros(())
-            H_j = jnp.zeros(())
-            for i, s in enumerate(p.species_order):
-                h_j = h_j + x_j[i] * self.thermo.H_pure(s, T_j, 'liquid')
-                H_j = H_j + y_j[i] * self.thermo.H_pure(s, T_j, 'vapor')
+            h_j = self._molar_enthalpy(x_j, T_j, 'liquid')
+            H_j = self._molar_enthalpy(y_j, T_j, 'vapor')
             return None, (h_j, H_j)
 
         _, (h_all, H_all) = lax.scan(stage_enthalpies, None, (x, y, T))
@@ -987,9 +1091,7 @@ class DistillationColumn:
 
         # Feed enthalpy (saturated liquid, q=1)
         z_arr = jnp.array([z[s] for s in p.species_order])
-        h_F = jnp.zeros(())
-        for i, s in enumerate(p.species_order):
-            h_F = h_F + z_arr[i] * self.thermo.H_pure(s, T_feed, 'liquid')
+        h_F = self._molar_enthalpy(z_arr, jnp.asarray(T_feed), 'liquid')
 
         # Distillate enthalpy (liquid at top T for total condenser)
         h_D = h_liquid_top
@@ -1081,10 +1183,14 @@ class DistillationColumn:
         def one_mesh_iter(carry, _):
             x, y, T, L, V = carry
 
-            # 1. Compute K values at current T
+            # 1. Compute K values at current T and stage liquid composition.
+            # An EOS K-value depends on the composition; a Raoult K ignores it
+            # and this is the old K(T, P).
             _, K = lax.scan(
-                lambda _, Tj: (None, self.thermo.K_values_array(Tj, P)),
-                None, T
+                lambda _, args: (
+                    None, self.thermo.K_values_array(args[1], P, args[0])
+                ),
+                None, (x, T)
             )
             # K shape: (n, nc)
 
@@ -1167,8 +1273,10 @@ class DistillationColumn:
 
             # 5. Recompute K and y with updated T
             _, K_new = lax.scan(
-                lambda _, Tj: (None, self.thermo.K_values_array(Tj, P)),
-                None, T_new
+                lambda _, args: (
+                    None, self.thermo.K_values_array(args[1], P, args[0])
+                ),
+                None, (x_new, T_new)
             )
             y_new = K_new * x_new
             y_new = y_new / jnp.maximum(
@@ -1179,16 +1287,10 @@ class DistillationColumn:
             h_all, H_all = self._compute_stage_enthalpies(x_new, y_new, T_new)
 
             # Feed enthalpy (saturated liquid, q=1)
-            h_F = sum(
-                z[i] * self.thermo.H_pure(s, jnp.asarray(T_feed), 'liquid')
-                for i, s in enumerate(p.species_order)
-            )
+            h_F = self._molar_enthalpy(z, jnp.asarray(T_feed), 'liquid')
 
             # Reflux enthalpy (total condenser: liquid at top stage T)
-            h_reflux = sum(
-                y_new[-1, i] * self.thermo.H_pure(s, T_new[-1], 'liquid')
-                for i, s in enumerate(p.species_order)
-            )
+            h_reflux = self._molar_enthalpy(y_new[-1], T_new[-1], 'liquid')
 
             # Top-down energy balance sweep from stage n-1 down to stage 1
             def eb_step(carry, stage_j):

--- a/tests/test_distillation.py
+++ b/tests/test_distillation.py
@@ -327,6 +327,104 @@ class TestDistillationColumn:
         assert "T_profile" in info
         assert "x_profile" in info
 
+    def test_distillate_leaves_at_the_condenser_temperature(
+        self, benzene_toluene_thermo
+    ):
+        """A total condenser delivers saturated liquid, so the distillate is at
+        the bubble point of its own composition -- not at the top stage
+        temperature, which is that composition's dew point."""
+        params = DistillationColumnParams(
+            species_order=["benzene", "toluene"],
+            n_stages=15,
+            feed_stage=7,
+            condenser_type="total",
+            P=101325.0,
+        )
+        column = DistillationColumn(params, benzene_toluene_thermo)
+        feed = make_stream({"benzene": 50.0, "toluene": 50.0}, T=380.0, P=101325.0)
+
+        distillate, bottoms, info = column(feed, R=2.0, D_spec=50.0)
+
+        x_D = info["y_profile"][-1]
+        T_bubble, _ = column._bubble_point_T(
+            x_D, jnp.asarray(101325.0), T_guess=info["T_profile"][-1]
+        )
+
+        assert float(distillate["T"]) == pytest.approx(float(T_bubble), rel=1e-9)
+        assert float(info["T_condenser"]) == pytest.approx(float(distillate["T"]))
+        # Bubble point <= dew point, with equality only for a pure component.
+        assert float(info["T_condenser"]) <= float(info["T_profile"][-1])
+
+        # The bottoms still leaves at the reboiler, which is a stage.
+        assert float(bottoms["T"]) == pytest.approx(float(info["T_profile"][0]))
+        assert float(info["T_reboiler"]) == pytest.approx(float(bottoms["T"]))
+
+    def test_condenser_gap_tracks_the_width_of_the_cut(
+        self, benzene_toluene_thermo, multicomponent_thermo
+    ):
+        """The condenser sits below the top stage by the distillate's own
+        boiling range: negligible for a sharp binary split, large for a
+        distillate carrying a spread of volatilities."""
+        sharp = DistillationColumn(
+            DistillationColumnParams(
+                species_order=["benzene", "toluene"], n_stages=15,
+                feed_stage=7, condenser_type="total", P=101325.0,
+            ),
+            benzene_toluene_thermo,
+        )
+        _, _, info_sharp = sharp(
+            make_stream({"benzene": 50.0, "toluene": 50.0}, T=380.0, P=101325.0),
+            R=2.0, D_spec=50.0,
+        )
+        gap_sharp = (float(info_sharp["T_profile"][-1])
+                     - float(info_sharp["T_condenser"]))
+
+        wide = DistillationColumn(
+            DistillationColumnParams(
+                species_order=["light", "middle", "heavy"], n_stages=15,
+                feed_stage=7, condenser_type="total", P=101325.0,
+            ),
+            multicomponent_thermo,
+        )
+        _, _, info_wide = wide(
+            make_stream({"light": 20.0, "middle": 40.0, "heavy": 40.0},
+                        T=400.0, P=101325.0),
+            R=3.0, D_spec=30.0,
+        )
+        gap_wide = (float(info_wide["T_profile"][-1])
+                    - float(info_wide["T_condenser"]))
+
+        assert gap_sharp >= 0.0
+        assert gap_wide >= gap_sharp
+
+    def test_condenser_duty_condenses_to_the_distillate_state(
+        self, benzene_toluene_thermo
+    ):
+        """Q_cond takes the top stage vapor to the condensed product, so it is
+        V_top * (h_D - H_top) with h_D at the condenser temperature."""
+        params = DistillationColumnParams(
+            species_order=["benzene", "toluene"],
+            n_stages=15,
+            feed_stage=7,
+            condenser_type="total",
+            P=101325.0,
+        )
+        column = DistillationColumn(params, benzene_toluene_thermo)
+        feed = make_stream({"benzene": 50.0, "toluene": 50.0}, T=380.0, P=101325.0)
+
+        _, _, info = column(feed, R=2.0, D_spec=50.0)
+
+        _, H_all = column._compute_stage_enthalpies(
+            info["x_profile"], info["y_profile"], info["T_profile"]
+        )
+        h_D = column._molar_enthalpy(
+            info["y_profile"][-1], info["T_condenser"], "liquid"
+        )
+        expected = float(info["V_profile"][-1]) * float(h_D - H_all[-1])
+
+        assert float(info["Q_condenser"]) == pytest.approx(expected, rel=1e-9)
+        assert float(info["Q_condenser"]) < 0.0
+
 
 class TestMulticomponentDistillation:
     """Tests for multicomponent distillation."""
@@ -556,6 +654,33 @@ class TestCubicThermoColumn:
         fd = (float(hexane_purity(2.0 + eps))
               - float(hexane_purity(2.0 - eps))) / (2 * eps)
         assert float(g) == pytest.approx(fd, rel=1e-4)
+
+    def test_condenser_is_well_below_the_top_stage_for_a_wide_cut(
+        self, thermo_pair, column_params, feed
+    ):
+        """Where this matters most: a C3-C8 distillate spans a wide boiling
+        range, so its bubble point is tens of degrees under the top stage's."""
+        _, cubic = thermo_pair
+        column = DistillationColumn(column_params, cubic)
+
+        distillate, _, info = column(feed, R=2.0, B_spec=40.0)
+
+        T_bubble, _ = column._bubble_point_T(
+            info["y_profile"][-1], jnp.asarray(self.P),
+            T_guess=info["T_profile"][-1],
+        )
+        assert float(distillate["T"]) == pytest.approx(float(T_bubble), rel=1e-9)
+        assert float(info["T_profile"][-1]) - float(info["T_condenser"]) > 20.0
+
+        # And it is a real EOS bubble point: the flash puts the vapor fraction
+        # at zero there and lifts it off just above.
+        from difflow.eos import flash_TP_eos
+
+        x_D = info["y_profile"][-1]
+        V_below, _, _ = flash_TP_eos(cubic.eos, x_D, info["T_condenser"] - 2.0, self.P)
+        V_above, _, _ = flash_TP_eos(cubic.eos, x_D, info["T_condenser"] + 2.0, self.P)
+        assert float(V_below) == pytest.approx(0.0, abs=1e-6)
+        assert float(V_above) > 1e-3
 
     def test_cubic_column_duties_are_physical(
         self, thermo_pair, column_params, feed

--- a/tests/test_distillation.py
+++ b/tests/test_distillation.py
@@ -360,3 +360,211 @@ class TestMulticomponentDistillation:
         # Heavy should go to bottoms
         heavy_recovery_bot = float(bot_flows["heavy"]) / 40.0
         assert heavy_recovery_bot > 0.8  # Most heavy goes to bottom
+
+
+class TestCubicThermoColumn:
+    """Rigorous column on a cubic EOS instead of Raoult's law (issue #210).
+
+    The reference the numbers are checked against is the EOS's own rigorous
+    flash (``flash_TP_eos``), which is an independent path through the same
+    Peng-Robinson object: if the column's stage K-values are right, the
+    temperature they put a stage's bubble point at is the temperature that
+    flash puts the vapor fraction at zero.
+    """
+
+    SPECIES = ["propane", "isobutane", "n_butane", "isopentane",
+               "n_pentane", "n_hexane", "n_heptane", "n_octane"]
+    P = 10e5
+
+    @pytest.fixture
+    def thermo_pair(self):
+        from difflow.database import get_critical_props, get_species_data
+        from difflow.eos import PengRobinson
+        from difflow.thermo import CubicThermo
+
+        ideal = IdealThermo({s: get_species_data(s) for s in self.SPECIES})
+        eos = PengRobinson({s: get_critical_props(s) for s in self.SPECIES})
+        return ideal, CubicThermo(ideal, eos)
+
+    @pytest.fixture
+    def column_params(self):
+        return DistillationColumnParams(
+            species_order=self.SPECIES,
+            n_stages=12,
+            feed_stage=6,
+            condenser_type="total",
+            P=self.P,
+        )
+
+    @pytest.fixture
+    def feed(self):
+        return make_stream(
+            dict(zip(self.SPECIES, [10.0, 7.0, 7.0, 8.0, 8.0, 20.0, 10.0, 30.0])),
+            T=380.0,
+            P=self.P,
+        )
+
+    def test_k_values_are_the_fugacity_coefficient_ratio(self, thermo_pair):
+        """K_i = phi_i^L(x) / phi_i^V(y) when both compositions are given."""
+        _, cubic = thermo_pair
+        x = jnp.array([0.30, 0.20, 0.20, 0.10, 0.10, 0.05, 0.03, 0.02])
+        y = jnp.array([0.60, 0.15, 0.12, 0.05, 0.04, 0.02, 0.01, 0.01])
+
+        K = cubic.K_values_array(330.0, self.P, x, y)
+        expected = (
+            cubic.eos.fugacity_coefficient(330.0, self.P, x, "liquid")
+            / cubic.eos.fugacity_coefficient(330.0, self.P, y, "vapor")
+        )
+        assert jnp.allclose(K, expected)
+
+    def test_k_values_dict_matches_array(self, thermo_pair):
+        """The dict form is the array form, keyed in the EOS's species order."""
+        _, cubic = thermo_pair
+        x = jnp.full(len(self.SPECIES), 1.0 / len(self.SPECIES))
+        K_arr = cubic.K_values_array(350.0, self.P, x)
+        K_dict = cubic.K_values(350.0, self.P, x)
+        for i, s in enumerate(cubic.eos.species_order):
+            assert float(K_dict[s]) == pytest.approx(float(K_arr[i]))
+
+    def test_k_values_without_composition_fall_back_to_raoult(self, thermo_pair):
+        """With no composition there is no fugacity coefficient to form."""
+        ideal, cubic = thermo_pair
+        assert jnp.allclose(
+            cubic.K_values_array(350.0, self.P),
+            ideal.K_values_array(350.0, self.P),
+        )
+
+    def test_ideal_thermo_ignores_compositions(self, thermo_pair):
+        """IdealThermo takes x and y for call compatibility and ignores them."""
+        ideal, _ = thermo_pair
+        x = jnp.full(len(self.SPECIES), 1.0 / len(self.SPECIES))
+        y = jnp.array([0.60, 0.15, 0.12, 0.05, 0.04, 0.02, 0.01, 0.01])
+        assert jnp.allclose(
+            ideal.K_values_array(350.0, self.P, x, y),
+            ideal.K_values_array(350.0, self.P),
+        )
+
+    @pytest.mark.parametrize("x_raw", [
+        [10.0, 7.0, 7.0, 8.0, 8.0, 20.0, 10.0, 30.0],       # feed
+        [0.38, 0.16, 0.13, 0.09, 0.08, 0.10, 0.03, 0.04],   # light cut
+        [1e-9, 1e-9, 1e-9, 1e-9, 1e-9, 0.002, 0.25, 0.748],  # heavy cut
+    ])
+    def test_bubble_point_agrees_with_eos_flash(
+        self, thermo_pair, column_params, x_raw
+    ):
+        """The stage bubble point is where the EOS flash's vapor fraction lifts
+        off zero -- checked against ``flash_TP_eos``, not against itself."""
+        from difflow.eos import flash_TP_eos
+
+        _, cubic = thermo_pair
+        column = DistillationColumn(column_params, cubic)
+        x = jnp.array(x_raw)
+        x = x / jnp.sum(x)
+
+        T_bub, y = column._bubble_point_T(
+            x, jnp.asarray(self.P), T_guess=jnp.asarray(350.0)
+        )
+        assert jnp.isfinite(T_bub)
+
+        V_below, _, _ = flash_TP_eos(cubic.eos, x, T_bub - 2.0, self.P)
+        V_above, _, _ = flash_TP_eos(cubic.eos, x, T_bub + 2.0, self.P)
+        assert float(V_below) == pytest.approx(0.0, abs=1e-6)
+        assert float(V_above) > 1e-3
+
+        # sum(K x) = 1 at the bubble point, and y is that vapor.
+        K = cubic.K_values_array(T_bub, self.P, x)
+        assert float(jnp.sum(K * x)) == pytest.approx(1.0, abs=1e-4)
+        assert float(jnp.sum(y)) == pytest.approx(1.0)
+
+    def test_eos_bubble_point_differs_from_raoult_for_light_ends(
+        self, thermo_pair, column_params
+    ):
+        """The reason the issue matters: Raoult's law is tens of degrees out for
+        light hydrocarbons at 10 bar, and within a degree for the heavy end."""
+        ideal, cubic = thermo_pair
+        col_i = DistillationColumn(column_params, ideal)
+        col_c = DistillationColumn(column_params, cubic)
+        P = jnp.asarray(self.P)
+        T_guess = jnp.asarray(350.0)
+
+        light = jnp.array([0.70, 0.15, 0.10, 0.03, 0.01, 0.005, 0.003, 0.002])
+        light = light / jnp.sum(light)
+        heavy = jnp.array([1e-9, 1e-9, 1e-9, 1e-9, 1e-9, 0.002, 0.25, 0.748])
+        heavy = heavy / jnp.sum(heavy)
+
+        d_light = float(col_c._bubble_point_T(light, P, T_guess)[0]
+                        - col_i._bubble_point_T(light, P, T_guess)[0])
+        d_heavy = float(col_c._bubble_point_T(heavy, P, T_guess)[0]
+                        - col_i._bubble_point_T(heavy, P, T_guess)[0])
+
+        assert abs(d_light) > 10.0
+        assert abs(d_heavy) < 2.0
+
+    def test_column_runs_on_cubic_thermo(self, thermo_pair, column_params, feed):
+        """The issue's reproducer: no AttributeError, and a physical answer."""
+        _, cubic = thermo_pair
+        column = DistillationColumn(column_params, cubic)
+
+        distillate, bottoms, info = column(feed, R=2.0, B_spec=40.0)
+
+        d_flows = get_flows(distillate)
+        b_flows = get_flows(bottoms)
+        assert all(jnp.isfinite(v).all() for v in d_flows.values())
+        assert all(jnp.isfinite(v).all() for v in b_flows.values())
+        assert jnp.isfinite(info["T_profile"]).all()
+
+        # Total material balance closes exactly (D and B are specified and the
+        # product compositions are normalised); the per-species split is only
+        # as tight as the MESH sweep itself, on this thermo package as on the
+        # ideal one.
+        feed_flows = get_flows(feed)
+        F_total = sum(float(v) for v in feed_flows.values())
+        assert sum(float(v) for v in d_flows.values()) + sum(
+            float(v) for v in b_flows.values()
+        ) == pytest.approx(F_total, rel=1e-8)
+        for s in self.SPECIES:
+            assert float(d_flows[s] + b_flows[s]) == pytest.approx(
+                float(feed_flows[s]), rel=0.05
+            )
+
+        # Monotonically hotter down the column, and the light key goes up.
+        T = info["T_profile"]
+        assert float(T[0]) > float(T[-1])
+        assert float(d_flows["propane"]) > float(b_flows["propane"])
+        assert float(b_flows["n_octane"]) > float(d_flows["n_octane"])
+
+        # Every stage sits at its own bubble point on the EOS K-values.
+        x = info["x_profile"]
+        for j in (0, 10, column_params.n_stages - 1):
+            K = cubic.K_values_array(T[j], self.P, x[j])
+            assert float(jnp.sum(K * x[j])) == pytest.approx(1.0, abs=1e-3)
+
+    def test_cubic_column_gradients(self, thermo_pair, column_params, feed):
+        """AD still runs through the EOS column, and matches finite difference."""
+        _, cubic = thermo_pair
+        column = DistillationColumn(column_params, cubic)
+
+        def hexane_purity(R):
+            distillate, _, _ = column(feed, R=R, B_spec=40.0)
+            total = sum(distillate[f"F_{s}"] for s in self.SPECIES)
+            return distillate["F_n_hexane"] / total
+
+        g = jax.grad(hexane_purity)(2.0)
+        assert jnp.isfinite(g)
+
+        eps = 1e-3
+        fd = (float(hexane_purity(2.0 + eps))
+              - float(hexane_purity(2.0 - eps))) / (2 * eps)
+        assert float(g) == pytest.approx(fd, rel=1e-4)
+
+    def test_cubic_column_duties_are_physical(
+        self, thermo_pair, column_params, feed
+    ):
+        """The EOS enthalpy path (departure, not Watson Hvap) still gives a
+        condenser that removes heat and a reboiler that adds it."""
+        _, cubic = thermo_pair
+        column = DistillationColumn(column_params, cubic)
+        _, _, info = column(feed, R=2.0, B_spec=40.0)
+
+        assert float(info["Q_condenser"]) < 0.0
+        assert float(info["Q_reboiler"]) > 0.0

--- a/tests/test_distillation.py
+++ b/tests/test_distillation.py
@@ -213,6 +213,189 @@ class TestShortcutColumn:
         assert float(grad_R) < 0
 
 
+class TestBubblePointRobustness:
+    """The bubble-point solve has to reach the root from a cold start.
+
+    Vapor pressure is exponential in -1/T, so a few hundred degrees below the
+    bubble point both sum(K x) and its slope are ~0 and a plain Newton step is
+    one tiny number divided by another. This came up for real: the shortcut
+    column's column-end temperatures are bubble points seeded from the feed,
+    and a feed 250 K below its own bubble point sent the solve to -1e157.
+    """
+
+    @pytest.fixture
+    def far_from_boiling_thermo(self):
+        """Two species whose normal boiling points are ~600 K and ~641 K."""
+        return IdealThermo({
+            "A": SpeciesData(
+                name="A", MW=100.0, Cp_coeffs=(75.0, 0.0, 0.0, 0.0),
+                Hvap_coeffs=(30000.0, 0.38, 750.0),
+                antoine_coeffs=(10.0, 2800.0, -40.0),
+            ),
+            "B": SpeciesData(
+                name="B", MW=100.0, Cp_coeffs=(75.0, 0.0, 0.0, 0.0),
+                Hvap_coeffs=(30000.0, 0.38, 790.0),
+                antoine_coeffs=(10.0, 3000.0, -40.0),
+            ),
+        })
+
+    @pytest.mark.parametrize("T_guess", [100.0, 250.0, 365.0, 620.0, 1500.0])
+    def test_reaches_the_root_from_any_start(
+        self, far_from_boiling_thermo, T_guess
+    ):
+        from difflow.units.distillation import _bubble_T
+
+        x = jnp.array([0.5, 0.5])
+        P = jnp.asarray(101325.0)
+        T, y = _bubble_T(far_from_boiling_thermo, x, P, jnp.asarray(T_guess))
+
+        assert jnp.isfinite(T)
+        # Between the two pure boiling points, and satisfying sum(K x) = 1.
+        assert 600.0 < float(T) < 641.0
+        K = far_from_boiling_thermo.K_values_array(T, P)
+        assert float(jnp.sum(K * x)) == pytest.approx(1.0, abs=1e-8)
+        assert float(jnp.sum(y)) == pytest.approx(1.0)
+
+    def test_shortcut_column_survives_a_cold_feed(self, far_from_boiling_thermo):
+        """The case that surfaced it: the feed is 250 K under its bubble point,
+        and the design still comes out finite and feasible."""
+        column = ShortcutColumn(
+            ShortcutColumnParams(
+                species_order=["A", "B"], light_key="A", heavy_key="B",
+            ),
+            far_from_boiling_thermo,
+        )
+        feed = make_stream({"A": 0.5, "B": 0.5}, T=365.0, P=101325.0)
+        distillate, bottoms, info = column(feed, R=2.0, P=101325.0)
+
+        assert jnp.isfinite(distillate["T"])
+        assert jnp.isfinite(bottoms["T"])
+        assert jnp.isfinite(info["N_min"])
+        # Nearly pure products, so each end sits at a pure boiling point.
+        assert float(info["T_top"]) == pytest.approx(600.6, abs=1.0)
+        assert float(info["T_bot"]) == pytest.approx(640.7, abs=1.0)
+        assert bool(info["feasible"])
+
+
+class TestShortcutColumnEndTemperatures:
+    """The column ends are bubble points, not estimates around the feed."""
+
+    def _column(self, thermo):
+        params = ShortcutColumnParams(
+            species_order=["light", "middle", "heavy"],
+            light_key="middle",
+            heavy_key="heavy",
+            x_D_LK=0.95,
+            x_B_HK=0.95,
+        )
+        return ShortcutColumn(params, thermo)
+
+    def _feed(self):
+        return make_stream(
+            {"light": 20.0, "middle": 40.0, "heavy": 40.0}, T=400.0, P=101325.0
+        )
+
+    def test_products_leave_at_their_own_bubble_points(
+        self, multicomponent_thermo
+    ):
+        """Distillate at the condenser (bubble point of x_D), bottoms at the
+        reboiler (bubble point of x_B) -- checked by re-solving each from a
+        different starting temperature."""
+        from difflow.units.distillation import _bubble_T
+
+        column = self._column(multicomponent_thermo)
+        distillate, bottoms, info = column(self._feed(), R=3.0, P=101325.0)
+
+        order = ["light", "middle", "heavy"]
+        x_D = jnp.array([info["x_D"][s] for s in order])
+        x_B = jnp.array([info["x_B"][s] for s in order])
+        P = jnp.asarray(101325.0)
+
+        T_D, _ = _bubble_T(multicomponent_thermo, x_D, P, jnp.asarray(300.0))
+        T_B, _ = _bubble_T(multicomponent_thermo, x_B, P, jnp.asarray(500.0))
+
+        assert float(info["T_top"]) == pytest.approx(float(T_D), rel=1e-6)
+        assert float(info["T_bot"]) == pytest.approx(float(T_B), rel=1e-6)
+        assert float(distillate["T"]) == pytest.approx(float(info["T_top"]))
+        assert float(bottoms["T"]) == pytest.approx(float(info["T_bot"]))
+        assert float(info["T_condenser"]) == pytest.approx(float(info["T_top"]))
+        assert float(info["T_reboiler"]) == pytest.approx(float(info["T_bot"]))
+
+        # The column really does run hot at the bottom and cool at the top.
+        assert float(info["T_bot"]) > float(info["T_top"])
+
+    def test_end_temperatures_do_not_track_the_feed_temperature(
+        self, multicomponent_thermo
+    ):
+        """They are set by the products at the column pressure, so feeding the
+        same mixture in hotter cannot move them."""
+        column = self._column(multicomponent_thermo)
+        _, _, cold = column(
+            make_stream({"light": 20.0, "middle": 40.0, "heavy": 40.0},
+                        T=340.0, P=101325.0),
+            R=3.0, P=101325.0,
+        )
+        _, _, hot = column(
+            make_stream({"light": 20.0, "middle": 40.0, "heavy": 40.0},
+                        T=460.0, P=101325.0),
+            R=3.0, P=101325.0,
+        )
+        assert float(cold["T_top"]) == pytest.approx(float(hot["T_top"]), rel=1e-6)
+        assert float(cold["T_bot"]) == pytest.approx(float(hot["T_bot"]), rel=1e-6)
+
+    def test_end_temperatures_rise_with_pressure(self, multicomponent_thermo):
+        """A bubble point does depend on pressure, and the estimate it replaced
+        did not."""
+        column = self._column(multicomponent_thermo)
+        _, _, low = column(self._feed(), R=3.0, P=101325.0)
+        _, _, high = column(
+            make_stream({"light": 20.0, "middle": 40.0, "heavy": 40.0},
+                        T=400.0, P=5 * 101325.0),
+            R=3.0, P=5 * 101325.0,
+        )
+        assert float(high["T_top"]) > float(low["T_top"])
+        assert float(high["T_bot"]) > float(low["T_bot"])
+
+    def test_volatilities_come_from_the_end_temperatures(
+        self, multicomponent_thermo
+    ):
+        """alpha is the geometric mean of the two ends, and the reported ends
+        are the converged ones -- so recomputing alpha from info reproduces it."""
+        column = self._column(multicomponent_thermo)
+        _, _, info = column(self._feed(), R=3.0, P=101325.0)
+
+        order = ["light", "middle", "heavy"]
+        x_D = jnp.array([info["x_D"][s] for s in order])
+        x_B = jnp.array([info["x_B"][s] for s in order])
+        alpha = column.average_alpha(
+            info["T_top"], info["T_bot"], jnp.asarray(101325.0), x_D, x_B
+        )
+        for s in order:
+            assert float(alpha[s]) == pytest.approx(float(info["alpha"][s]), rel=1e-9)
+
+    def test_duties_still_physical(self, multicomponent_thermo):
+        column = self._column(multicomponent_thermo)
+        _, _, info = column(self._feed(), R=3.0, P=101325.0)
+        assert float(info["Q_condenser"]) < 0.0
+        assert float(info["Q_reboiler"]) > 0.0
+
+    def test_gradients_survive_the_fixed_point(self, multicomponent_thermo):
+        """The end temperatures are an unrolled fixed point, so AD still runs
+        through the whole design calculation."""
+        column = self._column(multicomponent_thermo)
+        feed = self._feed()
+
+        def stages(R):
+            _, _, info = column(feed, R=R, P=101325.0)
+            return info["N"]
+
+        g = jax.grad(stages)(3.0)
+        assert jnp.isfinite(g)
+        eps = 1e-4
+        fd = (float(stages(3.0 + eps)) - float(stages(3.0 - eps))) / (2 * eps)
+        assert float(g) == pytest.approx(fd, rel=1e-4)
+
+
 class TestDesignFunctions:
     """Tests for standalone design functions."""
 
@@ -681,6 +864,59 @@ class TestCubicThermoColumn:
         V_above, _, _ = flash_TP_eos(cubic.eos, x_D, info["T_condenser"] + 2.0, self.P)
         assert float(V_below) == pytest.approx(0.0, abs=1e-6)
         assert float(V_above) > 1e-3
+
+    def test_shortcut_column_runs_on_cubic_thermo(self, thermo_pair, feed):
+        """The shortcut column reaches the EOS through the same K-value and
+        enthalpy interfaces, so it runs on Peng-Robinson too -- and the answer
+        is not the ideal one."""
+        ideal, cubic = thermo_pair
+        params = ShortcutColumnParams(
+            species_order=self.SPECIES,
+            light_key="n_pentane",
+            heavy_key="n_hexane",
+            x_D_LK=0.98,
+            x_B_HK=0.98,
+        )
+
+        results = {}
+        for name, thermo in (("ideal", ideal), ("eos", cubic)):
+            column = ShortcutColumn(params, thermo)
+            distillate, bottoms, info = column(feed, R=2.0, P=self.P, q=1.0)
+            assert jnp.isfinite(distillate["T"])
+            assert jnp.isfinite(info["N_min"])
+            assert float(info["Q_condenser"]) < 0.0
+            assert float(info["Q_reboiler"]) > 0.0
+            results[name] = info
+
+        # Raoult overstates the light key's volatility at 10 bar, so it
+        # promises the separation in fewer stages than the EOS does.
+        assert float(results["ideal"]["alpha_LK"]) > float(results["eos"]["alpha_LK"])
+        assert float(results["ideal"]["N_min"]) < float(results["eos"]["N_min"])
+
+    def test_shortcut_column_end_temperatures_are_eos_bubble_points(
+        self, thermo_pair, feed
+    ):
+        """And its column ends are EOS bubble points: the flash puts the vapor
+        fraction at zero there and lifts it off just above."""
+        from difflow.eos import flash_TP_eos
+
+        _, cubic = thermo_pair
+        column = ShortcutColumn(
+            ShortcutColumnParams(
+                species_order=self.SPECIES, light_key="n_pentane",
+                heavy_key="n_hexane", x_D_LK=0.98, x_B_HK=0.98,
+            ),
+            cubic,
+        )
+        _, _, info = column(feed, R=2.0, P=self.P, q=1.0)
+
+        for key, T_key in (("x_D", "T_top"), ("x_B", "T_bot")):
+            comp = jnp.array([info[key][s] for s in self.SPECIES])
+            T = info[T_key]
+            V_below, _, _ = flash_TP_eos(cubic.eos, comp, T - 2.0, self.P)
+            V_above, _, _ = flash_TP_eos(cubic.eos, comp, T + 2.0, self.P)
+            assert float(V_below) == pytest.approx(0.0, abs=1e-6)
+            assert float(V_above) > 1e-3
 
     def test_cubic_column_duties_are_physical(
         self, thermo_pair, column_params, feed

--- a/tests/test_docs_examples.py
+++ b/tests/test_docs_examples.py
@@ -1,0 +1,69 @@
+"""Execute the code examples in the docs, so they cannot silently rot.
+
+Documentation that names parameters the code does not have is worse than no
+documentation: it reads as authoritative. This module extracts the fenced
+``python`` blocks out of a documented section and runs them, so a rename in the
+source breaks the test rather than the reader.
+
+Scope is deliberately narrow -- the sections listed in ``DOC_SECTIONS`` are the
+ones whose examples have been checked line by line against the code. Widen it a
+section at a time, after auditing that section; a blanket sweep over every doc
+would fail on prose-style snippets that were never meant to run.
+"""
+
+import pathlib
+import re
+
+import jax
+import pytest
+
+jax.config.update("jax_enable_x64", True)
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+# (file, section heading, heading that ends it)
+DOC_SECTIONS = [
+    ("docs/unit-operations-chemical.md", "## Distillation", "## Heat Exchangers"),
+]
+
+
+def _blocks(doc: str, start_heading: str, end_heading: str):
+    """Fenced python blocks between two headings, with their line numbers."""
+    text = (REPO_ROOT / doc).read_text()
+    start = text.index(start_heading)
+    end = text.index(end_heading, start)
+    section = text[start:end]
+    for match in re.finditer(r"```python\n(.*?)```", section, re.S):
+        line_no = text[:start].count("\n") + section[:match.start()].count("\n") + 2
+        yield match.group(1), line_no
+
+
+def _is_runnable(block: str) -> bool:
+    """Skip the blocks that are illustrations rather than programs.
+
+    A dataclass field listing documents a signature; a one-liner showing a call
+    shape has no bindings behind it. Everything else is expected to run.
+    """
+    stripped = block.strip()
+    if stripped.startswith("@dataclass"):
+        return False
+    return len(stripped.splitlines()) > 1
+
+
+def _cases():
+    for doc, start, end in DOC_SECTIONS:
+        for block, line_no in _blocks(doc, start, end):
+            if _is_runnable(block):
+                yield pytest.param(block, id=f"{pathlib.Path(doc).name}:{line_no}")
+
+
+@pytest.mark.parametrize("block", list(_cases()))
+def test_doc_example_runs(block):
+    """Every runnable example in a covered section executes without error."""
+    namespace: dict = {}
+    exec(compile(block, "<doc example>", "exec"), namespace)
+
+
+def test_the_extractor_finds_examples():
+    """Guard against the scraper silently matching nothing after an edit."""
+    assert len(list(_cases())) >= 3


### PR DESCRIPTION
Fixes #210.

The rigorous `DistillationColumn` called `thermo.K_values_array(T, P)`, which
only `IdealThermo` had, so the MESH column was pinned to Raoult's law even when
the rest of the flowsheet was on Peng-Robinson. Fixing that turned up three
more things in the same code, each of which is a commit here.

## 1. `CubicThermo` gets the K-value interface

`K_i = phi_i^L(T,P,x) / phi_i^V(T,P,y)`, from the fugacity coefficients
`PengRobinson` already computes. `IdealThermo.K_values{,_array}` take the same
`x`/`y` and ignore them, so one column body serves both packages;
`K_depends_on_composition` distinguishes them. Stage enthalpies go through
`thermo.stream_enthalpy` instead of summing `H_pure` — bit-identical for
`IdealThermo`, EOS departure for `CubicThermo`, so the same EOS supplies the
latent heat as the K-values.

Two properties of EOS K-values shaped the solve. They **depend on composition**,
so they are a fixed point: whatever the caller omits is filled by a bounded
successive substitution. And they **only exist where the cubic has two roots** —
off the bubble point there is one root, both phases take it, and `K` comes back
identically 1. That is the EOS correctly reporting a single phase, but it makes
`sum(K x) - 1` a flat zero that a root finder reads as converged wherever it is
standing (the first attempt produced stage temperatures around -1e204). The
bubble point is now solved in two passes: Newton on ideal K-values to land
inside the two-root window, then a step-capped Newton on the EOS K-values that
bisects back if a step leaves it. Worst case is the ideal-K answer, never a NaN.

## 2. The distillate leaves the condenser, not the top stage

It was reported at `T_profile[-1]`. A total condenser condenses the whole of the
top stage's vapor, so the product is a saturated liquid of composition `x_D` at
its **own bubble point**. The gap is the boiling range of the distillate — the
top stage sits at the *dew* point of the vapor it sends up — which is why every
near-pure binary looked right:

| distillate | top stage T | condenser T | gap |
|---|---|---|---|
| 99.6 % benzene/toluene, 1 atm | 369.1 K | 368.7 K | 0.3 K |
| C3-C8 cut, 10 bar (PR) | 401.7 K | 363.3 K | 38 K |

`Q_cond` and the MESH reflux enthalpy move with it: the reflux re-enters the top
stage subcooled, which shifts the converged L/V profile.

## 3. The shortcut column's ends come from its products

`ShortcutColumn` set `T_top`/`T_bot` to `T_feed * (1 -/+ 0.05)`. Those are where
it evaluates the relative volatilities driving the whole
Fenske-Underwood-Gilliland chain, so the guess propagated into `N_min`, `R_min`,
`N` and the feed stage. They are now the condenser and reboiler bubble points,
solved as a small fixed point (the products come from the volatilities, the
volatilities are evaluated at the products' bubble points), seeded from the
feed's bubble point and swept three times — settling to under 0.01 K, unrolled
so `jax.grad` still runs through the design.

It also runs on a `CubicThermo` now, which it could not before. That matters for
the same reason the issue does: on a C3-C8 cut at 10 bar the light key's alpha
is **2.32 on Raoult against 1.81 on Peng-Robinson**, which is 3.7 minimum stages
against 5.6.

Doing this exposed a real gap in the bubble-point solve that the rigorous column
had never hit, because its stage guesses are always warm: vapor pressure is
exponential in `-1/T`, so a couple of hundred degrees below the bubble point
`sum(K x)` and its slope are both round-off from zero and a Newton step divides
one by the other. A feed 250 K under its bubble point sent the solve to
**-1e157**. It now takes a few damped steps on `log(sum(K x))` first — nearly
linear in `1/T` — before Newton on the residual itself, which optimistix
differentiates implicitly so the seed never enters the gradient.

## 4. The documented API matched neither column

Both `Params` blocks in `docs/unit-operations-chemical.md` were wrong in every
field (integer key indices, `x_D_lk`, a `reflux_ratio` parameter, `P_top`/
`P_bottom`); the Outputs table named `N_actual`, `condenser_duty` and
`feed_stage` for what are `N`, `Q_condenser` and `N_feed`; the utility example
called three of four correlations with their arguments in the wrong order.

Two were wrong in a way a reader could not have caught: `x_D_LK`/`x_B_HK` are
documented as mole fractions and are **recoveries** (on a 20/40/40 feed,
`x_D_LK=0.99` leaves the light key at a mole fraction of 0.66), and the rigorous
column's stage numbering was given as `1 = reboiler, n_stages = condenser` when
it is zero-based from the bottom with the condenser outside the cascade
entirely — the exact distinction §2 turns on.

`condenser_type='partial'` was accepted and silently solved as a total
condenser; it now raises `NotImplementedError`. Nothing in the repo passed it.

## Verification

Checked against things that are not this code:

- Stage bubble points against the EOS's own rigorous flash: `flash_TP_eos` puts
  the vapor fraction at zero two degrees below each one and lifts it off two
  degrees above.
- The reported distillate temperature satisfies `sum(K x_D) = 1` to 1e-6 on both
  thermo packages, i.e. it is genuinely a saturated liquid.
- The overall energy balance `F h_F + Q_reb = D h_D + B h_B + |Q_cond|` closes to
  zero.
- AD through the Peng-Robinson column matches finite differences to six digits;
  so does `jax.grad` through the shortcut column's fixed point.

`tests/test_docs_examples.py` extracts the fenced Python blocks from the audited
doc section and runs them, so a rename breaks the test rather than the reader —
verified it fails by renaming an `info` key. A separate check confirms all 32
`info` keys named in that section exist.

182 tests pass across `test_distillation`, `test_lle_distillation_bugs`,
`test_tier2_core_issues`, `test_catalog`, `test_serialize`, `test_codegen` and
the new doc-example tests; `tests/power`, `tests/ree`, `test_eos`,
`test_eos_units`, `test_heat_exchanger`, `test_cstr` and the flash tests pass
separately. Two full-suite runs aborted mid-way with an XLA
`backend_compile_and_load` abort in a *different* test each time, both of which
pass in isolation — container flakiness on long JAX compile chains, not a
regression, which is why the runs above are batched.

## Found and deliberately left

Filed rather than fixed, since each would move results that want their own
before/after:

- #211 — the CMO path (`use_mesh=False`) violates the per-species material
  balance: 51.7 mol/s of n-pentane leaves a column fed 30 mol/s of it.
- #212 — `feed_stage` is counted as rectifying by the CMO sweep and as stripping
  by the MESH flow initialisation.
- #213 — `Params` field descriptions never reach `difflow.catalog`: 87 Params
  classes, none carrying the `metadata` the catalog reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FFGzM5prELR6qYdMn9mSXG

---
_Generated by [Claude Code](https://claude.ai/code/session_01FFGzM5prELR6qYdMn9mSXG)_