### PR TITLE
fix(gui): a required number is a placeholder wherever the unit keeps it

### DIFF
--- a/docs/streams-and-flowsheets.md
+++ b/docs/streams-and-flowsheets.md
@@ -506,6 +506,20 @@ fs2 = serialize.load("plant.json", extras={"flash": {"thermo": my_thermo}})
 
 `extras` also *overrides* a stored thermo, which is the way to reload a saved flowsheet against a different property package.
 
+### Units that build their own `Params`
+
+Most units are constructed as `Unit(Params(...), thermo)`, but a substantial minority take their numbers as plain constructor arguments and build the `Params` themselves — `Compressor(ratio)`, `FlowSplit(w)`, `GasPipe(beta)`, and most of the gas plugin. Those numbers are written under `params`, because that is where the built unit keeps them, and they are passed straight back to the constructor on load. Nothing extra is needed:
+
+```python
+fs = Flowsheet(species_order=["CH4"])
+fs.add_unit(Unit("boost", Compressor(ratio=1.3), ["a"], ["b"]))
+serialize.from_json(serialize.to_json(fs))   # ratio comes back as 1.3
+```
+
+An argument that is *not* data — `Mixer(species_order)`, a `thermo` — still travels under `constructor`, and the two channels compose: `CompressorBoost(ratio, direction)` carries `ratio` by the first road and `direction` by the second.
+
+Only *required* constructor arguments are carried. An optional one left at its default is not written, so a unit that was built with a non-default optional argument comes back with the default; pass it on load with `extras=` when it matters.
+
 ---
 
 ## Generating Python

--- a/src/difflow/gui/edit.py
+++ b/src/difflow/gui/edit.py
@@ -218,6 +218,53 @@ def _is_number(annotation) -> bool:
     return "float" in text or "int" in text
 
 
+def placeholder_extras(cls: type, have: dict) -> tuple[dict, list[str]]:
+    """Constructor arguments that are plain numbers, given a placeholder.
+
+    The same bargain :func:`known_params` already strikes for a required
+    ``Params`` field, applied to the other half of the constructor. A
+    unit that builds its own ``Params`` from plain arguments ---
+    ``GasPipe(beta)``, ``CompressorBoost(ratio, direction)`` --- was
+    reported unmet for a plain ``float``, while an identical field one
+    line away in a ``Params`` got :data:`PLACEHOLDER` and dropped fine.
+    Nothing chose that; the placeholder path simply only ran on one of
+    the two.
+
+    ``have`` is everything already supplied, and it must include what
+    :func:`known_params` answered as well as the caller's own extras.
+    Where :func:`difflow.catalog._params_class` does find the ``Params``
+    --- ``Compressor`` and ``CompressorParams`` are named for each other,
+    ``GasPipe`` and ``PipeParams`` are not --- the number is answered
+    there and is not this function's to invent a second time.
+
+    Only annotations :func:`_is_number` admits, so a ``thermo`` or a
+    ``tuple[float, ...]`` is still named rather than invented. An
+    ``int``-only argument gets an ``int``, since a discrete one --- a
+    ``direction`` of 1 --- is the whole value of the annotation.
+
+    Returns ``(values, placeholders)``, and like ``known_params`` the
+    second list is what has to be shown to the user rather than trusted.
+    """
+    import inspect
+
+    try:
+        sig = inspect.signature(cls.__init__)
+    except (TypeError, ValueError):
+        return {}, []
+    values, placeholders = {}, []
+    for arg in constructor_extras(cls):
+        if arg in have:
+            continue
+        annotation = sig.parameters[arg].annotation
+        if not _is_number(annotation):
+            continue
+        text = str(annotation)
+        values[arg] = (int(PLACEHOLDER) if "int" in text and "float" not in text
+                       else PLACEHOLDER)
+        placeholders.append(arg)
+    return values, placeholders
+
+
 def known_params(flowsheet, params_cls, bindings: dict | None = None):
     """Values for the ``Params`` fields that have no default.
 
@@ -298,8 +345,17 @@ def unmet(flowsheet, cls: type, bindings: dict | None = None) -> list[str]:
     from difflow.catalog import _params_class
 
     have = known_extras(flowsheet, cls, bindings)
-    needs = [a for a in constructor_extras(cls) if a not in have]
-    _, _, missing = known_params(flowsheet, _params_class(cls), bindings)
+    values, _, missing = known_params(flowsheet, _params_class(cls), bindings)
+    # A unit that builds its own `Params` names the same number twice:
+    # once as a constructor argument and once as the field it goes into.
+    # `known_params` has already answered for the field, placeholder and
+    # all, so asking again under the argument's name reports a need that
+    # is met. What it cannot reach --- a `PipeParams` behind a `GasPipe`,
+    # which is not found by name -- is what the placeholder is for.
+    supplied = {**values, **have}
+    guessed, _ = placeholder_extras(cls, supplied)
+    needs = [a for a in constructor_extras(cls)
+             if a not in supplied and a not in guessed]
     return needs + missing
 
 

--- a/src/difflow/gui/session.py
+++ b/src/difflow/gui/session.py
@@ -736,13 +736,28 @@ class FlowsheetSession:
             values, placeholders, missing = edit.known_params(
                 self.flowsheet, _params_class(info.cls), self.bindings
             )
+            # After the two real sources, never before them: a number the
+            # code context actually supplies must not be shadowed by a
+            # made-up one, and a caller's `extras` outranks both. `values`
+            # counts as supplied too -- for a unit that builds its own
+            # `Params`, the constructor argument and the field it feeds
+            # are one number, and guessing it again here would hand the
+            # builder two.
+            guessed, guessed_names = edit.placeholder_extras(
+                info.cls, {**values, **override}
+            )
+            override.update(guessed)
+            placeholders = placeholders + guessed_names
             # Ask before building. `_build_operation` raises through the
             # file-loading path, whose message offers "written by a
             # different version of difflow" as the diagnosis -- true of a
             # file, and nonsense about a unit dropped from the palette a
-            # second ago. The palette flagged this same list.
+            # second ago. The palette flagged this same list, by the same
+            # reckoning: `values` supplies a constructor argument just as
+            # `override` does, along the road `_build_operation` takes for
+            # a unit that builds its own `Params`.
             unmet = [a for a in edit.constructor_extras(info.cls)
-                     if a not in override] + missing
+                     if a not in override and a not in values] + missing
             if unmet:
                 raise edit.EditError(
                     self._needs_hint(operation, info.cls, unmet)

--- a/src/difflow/gui/static/docs-index.json
+++ b/src/difflow/gui/static/docs-index.json
@@ -1,5 +1,5 @@
 {
- "n_sections": 759,
+ "n_sections": 760,
  "sections": [
   {
    "anchor": "overview",
@@ -2057,7 +2057,14 @@
    "heading": "Thermodynamics",
    "path": "Streams and Flowsheets > Saving and Loading Flowsheets > Thermodynamics",
    "source": "streams-and-flowsheets.md",
-   "text": "About half the core units need a `thermo` or `eos` object in the constructor, not just a `Params`. `IdealThermo` is written and rebuilt automatically. Anything else is refused on write, and can be supplied on load instead:\n\n```python\nfs2 = serialize.load(\"plant.json\", extras={\"flash\": {\"thermo\": my_thermo}})\n```\n\n`extras` also *overrides* a stored thermo, which is the way to reload a saved flowsheet against a different property package.\n\n---"
+   "text": "About half the core units need a `thermo` or `eos` object in the constructor, not just a `Params`. `IdealThermo` is written and rebuilt automatically. Anything else is refused on write, and can be supplied on load instead:\n\n```python\nfs2 = serialize.load(\"plant.json\", extras={\"flash\": {\"thermo\": my_thermo}})\n```\n\n`extras` also *overrides* a stored thermo, which is the way to reload a saved flowsheet against a different property package."
+  },
+  {
+   "anchor": "units-that-build-their-own-params",
+   "heading": "Units that build their own `Params`",
+   "path": "Streams and Flowsheets > Saving and Loading Flowsheets > Units that build their own `Params`",
+   "source": "streams-and-flowsheets.md",
+   "text": "Most units are constructed as `Unit(Params(...), thermo)`, but a substantial minority take their numbers as plain constructor arguments and build the `Params` themselves \u2014 `Compressor(ratio)`, `FlowSplit(w)`, `GasPipe(beta)`, and most of the gas plugin. Those numbers are written under `params`, because that is where the built unit keeps them, and they are passed straight back to the constructor on load. Nothing extra is needed:\n\n```python\nfs = Flowsheet(species_order=[\"CH4\"])\nfs.add_unit(Unit(\"boost\", Compressor(ratio=1.3), [\"a\"], [\"b\"]))\nserialize.from_json(serialize.to_json(fs))   # ratio comes back as 1.3\n```\n\nAn argument that is *not* data \u2014 `Mixer(species_order)`, a `thermo` \u2014 still travels under `constructor`, and the two channels compose: `CompressorBoost(ratio, direction)` carries `ratio` by the first road and `direction` by the second.\n\nOnly *required* constructor arguments are carried. An optional one left at its default is not written, so a unit that was built with a non-default optional argument comes back with the default; pass it on load with `extras=` when it matters.\n\n---"
   },
   {
    "anchor": "generating-python",

--- a/src/difflow/serialize.py
+++ b/src/difflow/serialize.py
@@ -585,10 +585,56 @@ def from_dict(data: dict, registry=None, extras: dict | None = None):
 def _build_operation(cls: type, encoded_params: dict, unit_name: str,
                      stored: dict | None = None, override: dict | None = None):
     """Instantiate an operation from its encoded parameters and extras."""
+    import inspect
+
     from difflow.catalog import _params_class
 
     extras = {k: _decode_value(v) for k, v in (stored or {}).items()}
     extras.update(override or {})
+
+    try:
+        sig = inspect.signature(cls.__init__)
+    except (TypeError, ValueError):
+        # Same guard `constructor_extras` keeps: a C-implemented `__init__`
+        # has no signature to read, and the Params path below is the older
+        # and safer answer when nothing is known.
+        sig = None
+
+    if sig is not None and not _takes_params_first(sig):
+        # This unit keeps its numbers as plain constructor arguments rather
+        # than in a Params object it is handed --- ``Compressor(ratio)``,
+        # ``FlowSplit(w)``, ``GasPipe(beta)``, most of the gas plugin. They
+        # build the Params themselves, so there is nothing to hand over;
+        # the values go back in the way they came out.
+        #
+        # ``to_dict`` writes them under "params" regardless, because it
+        # reads whatever the instance calls ``.params``. Wrapping those in
+        # a fresh Params and passing it positionally puts a dataclass where
+        # a float belongs, and demanding them under "extras" instead
+        # rejects a file that does carry the value --- one field away.
+        # Neither is what the file means.
+        kwargs = {k: _decode_value(v) for k, v in encoded_params.items()}
+        # extras last: a caller's ``extras=`` outranks the file, and an
+        # object that never went to JSON at all --- a thermo, a species
+        # order --- only ever arrives that way.
+        kwargs.update(extras)
+        missing = [a for a in constructor_extras(cls) if a not in kwargs]
+        if missing:
+            raise SerializationError(
+                f"unit {unit_name!r}: {cls.__name__} requires "
+                f"{', '.join(missing)}, which the file does not carry. Supply "
+                f"it on load, e.g. extras={{{unit_name!r}: "
+                f"{{{missing[0]!r}: ...}}}}."
+            )
+        try:
+            return cls(**kwargs)
+        except TypeError as exc:
+            raise SerializationError(
+                f"unit {unit_name!r}: {cls.__name__} rejected the stored "
+                f"parameters ({exc}). The file may have been written by a "
+                "different version of difflow."
+            ) from exc
+
     missing = [a for a in constructor_extras(cls) if a not in extras]
     if missing:
         raise SerializationError(

--- a/src/difflow_bio/units/filtration.py
+++ b/src/difflow_bio/units/filtration.py
@@ -493,6 +493,21 @@ class TFF:
         """
         rejection = rejection or {}
 
+        # Keep the arguments, not just what was built from them. TFF is a
+        # composition of two stages and holds no Params of its own, so
+        # `difflow.serialize` -- which reads a constructor argument off the
+        # instance by attribute of the same name -- had nothing to read,
+        # and a flowsheet containing a TFF could not be saved and loaded
+        # back at all. The other six are recorded for the same reason,
+        # though only the required one is carried by the file today.
+        self.membrane_area = membrane_area
+        self.MWCO = MWCO
+        self.rejection = rejection
+        self.Lp = Lp
+        self.k_mass = k_mass
+        self.sigma = sigma
+        self.fouling_coefficient = fouling_coefficient
+
         self.uf = Ultrafiltration(UltrafiltrationParams(
             membrane_area=membrane_area,
             MWCO=MWCO,

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -775,6 +775,122 @@ class TestWhatBlocksADrop:
         assert client.post("/api/unit", {"operation": "AmineAbsorber"})[1]["ok"]
 
 
+class TestANumberInTheConstructor:
+    """A required number is a placeholder wherever the unit keeps it.
+
+    ``known_params`` has always invented :data:`~difflow.gui.edit.PLACEHOLDER`
+    for a required ``Params`` field with no default, so a ``CSTR`` drops
+    with ``V = 1.0`` flagged for the user to correct. A unit that builds
+    its own ``Params`` from plain arguments --- ``GasPipe(beta)``,
+    ``Compressor(ratio)`` --- names an identical ``float`` one line away
+    and was refused outright. Nothing chose that asymmetry; the
+    placeholder path simply only ran down one of the two.
+
+    What must not follow from fixing it: inventing an *object*, or
+    handing the constructor the same number twice.
+    """
+
+    @pytest.fixture
+    def catalog(self, client):
+        return client.get_json("/api/catalog")[1]
+
+    def test_a_plain_float_argument_no_longer_blocks_the_drop(self, client, catalog):
+        """`GasPipe(beta)` keeps its number outside any Params difflow can find."""
+        if "GasPipe" not in catalog:
+            pytest.skip("difflow_gas not registered")
+        assert catalog["GasPipe"]["needs"] == []
+        status, added = client.post("/api/unit", {"operation": "GasPipe"})
+        assert status == 200 and added["ok"], added.get("error")
+        assert added["placeholders"] == ["beta"], (
+            "an invented number has to be flagged, exactly like a Params field"
+        )
+
+    def test_a_number_named_twice_is_supplied_once(self, client, catalog):
+        """`Compressor(ratio)` feeds `CompressorParams.ratio`.
+
+        The constructor argument and the field are one number. Answering
+        for it in both places hands the builder two values for `ratio`
+        and the drop dies in the file-loading path.
+        """
+        if "Compressor" not in catalog:
+            pytest.skip("difflow_gas not registered")
+        assert catalog["Compressor"]["needs"] == []
+        status, added = client.post("/api/unit", {"operation": "Compressor"})
+        assert status == 200 and added["ok"], added.get("error")
+        assert added["placeholders"] == ["ratio"], "named once, not twice"
+
+    def test_an_int_argument_gets_an_int(self, client, catalog):
+        """`direction` is +1 or -1; a `direction` of 1.0 is a different claim."""
+        if "CompressorBoost" not in catalog:
+            pytest.skip("difflow_gas not registered")
+        status, added = client.post("/api/unit", {"operation": "CompressorBoost"})
+        assert status == 200 and added["ok"], added.get("error")
+        name = added["name"]
+        _, doc = client.get_json("/api/flowsheet")
+        unit = next(u for u in doc["flowsheet"]["units"] if u["name"] == name)
+        assert unit["constructor"]["direction"] == 1
+        assert not isinstance(unit["constructor"]["direction"], float)
+
+    def test_a_tuple_of_numbers_is_still_refused(self, client, catalog):
+        """`AffineFlow(signs)` has a length nothing here knows."""
+        if "AffineFlow" not in catalog:
+            pytest.skip("difflow_gas not registered")
+        assert catalog["AffineFlow"]["needs"] == ["signs"], (
+            "`const`, `T_k` and `P_pa` are plain numbers; `signs` is not"
+        )
+
+    def test_a_non_numeric_argument_is_still_refused(self, client, catalog):
+        """The line held: only `_is_number` annotations get a value.
+
+        A `thermo` is an object and a `solvent` is a name; neither has a
+        plausible 1.0. `Mixer(species_order)` is deliberately absent from
+        this list --- the flowsheet already knows its species order, so
+        that one is answered rather than guessed.
+        """
+        assert catalog["Flash"]["needs"] == ["thermo"]
+        if "GroupSeparator" in catalog:
+            assert catalog["GroupSeparator"]["needs"] == ["elements"]
+        if "LLEEquilibrium" in catalog:
+            assert catalog["LLEEquilibrium"]["needs"] == [
+                "solutes", "aqueous_carrier", "organic_carrier",
+            ]
+
+    def test_a_real_binding_outranks_the_placeholder(self, client, catalog):
+        """A number the code context supplies must not be shadowed."""
+        if "GasPipe" not in catalog:
+            pytest.skip("difflow_gas not registered")
+        client.post("/api/code-context", {"source": "beta = 12.5\n"})
+        status, added = client.post("/api/unit", {"operation": "GasPipe"})
+        assert status == 200 and added["ok"], added.get("error")
+        assert "beta" not in added["placeholders"], (
+            "a bound value is known, not guessed"
+        )
+
+    def test_everything_droppable_saves_and_loads_back(self, client, catalog):
+        """The drop must not build a flowsheet the file format cannot hold.
+
+        ``encoded_params`` takes the encoding route so that a parameter
+        the editor accepts is one the file can carry. A constructor
+        argument reaches the file by a different road, and unblocking
+        nine units puts that road under load for the first time.
+        """
+        from difflow.serialize import from_json, to_json
+
+        unsaveable = []
+        for name, spec in catalog.items():
+            if spec["needs"]:
+                continue
+            status, answer = client.post("/api/unit", {"operation": name})
+            if status != 200 or not answer["ok"]:
+                continue
+            try:
+                from_json(to_json(client.session.flowsheet))
+            except Exception as exc:
+                unsaveable.append((name, f"{type(exc).__name__}: {exc}"))
+            client.delete(f"/api/unit/{answer['name']}")
+        assert not unsaveable
+
+
 class TestAnEmptyEditor:
     """`difflow gui` with no file: a live canvas, waiting for species.
 

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -501,5 +501,110 @@ class TestPluginTypes:
             "a plugin outside _PACKAGES saves fine and refuses to load")
 
 
+# =============================================================================
+# Units that build their own Params
+# =============================================================================
+
+
+class TestUnpackedParams:
+    """Units that take their numbers as plain constructor arguments.
+
+    ``Compressor(ratio)``, ``FlowSplit(w)``, ``GasPipe(beta)`` and most of
+    the gas plugin build their own ``Params`` rather than being handed
+    one. ``to_dict`` still writes those numbers under ``"params"``,
+    because it writes whatever the instance calls ``.params`` --- so the
+    value is in the file, one field away from where the loader used to
+    look for it. It demanded them under ``"constructor"`` instead and
+    refused a file that plainly carried them.
+    """
+
+    CASES = [
+        ("Compressor", dict(ratio=1.3), "ratio", 1.3),
+        ("FlowSplit", dict(w=2.0), "w", 2.0),
+        ("SourceHead", dict(P_set=5.0e6), "P_set", 5.0e6),
+        ("GasPipe", dict(beta=7.0), "beta", 7.0),
+        ("BackPipe", dict(beta=7.0), "beta", 7.0),
+        ("PressureDrivenPipe", dict(beta=7.0), "beta", 7.0),
+    ]
+
+    def _round_trip(self, name, kwargs):
+        from difflow.catalog import _default_registry
+
+        cls = _default_registry().list_operations()[name].cls
+        fs = Flowsheet(species_order=SPECIES)
+        fs.add_unit(Unit(name.lower(), cls(**kwargs), ["a"], ["b"]))
+        return fs, serialize.from_json(serialize.to_json(fs))
+
+    @pytest.mark.parametrize("name,kwargs,field,value", CASES)
+    def test_the_value_comes_back(self, name, kwargs, field, value):
+        _, back = self._round_trip(name, kwargs)
+        assert getattr(back.units[0].operation.params, field) == value
+
+    @pytest.mark.parametrize("name,kwargs,field,value", CASES)
+    def test_the_file_carries_it_under_params(self, name, kwargs, field, value):
+        """Where the loader now reads it from, stated as its own fact."""
+        fs, _ = self._round_trip(name, kwargs)
+        written = json.loads(serialize.to_json(fs))["units"][0]
+        assert written["params"][field] == value
+        assert field not in written["constructor"]
+
+    def test_defaults_the_unit_filled_in_survive_too(self):
+        """Not just the required argument: the whole Params it built."""
+        _, back = self._round_trip("Compressor", dict(ratio=1.3))
+        params = back.units[0].operation.params
+        assert (params.eta_ad, params.kappa, params.cp) == (0.8, 1.3, 2200.0)
+
+    def test_a_non_params_argument_still_travels_as_a_constructor_extra(self):
+        """The two channels compose: `ratio` by params, `direction` by extras."""
+        _, back = self._round_trip(
+            "CompressorBoost", dict(ratio=1.2, direction=-1)
+        )
+        assert back.units[0].operation.params.ratio == 1.2
+        assert back.units[0].operation.direction == -1
+
+    def test_extras_on_load_still_outrank_the_file(self):
+        from difflow.catalog import _default_registry
+
+        cls = _default_registry().list_operations()["GasPipe"].cls
+        fs = Flowsheet(species_order=SPECIES)
+        fs.add_unit(Unit("pipe", cls(beta=7.0), ["a"], ["b"]))
+        back = serialize.from_json(
+            serialize.to_json(fs), extras={"pipe": {"beta": 9.0}}
+        )
+        assert back.units[0].operation.params.beta == 9.0
+
+    def test_a_genuinely_absent_argument_is_still_refused(self):
+        """The message has to keep meaning what it says.
+
+        ``Mixer(species_order)`` is an object the file does not carry, and
+        widening the loader to read "params" must not turn that into a
+        silent success or a different error.
+        """
+        from difflow.catalog import _default_registry
+
+        cls = _default_registry().list_operations()["Mixer"].cls
+        fs = Flowsheet(species_order=SPECIES)
+        fs.add_unit(Unit("mix", cls(species_order=SPECIES), ["a"], ["b"]))
+        text = serialize.to_json(fs)
+        spec = json.loads(text)
+        spec["units"][0]["constructor"] = {}
+        with pytest.raises(SerializationError, match="requires species_order"):
+            serialize.from_dict(spec)
+
+    def test_tff_records_the_arguments_it_was_built_with(self):
+        """A composite still has to answer for its own constructor.
+
+        TFF holds two stages and no Params, so the writer --- which reads
+        a constructor argument off the instance by attribute --- found
+        nothing to write and a TFF flowsheet could not be saved at all.
+        """
+        from difflow_bio import TFF
+
+        fs = Flowsheet(species_order=SPECIES)
+        fs.add_unit(Unit("tff", TFF(membrane_area=4.0), ["a"], ["b"]))
+        back = serialize.from_json(serialize.to_json(fs))
+        assert back.units[0].operation.membrane_area == 4.0
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
Two halves of one asymmetry, plus the bug the first half uncovered.

## The palette half

`known_params` has always invented a `PLACEHOLDER` for a required `Params` field with no default. A CSTR drops onto the canvas with `V = 1.0`, flagged so the user knows to correct it. That is the whole bargain: a made-up number you can see beats a unit you cannot place.

A unit that keeps an identical `float` as a **constructor argument** got no such offer. The palette greyed it out and said `needs beta` — a need that nothing but the same `1.0` was ever going to meet. Nothing chose that; the placeholder path simply only ran down one of the two roads into a constructor.

`placeholder_extras` runs it down the other, under exactly the same rule. Only annotations `_is_number` admits, so a `thermo`, a `solvent` and `AffineFlow`'s `signs: tuple[float, ...]` are still **named rather than invented**. An int-only argument gets an `int`, because a `direction` of `1.0` is a different claim than a `direction` of `1`.

Nine units become droppable — `BackPipe`, `Compressor`, `CompressorBoost`, `FlowSplit`, `GasPipe`, `PipePressure`, `PressureDrivenPipe`, `SourceHead`, `TFF`. None becomes newly blocked. `AffineFlow` narrows from four unmet arguments to the one that really is.

Blocked palette units on an empty flowsheet: **54 to 45**.

## Not answering twice

A unit that builds its own `Params` names the same number in two places — as the constructor argument and as the field it feeds. `known_params` already reaches it whenever `_params_class` finds the class by name, which it does for `Compressor`/`CompressorParams` and does not for `GasPipe`/`PipeParams`. Guessing it a second time hands the builder two values for `ratio` and the drop dies.

So `unmet` and `add_unit` both count `values` as supplied, and a real binding from the code context still outranks the placeholder.

## The serializer half

Unblocking those nine put a road under load for the first time, and it was out.

`Compressor(ratio)`, `FlowSplit(w)`, `GasPipe(beta)` and most of the gas plugin build their own `Params`. `to_dict` writes their numbers under `params`, because it writes whatever the instance calls `.params`. The loader asked for them under `constructor` instead:

```
SerializationError: unit 'u': Compressor requires ratio,
which the file does not carry.
```

The file carried it. One field away from where the loader looked. **21 registered operations could be saved and never loaded back** — a pre-existing bug, independent of the editor, that this branch only made visible.

`_build_operation` now recognises the case it already had a predicate for (`_takes_params_first` is False) and passes the encoded params straight to the constructor. `extras=` still outranks the file; a genuinely absent argument is still refused with the same message; `CompressorBoost(ratio, direction)` shows the two channels composing — `ratio` by params, `direction` by constructor.

`TFF` is the same bug from the other end: it composes two stages and kept no record of its own arguments, so the writer — which reads a constructor argument off the instance by attribute — had nothing to read, and no `TFF` flowsheet was saveable at all. It now records them.

## Checking

Two invariants held exhaustively over all 87 registered operations:

- **the palette cannot promise what the adder refuses** — 51 accepted, 1 refused, and that one is `Transformer` rejecting `tap=1, shift=0` as "this is a line", which is the model being right and was already true.
- **a drop cannot build a flowsheet the file format will not hold** — 42 dropped, 42 round-tripped, 0 unsaveable. This one is new, and it is what caught `TFF`.

24 tests added. Nine mutations tried against them, each caught:

| mutation | caught by |
|---|---|
| loader branch never fires | 2 tests |
| file outranks caller `extras=` | `test_extras_on_load_still_outrank_the_file` |
| drop the `missing` check | `test_a_genuinely_absent_argument_is_still_refused` |
| `TFF` forgets its arguments | `test_tff_records_the_arguments_it_was_built_with` |
| placeholder invents nothing | 3 tests |
| guess what `known_params` answered | `test_a_number_named_twice_is_supplied_once` |
| int argument gets a float | `test_an_int_argument_gets_an_int` |
| `_is_number` widened to accept anything | 3 tests |
| a bound value is shadowed | 2 tests |

Local: 1060 passed across `test_serialize`, `test_gui`, `test_codegen`, `bio/`, `gas/`, `ree/`, `power/`.

Docs index regenerated (759 to 760 sections) for the new serialization section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UC5Y7FcrQz1humuVkWyUxZ
