### PR TITLE
fix(planning): honour tablefmt when tabulate is not installed

### DIFF
--- a/src/difflow/planning/benchmark.py
+++ b/src/difflow/planning/benchmark.py
@@ -259,14 +259,23 @@ def format_scaling_table(rows: Sequence[CostRatio],
 
     Uses ``tabulate`` when it is installed --- so the column widths line
     up whether the table is printed to a terminal or rendered as
-    Markdown in a notebook --- and falls back to a hand-written
-    Markdown table when it is not.
+    Markdown in a notebook --- and falls back to a hand-written table
+    when it is not.
+
+    ``tabulate`` lives in the ``examples`` extra, so the fallback is the
+    path a plain ``pip install difflow[dev]`` takes. It honours the two
+    formats this function is actually called with rather than ignoring
+    the argument: a caller who asks for ``"simple"`` wants something to
+    read in a terminal, and handing back Markdown pipes because an
+    optional dependency is absent is the wrong answer, not a lesser one.
+    Any other ``tablefmt`` needs tabulate and falls back to Markdown.
 
     Args:
         rows: The :class:`CostRatio` rows to render.
         tablefmt: Any ``tabulate`` table format; ``"github"`` renders as
             Markdown, ``"simple"`` reads better in a plain terminal.
-            Ignored when tabulate is unavailable.
+            Without tabulate those two are honoured and anything else
+            renders as Markdown.
 
     Returns:
         The table as text.
@@ -281,13 +290,34 @@ def format_scaling_table(rows: Sequence[CostRatio],
              f"{r.fd_ratio:.0f}x", f"{r.speedup:.0f}x"] for r in rows]
     try:
         from tabulate import tabulate
-    except ImportError:      # pragma: no cover - depends on the environment
-        out = ["| " + " | ".join(header) + " |",
-               "|" + "|".join(["---"] * len(header)) + "|"]
-        out += ["| " + " | ".join(row) + " |" for row in body]
-        return "\n".join(out)
+    except ImportError:
+        return _plain_table(header, body, tablefmt)
     return tabulate(body, headers=header, tablefmt=tablefmt,
                     colalign=("right",) * len(header))
+
+
+def _plain_table(header: Sequence[str],
+                 body: Sequence[Sequence[str]],
+                 tablefmt: str) -> str:
+    """``format_scaling_table`` without tabulate.
+
+    Right-aligned like the tabulate call it stands in for, because these
+    are all numbers and a column of numbers is read down its last digit.
+    """
+    widths = [max(len(row[i]) for row in (header, *body))
+              for i in range(len(header))]
+    pad = lambda row: [cell.rjust(w) for cell, w in zip(row, widths)]
+
+    if tablefmt == "simple":
+        # No pipes: tabulate's `simple` is columns separated by blanks,
+        # under a rule that spans each column.
+        rule = ["-" * w for w in widths]
+        lines = [pad(header), rule, *(pad(row) for row in body)]
+        return "\n".join("  ".join(line).rstrip() for line in lines)
+
+    rule = ["-" * w for w in widths]
+    lines = [pad(header), rule, *(pad(row) for row in body)]
+    return "\n".join("| " + " | ".join(line) + " |" for line in lines)
 
 
 def planner_objective(planner) -> Callable[[Array], Array]:

--- a/tests/test_planning.py
+++ b/tests/test_planning.py
@@ -12,6 +12,8 @@ The acceptance criteria for the module are covered explicitly:
    ``test_chain_allocation_lever_switches_with_prices`` covers its claim.
 """
 
+import re
+import sys
 import warnings
 
 import jax
@@ -799,6 +801,37 @@ class TestScaling:
         header, rule = text.splitlines()[:2]
         assert "n" in header and set(rule) <= set("|- :")
         assert format_scaling_table(rows, tablefmt="simple").count("|") == 0
+
+    def test_the_table_holds_its_shape_without_tabulate(self, monkeypatch):
+        """tabulate is in the ``examples`` extra, so this is the common path.
+
+        Hidden here rather than skipped when absent: an environment that
+        has tabulate is exactly the one that would never notice the
+        fallback drifting, and CI installs ``[dev,gui,solvers]`` --- which
+        has no tabulate --- so without this the fallback is covered
+        nowhere.
+        """
+        rows = scaling_study(self._make, [5], repeats=1, warmup=1)
+        # `from tabulate import tabulate` raises ImportError against a
+        # None entry in sys.modules, which is how the fallback is reached.
+        monkeypatch.setitem(sys.modules, "tabulate", None)
+
+        text = format_scaling_table(rows)
+        assert text.lstrip().startswith("|")
+        assert "speedup" in text
+        header, rule = text.splitlines()[:2]
+        assert "n" in header and set(rule) <= set("|- :")
+
+        # `simple` is the terminal format, and the point of asking for it
+        # is not getting Markdown back.
+        plain = format_scaling_table(rows, tablefmt="simple")
+        assert plain.count("|") == 0
+        assert "speedup" in plain
+        head, rule, row = plain.splitlines()
+        assert set(rule) <= set("- ")
+        # Seven columns on every line, so the numbers sit under their names.
+        assert [len(re.split(r"\s{2,}", line.strip())) for line in
+                (head, rule, row)] == [7, 7, 7]
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
`format_scaling_table(rows, tablefmt="simple")` handed back a Markdown table,
pipes and all, whenever tabulate was not installed. The fallback rendered one
shape and ignored the argument, which the docstring described as intended
("Ignored when tabulate is unavailable").

tabulate lives in the `examples` extra, so that fallback is the path a plain
`pip install difflow[dev]` takes -- and a caller who asks for `simple` wants
something to read in a terminal. Markdown is the wrong answer there, not a
lesser one. The fallback now renders both formats, right-aligned like the
tabulate call it stands in for, because these are columns of numbers and a
column of numbers is read down its last digit.

```
 n  one eval  AD gradient  FD gradient  AD / eval  FD / eval  speedup
--  --------  -----------  -----------  ---------  ---------  -------
 5   0.001 s      0.002 s       0.01 s       2.0x        10x       5x
50   0.001 s      0.002 s        0.1 s       2.0x       100x      50x
```

Both documented callers -- `docs/planning.md` and
`examples/30_delta_base_planning.ipynb` -- take the default `github` format,
which still renders Markdown either way, so nothing downstream changes.

## Why nobody saw it

The mismatch was invisible from two directions at once.

`tests/test_planning.py::TestScaling::test_table_formats` asserts the pipe-free
`simple` output unconditionally, so it failed on any install without tabulate --
`pytest tests/test_planning.py` on a `[dev]` checkout. CI never reported it,
because CI installs `[dev,gui,solvers]`, which has no tabulate either: the
assertion that would have tripped was only reached on the tabulate path, and the
fallback was marked `# pragma: no cover - depends on the environment` and covered
nowhere.

So the new test hides tabulate behind a `None` entry in `sys.modules` rather than
skipping when it is absent. An environment that has tabulate is exactly the one
that would never notice the fallback drifting, so it is now exercised in both.

Verified: with tabulate blocked, `test_table_formats` fails on `main` and passes
here. 133 passed across `tests/test_planning.py` and `tests/test_planning_export.py`.

Noticed while merging #234, whose description flagged it as failing on `main`
and out of that PR's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UC5Y7FcrQz1humuVkWyUxZ
