### PR TITLE
test(flexibility): stop the brute-force oracle from OOM-killing the 3.10 job

### DIFF
--- a/tests/test_flexibility.py
+++ b/tests/test_flexibility.py
@@ -115,17 +115,27 @@ CURVED_SET = {"a": (1.0, 0.3, 0.2), "b": (2.0, 0.5, 0.4), "c": (0.5, 0.25, 0.1)}
 CURVED_CONTROLS = {"u": (0.0, 6.0)}
 
 
-def brute_force_psi(theta_lo, theta_hi, u_lo, u_hi, f_np, n_theta=31, n_u=4001):
+def brute_force_psi(theta_lo, theta_hi, u_lo, u_hi, f_np, n_theta=31, n_u=4001,
+                    u_chunk=256):
     """``max_theta min_u max_j f_j`` on a dense grid, in plain numpy.
 
     Returns ``(psi, theta_star)``.  This is the independent oracle: it shares
     no code with the module under test.
+
+    The ``u`` axis is walked in blocks of ``u_chunk``.  ``min`` over the whole
+    grid is the min of the per-block minima, so the answer is bit-identical to
+    the one-shot form -- but the one-shot form materialises ``n_theta**3 x
+    n_u`` twice and then stacks it, which for the defaults is 3.6 GB resident
+    and enough to get the runner killed part way through the suite.
     """
     grids = [np.linspace(lo, hi, n_theta)
              for lo, hi in zip(theta_lo, theta_hi)]
     thetas = np.array(list(itertools.product(*grids)))
     us = np.linspace(u_lo, u_hi, n_u)
-    inner = np.max(f_np(thetas, us), axis=0).min(axis=1)
+    inner = np.full(thetas.shape[0], np.inf)
+    for start in range(0, n_u, u_chunk):
+        block = np.max(f_np(thetas, us[start:start + u_chunk]), axis=0).min(axis=1)
+        np.minimum(inner, block, out=inner)
     k = int(np.argmax(inner))
     return float(inner[k]), thetas[k]
 


### PR DESCRIPTION
## What is broken

`test (3.10)` on `main` has failed twice since #221 landed — once on `c72f200`, once on `8e12b31` — and neither failure is a test failure. Both end:

```
tests/test_flexibility.py::TestFeasibilityFunction::test_critical_realization_is_the_true_argmax
##[error]The runner has received a shutdown signal.
##[error]Process completed with exit code 143.
```

Same test, same 59% mark, **1665 passed / 0 failed** to that point, ~24 minutes into a 45-minute cap, on two different runners. Not the timeout, not an assertion — the runner being killed under memory pressure. 3.11 and 3.12 pass this same test on the same commits, so 3.10 is simply the job that loses the race.

#221 was necessary but this is a second, independent 3.10 problem that the asdex install failure was masking.

## The cause

`brute_force_psi` materialises the whole grid at once. For the defaults (`n_theta=31`, `n_u=4001`, so `31**3 = 29791` parameter points):

| step | resident |
|---|---|
| `f0` | 0.89 GB |
| `f1` | 0.89 GB |
| `np.stack([f0, f1])` | 1.78 GB (with `f0`, `f1` still live) |
| `np.max(..., axis=0)` | 0.89 GB |

Measured standalone with `resource.getrusage`: **3.59 GB peak RSS** for that single call, arriving on top of everything JAX is holding 59% into the suite.

## The fix

Walk the `u` axis in blocks of 256 and keep a running `np.minimum`. `min` over the full grid equals the min of the per-block minima, so this is an associativity rewrite, not a weakened oracle:

- still evaluates every one of the 29791 × 4001 grid points;
- still shares no code with the module under test;
- returns bit-identical answers — `psi = -0.08499999999999996`, `theta = [1.2, 2.4, 0.25]` before and after.

## Measured effect

| | before | after |
|---|---|---|
| `brute_force_psi` call, peak RSS | 3.59 GB | 0.26 GB |
| this test's contribution to peak RSS across the file | ~3.6 GB | 0.36 GB |
| `tests/test_flexibility.py` | 80 passed | 80 passed |

After the patch this test is no longer an outlier — every remaining per-test delta in the file is under 0.4 GB and is ordinary JAX accumulation.

## What this does not claim

It does not claim 3.10 is now comfortable. The fast suite's high-water mark is cumulative across every file in one process, and this removes the single largest spike rather than lowering the baseline. If 3.10 falls over again somewhere else, that is a separate finding — but this spike is 10× anything else in the file and reproduced identically twice, so it is the one to remove first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UC5Y7FcrQz1humuVkWyUxZ
