### PR TITLE
refactor(reconciliation): drop a nan-guard that guards nothing

### DIFF
--- a/src/difflow/mhe/ekf.py
+++ b/src/difflow/mhe/ekf.py
@@ -137,6 +137,12 @@ def ekf_update(
     lin = x if x_lin is None else x_lin
     h = model.observation_jacobian(lin, u, theta)
     h = jnp.where(mask[:, None], h, 0.0)
+    # The inner `where` is load-bearing, unlike the plain select it
+    # resembles: it replaces an infinite sigma *before* the square, so
+    # `inf ** 2` is never evaluated. Written as one `where`, the
+    # unsampled channels reach reverse mode as d(sigma^2) = 2 inf and
+    # the cotangent comes back nan. Pinned by
+    # test_ekf_keeps_an_unsampled_channel_gradient_finite.
     var = jnp.where(mask, jnp.where(mask, sigma, 1.0) ** 2, 1.0)
     r = jnp.diag(var)
 

--- a/src/difflow/reconciliation/core.py
+++ b/src/difflow/reconciliation/core.py
@@ -144,7 +144,7 @@ def auto_scaling(
         fallback = jnp.broadcast_to(
             jnp.asarray(unmeasured_scale, dtype=jnp.float64), x0.shape
         )
-    d = jnp.where(mask, jnp.where(mask, sigma, 1.0), fallback)
+    d = jnp.where(mask, sigma, fallback)
     d = jnp.where(d > 0, d, 1.0)
 
     a = jacobian_of(residual_fn, x0, params)

--- a/src/difflow/reconciliation/reconcile.py
+++ b/src/difflow/reconciliation/reconcile.py
@@ -176,7 +176,7 @@ def reconcile(
     if x0 is None:
         init = 1.0 if unmeasured_init is None else unmeasured_init
         init = jnp.broadcast_to(jnp.asarray(init, dtype=jnp.float64), y.shape)
-        x0 = jnp.where(mask, jnp.where(mask, y, 0.0), init)
+        x0 = jnp.where(mask, y, init)
     x0 = jnp.asarray(x0, dtype=jnp.float64)
 
     m = int(residual_fn(x0, params).shape[0])

--- a/src/difflow/reconciliation/tracking.py
+++ b/src/difflow/reconciliation/tracking.py
@@ -240,6 +240,12 @@ class TrackerState(ParamsMixin):
         came from :func:`difflow.estimation.predicted_covariance` or
         :func:`~difflow.reconciliation.reconciled_covariance`, which
         return the correlations rather than discarding them).
+
+        ``time`` is the clock this prior is current at, not the clock
+        the record starts at. :func:`track_parameters` advances the
+        state by ``t - state.time`` each period, so leaving both at
+        their defaults means the first period does no drift update ---
+        the prior is taken as current, rather than one period stale.
         """
         names = list(names)
         mean = jnp.asarray(mean, dtype=jnp.float64).reshape(-1)
@@ -356,7 +362,10 @@ def time_update(
 
     Args:
         state: the current state.
-        dt: elapsed time, in whatever clock ``drift_std`` is a rate in.
+        dt: elapsed time, in whatever clock ``drift_std`` is a rate
+            in. Zero is legal and is a no-op, which is what the first
+            period of a campaign gets when the state's clock and the
+            record's first reading agree.
         drift_std: :math:`\\sqrt{\\mathrm{diag}(Q)}`, per unit time,
             scalar or per parameter. See
             :func:`drift_std_from_time_constant`.
@@ -583,7 +592,7 @@ def parameter_measurement(
     if x0 is None:
         init = 1.0 if unmeasured_init is None else unmeasured_init
         init = jnp.broadcast_to(jnp.asarray(init, dtype=jnp.float64), y.shape)
-        plant0 = jnp.where(mask, jnp.where(mask, y, 0.0), init)
+        plant0 = jnp.where(mask, y, init)
     else:
         plant0 = jnp.asarray(x0, dtype=jnp.float64).reshape(-1)
         if plant0.shape != y.shape:
@@ -814,8 +823,15 @@ def track_parameters(
             it is the bandwidth of the twin, not a nuisance. See
             :func:`drift_std_from_time_constant`.
         times: the clock reading of each period. Defaults to
-            ``0, 1, 2, ...``, which makes ``drift_std`` a per-period
-            figure.
+            ``state.time, state.time + 1, ...``, which makes
+            ``drift_std`` a per-period figure. Note what that means for
+            the first period: it carries the state's own clock reading,
+            so its ``dt`` is zero and ``n`` periods produce ``n - 1``
+            drift increments. That is deliberate --- the prior is
+            as-of its own clock, not one period stale --- and if the
+            state was last updated some time before the record starts,
+            say so by passing ``times`` explicitly rather than by
+            back-dating ``state.time``.
         params: extra argument threaded to ``residual_fn``, into which
             the tracked parameters are injected.
         names: plant variable names.

--- a/tests/test_mhe.py
+++ b/tests/test_mhe.py
@@ -328,6 +328,32 @@ def test_ekf_treats_an_infinite_sigma_as_no_reading():
     assert float(innov[0]) == 0.0
 
 
+def test_ekf_keeps_an_unsampled_channel_gradient_finite():
+    """Why ``var`` in :func:`ekf_update` squares a *masked* sigma.
+
+    Written as the single select it resembles --- ``where(mask, sigma **
+    2, 1.0)`` --- the forward value is identical, so nothing here would
+    catch it. Reverse mode is where it shows: an unsampled channel
+    carries ``sigma = inf``, ``d(sigma ** 2) = 2 inf``, and the
+    cotangent comes back ``nan``. Masking before the square keeps
+    ``inf ** 2`` from ever being evaluated.
+    """
+    model = linear_model(jnp.array([[0.9]]), jnp.array([[1.0], [1.0]]))
+
+    def posterior(sigma):
+        x_up, _, _ = ekf_update(
+            model, jnp.array([1.0]), jnp.array([[0.25]]),
+            jnp.array([1.5, 99.0]), sigma, jnp.zeros(0),
+        )
+        return jnp.sum(x_up)
+
+    sigma = jnp.array([0.3, jnp.inf])          # one sampled, one not
+    grad = np.asarray(jax.grad(posterior)(sigma))
+    assert np.all(np.isfinite(grad)), grad
+    assert grad[1] == 0.0                      # the unsampled channel
+    assert grad[0] != 0.0                      # the sampled one still moves
+
+
 def test_ekf_covariances_stay_symmetric_and_psd():
     xs, ys = simulate([[0.9, 0.1], [0.0, 0.85]], [[1.0, 0.0]], [1.0, -1.0],
                       12, 0.03, 0.2, seed=1)


### PR DESCRIPTION
Follow-up to the two notes on #244 that were explicitly not worth holding that merge for. No behaviour change.

## The `where` nit turned out to be a pattern

The review flagged `jnp.where(mask, jnp.where(mask, y, 0.0), init)` in `parameter_measurement` as a puzzle — the standard NaN-safe-gradient idiom, on a forward-only initial guess with nothing differentiating through it.

Checking it turned up **why** it reads as a puzzle: the idiom is correct in exactly one place in the codebase and copied into three where it does nothing, and the two cases are not distinguishable by looking.

**Where the branch is a plain value — the guard is a no-op:**

```python
where(mask, v, init)
where(mask, where(mask, v, 0.0), init)
```

Identical value *and* identical gradient, with `nan` or `inf` sitting in the unselected slot. `where` selects, it does not multiply, so nothing ever creates a `nan` to guard against. Measured: both give `[1., 0.]`.

**Where an operation is applied to the branch — the guard is real:**

```python
where(mask, sigma ** 2, 1.0)
where(mask, where(mask, sigma, 1.0) ** 2, 1.0)
```

Identical value, **different gradient**. The first evaluates `inf ** 2` on unsampled channels, so `d(sigma²) = 2·inf` and the cotangent comes back `nan`. Measured against the real `ekf_update`: `[-0.649, nan]` vs `[-0.649, 0.]`.

So:

| site | branch is | change |
|---|---|---|
| `reconciliation/tracking.py` | value | inner `where` dropped |
| `reconciliation/reconcile.py` | value | inner `where` dropped |
| `reconciliation/core.py` | value | inner `where` dropped |
| `mhe/ekf.py` | `sigma ** 2` | **kept**, commented, and pinned by a test |

`reconcile.py` is in scope because it is the site `tracking.py` was copied from — leaving it is what guarantees the next person copies it again, which is exactly how it reached the new module. `core.py` is the same shape a third time; applying the rule to two of three would leave the codebase in a more confusing state than before.

The test on the `ekf.py` side is the part I would defend hardest. The forward value is identical either way, so **nothing else in the suite would notice** if someone later "tidied" that one to match the other three. `test_ekf_keeps_an_unsampled_channel_gradient_finite` asserts the gradient is finite, zero on the unsampled channel, and non-zero on the sampled one.

## The first-period clock

The other note: with `times=None` the first period gets `dt = 0`, so `n` periods produce `n − 1` drift increments. Correct reading, and deliberate — the prior is as-of its own clock, not one period stale — but it was an interpretation a reader had to reconstruct. Now stated once in each place it could be met:

- `track_parameters` — what the default `times` means, and to pass `times` explicitly rather than back-date `state.time` if the prior really is older than the record.
- `TrackerState.initial` — that `time` is the clock the prior is current at, not the clock the record starts at.
- `time_update` — that `dt = 0` is legal and a no-op.

## Testing

- Full suite: **3260 passed, 42 skipped**, exit 0.
- 371 passed across the directly affected areas (`mhe`, `reconciliation`, `tracking`, `gas`, `power`) before that.
- One new test; no existing test changed, which is the point — the three simplifications are provably identity-preserving in both value and gradient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtoJtxZN9o3xzqMNukvFid


---
_Generated by [Claude Code](https://claude.ai/code/session_01TtoJtxZN9o3xzqMNukvFid)_