### PR TITLE
fix(gui): say which port is taken instead of raising from socketserver

### DIFF
--- a/src/difflow/gui/server.py
+++ b/src/difflow/gui/server.py
@@ -8,10 +8,13 @@ Deliberately stdlib only --- see :mod:`difflow.gui`.
 
 from __future__ import annotations
 
+import errno
 import hmac
 import html
 import json
 import secrets
+import socket
+import sys
 import threading
 import webbrowser
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -436,6 +439,54 @@ def serve(
         server.server_close()
 
 
+def free_port_near(port: int, tries: int = 20) -> int:
+    """The first bindable port after ``port``, for use in a suggestion.
+
+    A message that names a command has to name one that works, so the
+    candidate is actually bound and released rather than guessed. That
+    makes it a suggestion and not a reservation --- the socket is closed
+    again immediately, and something else may take it in between. The
+    fallback if the whole window is busy is ``port + 1``, which is no
+    worse than saying nothing.
+    """
+    for candidate in range(port + 1, port + 1 + tries):
+        with socket.socket() as probe:
+            probe.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            try:
+                probe.bind((HOST, candidate))
+            except OSError:
+                continue
+            return candidate
+    return port + 1
+
+
+def port_in_use_message(port: int, prog: str) -> str:
+    """What to say when the bind fails because the port is taken.
+
+    Worth spelling out rather than letting the ``OSError`` through: the
+    traceback surfaces from inside ``socketserver`` with the port itself
+    nowhere in it, so the reader learns that *a* socket is in use and
+    nothing about which one or what to do. Nine times in ten the answer
+    is that they already have the editor open.
+
+    ``SO_REUSEADDR`` is not the fix and is not offered as one. It is
+    already set --- ``HTTPServer`` turns it on --- and it only relieves a
+    socket in ``TIME_WAIT``. A live listener is meant to refuse; the
+    flag that would override that, ``SO_REUSEPORT``, would leave two
+    editors sharing the port and requests landing on whichever won.
+    """
+    return (
+        f"{prog}: port {port} on {HOST} is already in use.\n"
+        f"\n"
+        f"An editor is probably running there already --- open\n"
+        f"    http://{HOST}:{port}/\n"
+        f"before starting a second one. To run another alongside it, or if\n"
+        f"that address is something else entirely, pick a free port:\n"
+        f"\n"
+        f"    {prog} --port {free_port_near(port)}\n"
+    )
+
+
 def main(argv: list[str] | None = None, prog: str = "difflow gui") -> int:
     """``difflow gui [flowsheet.json] [--port N] [--no-browser]``.
 
@@ -458,8 +509,17 @@ def main(argv: list[str] | None = None, prog: str = "difflow gui") -> int:
     )
     args = parser.parse_args(argv)
 
-    serve(path=args.path, port=args.port, open_browser=not args.no_browser,
-          token=args.token)
+    try:
+        serve(path=args.path, port=args.port, open_browser=not args.no_browser,
+              token=args.token)
+    except OSError as exc:
+        # Only the one the caller can act on. Anything else --- a missing
+        # flowsheet, a permission --- still gets its traceback, which for
+        # those is the useful thing.
+        if exc.errno != errno.EADDRINUSE:
+            raise
+        print(port_in_use_message(args.port, prog), file=sys.stderr)
+        return 1
     return 0
 
 

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -12,12 +12,14 @@ editor whose edits do not reach the model is worse than none --- and
 as `Infinity`, which the browser refuses to parse.
 """
 
+import errno
 import json
 import math
 import os
 import pathlib
 import re
 import shutil
+import socket
 import subprocess
 import sys
 import threading
@@ -54,6 +56,7 @@ from difflow.gui import (
     context,
     make_server,
     sensitivity,
+    server,
 )
 
 SPECIES = ["water", "ethanol"]
@@ -2021,6 +2024,104 @@ class TestConsoleFigures:
     def test_an_image_survives_the_json_the_server_sends(self):
         drawn = console.image(b"\x89PNG\r\n\x1a\n binary \xff\xfe")
         assert json.loads(json.dumps(drawn)) == drawn
+
+
+# =============================================================================
+# Starting up
+# =============================================================================
+
+
+class TestPortInUse:
+    """Bind failures are the one startup error a user meets by accident.
+
+    Leaving them raw means a traceback out of ``socketserver`` whose only
+    content is ``[Errno 48] Address already in use`` --- no port, no
+    program name, no next move.
+    """
+
+    def taken_port(self):
+        """A port with a live listener on it, released at teardown."""
+        held = socket.socket()
+        held.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        held.bind((gui.HOST, 0))
+        held.listen(1)
+        return held, held.getsockname()[1]
+
+    def test_a_taken_port_is_a_message_and_an_exit_code(self, capsys):
+        held, port = self.taken_port()
+        try:
+            status = server.main(["--port", str(port), "--no-browser"])
+        finally:
+            held.close()
+
+        assert status == 1, "a failed start must not report success"
+        said = capsys.readouterr().err
+        assert str(port) in said, "the reader needs to know which port"
+        assert "--port" in said, "and how to get past it"
+
+    def test_the_suggested_port_steps_over_a_run_of_busy_ones(self):
+        """A suggestion that fails the same way is worse than none.
+
+        The run has to be longer than one, or a naive ``port + 1`` passes
+        this by luck: the next port is usually free anyway.
+        """
+        held, port = self.taken_port()
+        # Held open for the length of the test. A socket that goes out of
+        # scope is collected and its port freed, which quietly empties the
+        # run this test is built on.
+        holding = [held]
+        busy = {port}
+        try:
+            for offset in (1, 2, 3):
+                neighbour = socket.socket()
+                neighbour.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+                try:
+                    neighbour.bind((gui.HOST, port + offset))
+                    neighbour.listen(1)
+                except OSError:       # already someone else's; still busy
+                    neighbour.close()
+                else:
+                    holding.append(neighbour)
+                busy.add(port + offset)
+            assert len(busy) > 1, "the point of the test is a run, not one port"
+
+            suggested = server.free_port_near(port)
+            assert suggested not in busy, (
+                f"suggested {suggested}, which is in the busy run {sorted(busy)}")
+            probe = socket.socket()
+            try:
+                probe.bind((gui.HOST, suggested))   # the point: this works
+            finally:
+                probe.close()
+        finally:
+            for sock in holding:
+                sock.close()
+
+    def test_the_message_names_the_way_in_that_was_used(self):
+        """Two entry points; naming the other one sends the reader in a circle."""
+        said = server.port_in_use_message(8756, "python -m difflow.gui")
+        assert "python -m difflow.gui --port" in said
+        assert "difflow gui --port" not in said
+
+    def test_another_oserror_still_raises(self, monkeypatch):
+        """Only the actionable one is swallowed; the rest keep their traceback."""
+        def refuse(**kwargs):
+            raise OSError(errno.EACCES, "permission denied")
+
+        monkeypatch.setattr(server, "serve", refuse)
+        with pytest.raises(OSError) as caught:
+            server.main(["--no-browser"])
+        assert caught.value.errno == errno.EACCES
+
+    def test_reuse_address_is_already_on(self):
+        """So the bind refusal is a live listener, not a lingering TIME_WAIT.
+
+        Pinning this down because the tempting "fix" for Errno 48 is to set
+        ``SO_REUSEADDR``, and it is set. If a future stdlib stops setting it
+        the diagnosis above changes and this should be read again.
+        """
+        from http.server import ThreadingHTTPServer
+        assert ThreadingHTTPServer.allow_reuse_address
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What happened

Starting the editor while one was already running produced this, and nothing else:

```
  File ".../socketserver.py", line 478, in server_bind
    self.socket.bind(self.server_address)
OSError: [Errno 48] Address already in use
```

The port is not in the traceback. Neither is the program name, nor the one fact that resolves it nine times out of ten: the address is the reader's own editor, still up from earlier. `serve()` goes straight to `ThreadingHTTPServer((HOST, port), handler)`, so the failure surfaces from inside the stdlib with no difflow frame carrying context.

## What it says now

```
difflow gui: port 8756 on 127.0.0.1 is already in use.

An editor is probably running there already --- open
    http://127.0.0.1:8756/
before starting a second one. To run another alongside it, or if
that address is something else entirely, pick a free port:

    difflow gui --port 8757
```

Exit status 1, no traceback. Three details worth naming:

- **The suggested port is bound and released before being printed** (`free_port_near`), so it is one that actually works. A suggestion that fails the same way is worse than no suggestion. It is explicitly a suggestion and not a reservation — the socket closes again immediately and something else may take it in between.
- **The message uses `prog`.** `python -m difflow.gui` is told about itself, not about the console script — the same reasoning already written into `main()`'s docstring about help text sending the reader in a circle.
- **Only `EADDRINUSE` is swallowed.** Every other `OSError` — a missing flowsheet, a permission — keeps its traceback, which for those is the useful output.

## The fix not taken

`SO_REUSEADDR` was the obvious candidate and it is not the answer, so it is not added:

- It is **already set**. `HTTPServer.allow_reuse_address` is `1` and `ThreadingHTTPServer` inherits it. The bind failed with the flag on.
- It only relieves a socket in `TIME_WAIT`. Refusing a **live listener** is the correct behaviour, not a bug to work around.
- The flag that *would* override it, `SO_REUSEPORT`, would leave two editors sharing 8756 with requests landing on whichever won — a much worse failure than the one being fixed, and a silent one.

`test_reuse_address_is_already_on` pins that assumption so the diagnosis gets rechecked if a future stdlib changes the default.

## Tests

Five, in `TestPortInUse`. Each of the three behaviours is pinned by exactly one of them — verified by mutation rather than assumed:

| mutation | test that fails |
|---|---|
| restore the pre-fix `main()` (no catch) | `test_a_taken_port_is_a_message_and_an_exit_code` |
| `free_port_near` → naive `port + 1` | `test_the_suggested_port_steps_over_a_run_of_busy_ones` |
| catch every `OSError`, not just `EADDRINUSE` | `test_another_oserror_still_raises` |

The middle one holds a *run* of ports rather than one, because a naive `port + 1` passes a single-port test by luck — the next port is usually free anyway.

Verified end to end against a live editor on 8756, through both entry points.

Local: `tests/test_gui.py tests/test_gui_edit.py tests/test_gui_layout.py tests/test_gui_symbols.py tests/test_cli.py tests/test_publish.py` → **294 passed**. `docs_index.py` regenerates to the committed 759 sections, so `Editor front end` has nothing to diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UC5Y7FcrQz1humuVkWyUxZ
