### PR TITLE
feat(convergence): a hard-flowsheet corpus and the recycle solver's pass rate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,9 @@ pytest tests/ --cov=src/difflow
 # Re-measure the per-test durations CI shards its three jobs on
 make test-durations
 
+# Measure the recycle solver's pass rate over the hard-flowsheet corpus
+make convergence
+
 # Build documentation (Jupyter Book)
 make book
 
@@ -44,6 +47,7 @@ difflow/
 │   │   ├── database.py    # Species property database
 │   │   ├── flowsheet.py   # Flowsheet with recycle solving
 │   │   ├── uncertainty.py # Sensitivity & UQ
+│   │   ├── convergence.py # Hard-flowsheet corpus + pass-rate benchmark
 │   │   ├── stochastic/    # Two-stage stochastic programming (SAA over scenarios)
 │   │   ├── planning/      # Delta-base planning (LP/MILP + trust region)
 │   │   ├── catalog.py     # Machine-readable schema of every unit operation
@@ -511,6 +515,53 @@ accuracy claim: SLP over AD delta vectors reaches the AC-OPF optimum and beats
 DC-OPF, all three dispatches scored in the full AC model; and the termination
 claim, linear against quadratic).
 
+### Measuring Convergence (`difflow.convergence`)
+
+How often the recycle solver works, over a corpus of deliberately hard
+flowsheets. `make convergence` (or `python -m difflow.convergence`), or:
+
+```python
+from difflow.convergence import run_benchmark
+report = run_benchmark()          # 54 solves: 6 cases x 3 accelerations x 3 inits
+print(report.as_text())
+```
+
+Invariants encoded in the module (do not weaken them):
+- **Passing is `converged AND correct`.** `Outcome.converged` is the solver's
+  own verdict and `Outcome.correct` is an audit of the answer (the overall
+  mole balance, or a known analytic solution). Keeping them apart is the
+  point: today three of 54 solves report success and land somewhere that does
+  not audit, and a benchmark reading only the flag would score those as wins.
+- **Every `Case.build` returns a FRESH flowsheet.** `solve` records its
+  verdict on the object, so a shared one carries one run's result into the
+  next.
+- **No case may be rigged.** A strategy must not start on the answer it is
+  scored against. `overshoot_loop` originally used `g(x) = 3F - 2x`, whose
+  fixed point is `x = F` — exactly the `"feed"` guess, which collected two
+  free passes. `TestNoCaseIsRigged` checks all six.
+- **Keep a control that is meant to pass.** An all-failing corpus cannot tell
+  a hard corpus from a broken solver; `two_phase_flash` passes 9/9.
+- **A raise is an outcome, not an error.** `run_case` records it and carries
+  on; a benchmark that dies on its hardest case reports the pass rate of the
+  cases before it.
+- Every `Case` states its own `difficulty`. A hard case that does not say why
+  measures something nobody can act on.
+
+What it measured (2026-09, and meant to move): pass rate 46.3%, convergence
+rate 51.9%. Anderson 88.9% against plain substitution's 16.7% — acceleration
+dominates. The three initialization strategies are separated by one solve, and
+`"unit"` (the path #247 wired up) scores exactly what the 0.01 mol/s default
+it replaced scores: it saves an iteration or two and flips no verdict. Anderson
+is not free — `phase_coupled_flash` fails under it and converges under Wegstein.
+
+The trap `trace_recycle` exists to expose: `tol` is an ABSOLUTE tear residual,
+so on a loop of gain `g` it understates the remaining error by `1/(1-g)`. At
+`g = 0.97` Wegstein stops inside `1e-8` and is 1% out, reporting convergence
+and meaning it.
+
+Docs: `docs/convergence.md` ("Measured pass rates"). Tests:
+`tests/test_convergence_benchmark.py`, `tests/test_benchmarks_verdict.py`.
+
 ### Stochastic Programming (`difflow.stochastic`)
 
 Design under uncertainty: the sample average approximation of a two-stage
@@ -667,6 +718,7 @@ jax.debug.print("value: {x}", x=value)
 | `src/difflow/params_mixin.py` | ParamsMixin base class for all Params dataclasses |
 | `src/difflow/docstrings.py` | Reads Params field descriptions out of the `Attributes:` docstrings and field comments, for the catalog |
 | `src/difflow/gui/doclinks.py` | Resolves an operation name to its section in `docs/` (the palette's documentation link) |
+| `src/difflow/convergence.py` | Hard-flowsheet corpus and the recycle solver's measured pass rate |
 | `src/difflow/planning/` | Delta-base planning: AD delta vectors -> trust-region LP/MILP |
 | `src/difflow/stochastic/` | Two-stage stochastic programming: SAA over a scenario sample, VSS/EVPI |
 | `src/difflow_bio/__init__.py` | Bio manufacturing plugin exports |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -522,7 +522,7 @@ flowsheets. `make convergence` (or `python -m difflow.convergence`), or:
 
 ```python
 from difflow.convergence import run_benchmark
-report = run_benchmark()          # 54 solves: 6 cases x 3 accelerations x 3 inits
+report = run_benchmark()          # 99 solves: 11 cases x 3 accelerations x 3 inits
 print(report.as_text())
 ```
 
@@ -547,17 +547,34 @@ Invariants encoded in the module (do not weaken them):
 - Every `Case` states its own `difficulty`. A hard case that does not say why
   measures something nobody can act on.
 
-What it measured (2026-09, and meant to move): pass rate 46.3%, convergence
-rate 51.9%. Anderson 88.9% against plain substitution's 16.7% — acceleration
+What it measured (2026-09, and meant to move): pass rate 46.5%, convergence
+rate 49.5%. Anderson 84.8% against plain substitution's 27.3% — acceleration
 dominates. The three initialization strategies are separated by one solve, and
 `"unit"` (the path #247 wired up) scores exactly what the 0.01 mol/s default
-it replaced scores: it saves an iteration or two and flips no verdict. Anderson
-is not free — `phase_coupled_flash` fails under it and converges under Wegstein.
+it replaced scores: it saves an iteration or two and flips no verdict. That
+held unchanged when the corpus went from six cases to eleven.
 
-The trap `trace_recycle` exists to expose: `tol` is an ABSOLUTE tear residual,
-so on a loop of gain `g` it understates the remaining error by `1/(1-g)`. At
-`g = 0.97` Wegstein stops inside `1e-8` and is 1% out, reporting convergence
-and meaning it.
+**Every case is solved by at least one acceleration.** Eleven cases across the
+families #251 names — high gain, sharp splits, multi-loop, phase-regime
+switching, near-pinch columns, trace tears, signed tears — and none defeats
+all three methods. That negative result is the benchmark's main finding and
+the thing #251 turns on.
+
+Two traps it exposes, both worth knowing independently of that:
+- `tol` is an ABSOLUTE tear residual, so on a loop of gain `g` it understates
+  the remaining error by `1/(1-g)` (worse for a non-normal coupling, where it
+  is `||(I - M)^-1||`). At `g = 0.97` Wegstein stops inside `1e-8` and is 1%
+  out, reporting convergence and meaning it. `trace_recycle` pins it.
+- `clip_negative_flows` defaults to True and is applied by the Wegstein and
+  Anderson paths but NOT by the unaccelerated one. On a tear whose answer is
+  genuinely negative that projection is the difference between solving it and
+  not: `signed_tear` is the one case where plain substitution beats both
+  accelerated methods, and `clip_negative_flows=False` fixes Anderson on it
+  (100 iterations to 13). Same point `difflow_gas` already makes for signed
+  flows.
+
+Anderson is not free either — `phase_coupled_flash` fails under it and
+converges under Wegstein.
 
 Docs: `docs/convergence.md` ("Measured pass rates"). Tests:
 `tests/test_convergence_benchmark.py`, `tests/test_benchmarks_verdict.py`.

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ endif
 .PHONY: all notebooks notebooks-force notebooks-bio notebooks-ree notebooks-cc \
         notebooks-bio-force notebooks-ree-force notebooks-cc-force \
         clean test test-release test-slow test-all test-durations book book-clean sync \
-        gui gui-build gui-test
+        gui gui-build gui-test convergence
 
 all: notebooks
 
@@ -155,6 +155,13 @@ test-all:
 # machine, or the numbers it records are of a loaded box, which takes ~40 min.
 test-durations:
 	$(UV_RUN_DEV) pytest tests/ --store-durations
+
+# Measure how often the recycle solver converges, over the hard-flowsheet
+# corpus in difflow.convergence. A few minutes, mostly JAX compilation. The
+# number is a measurement and is meant to move -- rerun it after anything
+# that touches initialization, acceleration or the tear solve.
+convergence:
+	$(UV_RUN_DEV) python -m difflow.convergence
 
 # Clean generated files
 clean:

--- a/docs/convergence.md
+++ b/docs/convergence.md
@@ -21,6 +21,7 @@ loop still will not close.
 - [The equation-oriented route](#the-equation-oriented-route)
 - [Diagnostics](#diagnostics)
 - [A worked diagnosis](#a-worked-diagnosis)
+- [Measured pass rates](#measured-pass-rates)
 - [Tear selection](#tear-selection)
 - [What the plugins add](#what-the-plugins-add)
 
@@ -621,6 +622,119 @@ h = 1e-6
 finite_difference = (objective(1.0 + h) - objective(1.0 - h)) / (2 * h)
 assert abs(gradient - finite_difference) < 1e-6
 ```
+
+---
+
+## Measured pass rates
+
+How often any of this actually works is a measurement, and
+`difflow.convergence` is where it is made. It holds a corpus of deliberately
+hard flowsheets and runs each one across every acceleration and every
+initialization strategy:
+
+```python
+from difflow.convergence import run_benchmark
+
+report = run_benchmark()
+print(report.as_text())
+```
+
+The full grid is 54 solves and takes a few minutes, most of it JAX
+compilation. Narrow it while iterating:
+
+```python
+report = run_benchmark(cases=["high_gain_recycle"], accelerations=("anderson",))
+```
+
+### Passing means converged *and* right
+
+A solve reports two separate things, and the benchmark keeps them apart:
+
+| | meaning |
+|---|---|
+| `Outcome.converged` | the solver's own verdict, `last_solve_converged` |
+| `Outcome.correct` | the answer closes its material balance, or matches a known one |
+| `Outcome.passed` | both |
+
+They are not the same. `pass_rate` is 46.3% against a `convergence_rate` of
+51.9%: three of the 54 solves report success and land somewhere that does not
+audit. A benchmark that counted only the solver's flag would call those wins.
+
+### What the corpus says today
+
+```
+54 solves  (tol=1e-08, max_iter=100)
+pass rate         46.3%   (converged AND the answer audits)
+convergence rate  51.9%   (the solver's own verdict)
+
+by acceleration                    by initialization
+  anderson      16/18   88.9%        default        8/18   44.4%
+  wegstein       6/18   33.3%        unit           8/18   44.4%
+  none           3/18   16.7%        feed           9/18   50.0%
+
+mean iterations over passing solves: anderson=4.9, wegstein=22.8, none=35.0
+```
+
+Three findings worth acting on:
+
+**Acceleration dominates; initialization barely registers.** Anderson passes
+88.9% where plain substitution passes 16.7%. Against that, the three starting
+points are separated by a single solve. The obvious lever on a failing recycle
+is `acceleration`, not the guess.
+
+**The `initialize()` path (#247) changed no outcome.** `"unit"` — the
+propagation pass that #247 wired up — scores exactly what `"default"` scores,
+the 0.01 mol/s stream it replaced: 8/18 either way. It reliably saves an
+iteration or two (`flash_recycle` goes 3 → 2 under Anderson) and it flips no
+verdict anywhere in the corpus. It made the first step better without making a
+failing solve succeed. If a recycle is failing, a better guess of the same
+kind is not the fix.
+
+**Anderson is not free.** `phase_coupled_flash` is in the corpus because
+Anderson fails it where Wegstein converges in 28 iterations — and fails it by
+walking somewhere else entirely, not by running out of iterations. On a loop
+that changes phase regime as it iterates, try Wegstein before concluding the
+flowsheet is wrong.
+
+### The trap the corpus exposes
+
+`tol` is an **absolute** residual on the tear, and on a high-gain loop that is
+much weaker than it looks. A step of $d$ on a loop of gain $g$ leaves an error
+of about $d/(1-g)$, so at $g = 0.97$ the residual understates the remaining
+error by a factor of 33.
+
+`trace_recycle` is built on exactly that: gain 0.97 on a tear whose converged
+value is about $3 \times 10^{-5}$. Wegstein stops with a residual inside
+`1e-8`, reports convergence, and is about 1% out. It is right on its own terms
+— the step really is that small — and wrong on yours.
+
+On a loop where you know the gain is near one, tighten `tol` by roughly
+$1/(1-g)$, or audit the answer rather than the residual.
+
+### Adding a case
+
+A case is a name, a builder, and a sentence saying what makes it hard:
+
+```python
+from difflow.convergence import Case, run_case
+
+case = Case(
+    name="my_hard_loop",
+    build=build_my_flowsheet,          # must return a FRESH Flowsheet
+    difficulty="Why this one is hard, in a sentence.",
+    tags=("recycle", "high-gain"),
+)
+run_case(case, acceleration="wegstein")
+```
+
+`build` has to return a new flowsheet each call — `solve` records its verdict
+on the object, so a shared one carries one run's result into the next. The
+default audit is the overall mole balance; a case whose reaction changes the
+mole count, or whose answer is known analytically, passes its own `check`.
+
+Keep at least one case in the corpus that is *meant* to pass. A benchmark
+where everything fails cannot distinguish a hard corpus from a broken solver;
+`two_phase_flash` is that control, and it passes 9/9.
 
 ---
 

--- a/docs/convergence.md
+++ b/docs/convergence.md
@@ -639,7 +639,7 @@ report = run_benchmark()
 print(report.as_text())
 ```
 
-The full grid is 54 solves and takes a few minutes, most of it JAX
+The full grid is 99 solves and takes several minutes, most of it JAX
 compilation. Narrow it while iterating:
 
 ```python
@@ -656,45 +656,78 @@ A solve reports two separate things, and the benchmark keeps them apart:
 | `Outcome.correct` | the answer closes its material balance, or matches a known one |
 | `Outcome.passed` | both |
 
-They are not the same. `pass_rate` is 46.3% against a `convergence_rate` of
-51.9%: three of the 54 solves report success and land somewhere that does not
+They are not the same. `pass_rate` is 46.5% against a `convergence_rate` of
+49.5%: three of the 99 solves report success and land somewhere that does not
 audit. A benchmark that counted only the solver's flag would call those wins.
 
 ### What the corpus says today
 
 ```
-54 solves  (tol=1e-08, max_iter=100)
-pass rate         46.3%   (converged AND the answer audits)
-convergence rate  51.9%   (the solver's own verdict)
+99 solves  (tol=1e-08, max_iter=100)
+pass rate         46.5%   (converged AND the answer audits)
+convergence rate  49.5%   (the solver's own verdict)
 
 by acceleration                    by initialization
-  anderson      16/18   88.9%        default        8/18   44.4%
-  wegstein       6/18   33.3%        unit           8/18   44.4%
-  none           3/18   16.7%        feed           9/18   50.0%
+  anderson      28/33   84.8%        default       15/33   45.5%
+  wegstein       9/33   27.3%        unit          15/33   45.5%
+  none           9/33   27.3%        feed          16/33   48.5%
 
-mean iterations over passing solves: anderson=4.9, wegstein=22.8, none=35.0
+mean iterations over passing solves: anderson=4.3, wegstein=18.9, none=41.0
 ```
 
-Three findings worth acting on:
+**Every case in the corpus is solved by at least one acceleration.** Eleven
+cases across the hard families — high loop gain, sharp splits, multi-loop,
+phase-regime switching, near-pinch columns, trace-magnitude tears, signed
+tears — and none of them defeats all three methods. That is the most useful
+thing the benchmark says, and it is a negative result.
+
+Four findings worth acting on:
 
 **Acceleration dominates; initialization barely registers.** Anderson passes
-88.9% where plain substitution passes 16.7%. Against that, the three starting
-points are separated by a single solve. The obvious lever on a failing recycle
-is `acceleration`, not the guess.
+84.8% where plain substitution passes 27.3%. Against that, the three starting
+points are separated by a single solve. The first thing to change on a failing
+recycle is `acceleration`, not the guess.
 
 **The `initialize()` path (#247) changed no outcome.** `"unit"` — the
 propagation pass that #247 wired up — scores exactly what `"default"` scores,
-the 0.01 mol/s stream it replaced: 8/18 either way. It reliably saves an
-iteration or two (`flash_recycle` goes 3 → 2 under Anderson) and it flips no
-verdict anywhere in the corpus. It made the first step better without making a
-failing solve succeed. If a recycle is failing, a better guess of the same
-kind is not the fix.
+the 0.01 mol/s stream it replaced: 15/33 either way, unchanged from when the
+corpus was six cases. It reliably saves an iteration or two and it flips no
+verdict anywhere. It made the first step better without making a failing solve
+succeed. If a recycle is failing, a better guess of the same kind is not the
+fix.
 
-**Anderson is not free.** `phase_coupled_flash` is in the corpus because
-Anderson fails it where Wegstein converges in 28 iterations — and fails it by
-walking somewhere else entirely, not by running out of iterations. On a loop
-that changes phase regime as it iterates, try Wegstein before concluding the
-flowsheet is wrong.
+**Anderson is not free, and `clip_negative_flows` is why, once.**
+`phase_coupled_flash` fails under Anderson and converges under Wegstein in 28
+iterations — Anderson walks off somewhere else rather than running out of road.
+And `signed_tear` inverts the ranking outright: plain substitution solves it
+and *both* accelerated methods fail. The reason is worth knowing —
+`clip_negative_flows` defaults to `True` and is applied by the Wegstein and
+Anderson paths but **not** by the unaccelerated one, so on a tear whose answer
+is genuinely negative the two accelerated methods carry a projection the plain
+one does not. Passing `clip_negative_flows=False` fixes Anderson on it
+immediately (100 iterations without convergence → 13 with). This is the same
+point `difflow_gas` already makes for signed flows; it applies to any tear
+whose components can go negative.
+
+**A disjunction does not need binaries here.** `regime_switch` is a unit
+choosing between two linear branches with the answer exactly on the boundary,
+expanding below the switch and contracting above it. Plain substitution can
+only chatter across the join, and Wegstein stalls — but Anderson lands on it
+in two iterations.
+
+### What is *not* hard
+
+Worth recording, because these are the families most often assumed difficult:
+
+- **A rigorous MESH column in a recycle.** `column_recycle` — twelve stages,
+  95% of the distillate returned — passes under every setting, at every reflux
+  ratio tried from just above minimum to well above it.
+- **Nonsmooth tear maps as such.** Both `regime_switch` and the kinked maps
+  tried while building the corpus fall to Anderson quickly.
+- **Tear dimension.** A tear with twelve components and a spectral radius of
+  0.985 converges under Anderson as readily as one with three, provided the
+  coupling is non-negative. Where high-dimensional cases did fail, the cause
+  was the negative-flow clipping above, not the dimension.
 
 ### The trap the corpus exposes
 
@@ -710,6 +743,12 @@ value is about $3 \times 10^{-5}$. Wegstein stops with a residual inside
 
 On a loop where you know the gain is near one, tighten `tol` by roughly
 $1/(1-g)$, or audit the answer rather than the residual.
+
+For a multicomponent tear the factor is $\lVert (I-M)^{-1} \rVert$ rather than
+$1/(1-\rho)$, and for a non-normal $M$ those are not close: `signed_tear` has
+$\rho = 0.75$, which suggests a factor of 4, and actually leaves a relative
+error of $1.2 \times 10^{-6}$ from a residual of $10^{-8}$ — a factor of about
+450.
 
 ### Adding a case
 
@@ -733,8 +772,14 @@ default audit is the overall mole balance; a case whose reaction changes the
 mole count, or whose answer is known analytically, passes its own `check`.
 
 Keep at least one case in the corpus that is *meant* to pass. A benchmark
-where everything fails cannot distinguish a hard corpus from a broken solver;
-`two_phase_flash` is that control, and it passes 9/9.
+where everything fails cannot distinguish a hard corpus from a broken solver.
+`two_phase_flash` and `column_recycle` are the controls, and both pass 9/9.
+
+And check a new case is not *rigged* — that no initialization strategy starts
+on the answer it is about to be scored against. `overshoot_loop` originally
+used $g(x) = 3F - 2x$, whose fixed point is $x = F$, exactly the `"feed"`
+guess; that strategy collected two passes on a case it had not solved.
+`TestNoCaseIsRigged` checks every case in the corpus against this.
 
 ---
 

--- a/src/difflow/benchmarks.py
+++ b/src/difflow/benchmarks.py
@@ -22,19 +22,24 @@ class SolverComparison:
     Attributes:
         sm_time: SM solve wall time (seconds)
         eo_time: EO solve wall time (seconds)
-        sm_iterations: SM iteration count
+        sm_iterations: SM tear iteration count, from
+            ``Flowsheet.last_solve_iterations``.  ``None`` for a
+            recycle-free flowsheet, which does not iterate at all.
         eo_iterations: EO Newton iteration count
         max_stream_difference: Maximum absolute difference in any stream variable
         gradient_difference: Maximum difference in gradients (if computed)
-        sm_converged: Whether SM solver converged
+        sm_residual: Final SM tear residual.
+        sm_converged: Whether the SM solve met its tolerance, from
+            ``Flowsheet.last_solve_converged``.
         eo_converged: Whether EO solver converged
     """
     sm_time: float
     eo_time: float
-    sm_iterations: int
+    sm_iterations: int | None
     eo_iterations: int
     max_stream_difference: float
     gradient_difference: float | None = None
+    sm_residual: float | None = None
     sm_converged: bool = True
     eo_converged: bool = True
 
@@ -49,6 +54,14 @@ def compare_solvers(
 
     Runs both solvers on the same problem and compares results.
 
+    ``max_stream_difference`` is only meaningful when both solvers
+    converged: comparing a converged answer against a last iterate measures
+    how far one of them got, not how far apart the methods are.  Check
+    ``sm_converged`` and ``eo_converged`` before reading it.
+
+    A non-converged SM solve warns as it normally would; the verdict is also
+    returned, so a caller can test ``sm_converged`` instead of catching.
+
     Args:
         flowsheet: The flowsheet to solve
         tol: Convergence tolerance for both solvers
@@ -58,9 +71,10 @@ def compare_solvers(
     Returns:
         SolverComparison with timing and accuracy metrics
     """
-    species_order = flowsheet.species_order
-
-    # Run SM solver
+    # Run SM solver.  The non-convergence warning is left to fire: #249
+    # made a failed recycle solve say so, and a comparison is no reason to
+    # take that back.  sm_converged carries the same verdict for a caller
+    # that would rather test it than catch it.
     t0 = time.time()
     sm_streams = flowsheet.solve(
         tol=tol,
@@ -88,11 +102,17 @@ def compare_solvers(
                 diff = float(jnp.abs(sm_s[key] - eo_s[key]))
                 max_diff = max(max_diff, diff)
 
+    # The flowsheet records its own verdict (#249); before that this
+    # function reported sm_converged=True unconditionally and sm_iterations
+    # as the iteration cap, so a diverged SM solve looked like a converged
+    # one that happened to disagree with EO.
     return SolverComparison(
         sm_time=sm_time,
         eo_time=eo_time,
-        sm_iterations=max_iter,  # SM doesn't report iteration count directly
+        sm_iterations=flowsheet.last_solve_iterations,
         eo_iterations=eo_result.n_iterations,
         max_stream_difference=max_diff,
+        sm_residual=flowsheet.last_solve_residual,
+        sm_converged=bool(flowsheet.last_solve_converged),
         eo_converged=eo_result.converged,
     )

--- a/src/difflow/convergence.py
+++ b/src/difflow/convergence.py
@@ -50,10 +50,25 @@ The corpus
 ----------
 Each :class:`Case` says in its own ``difficulty`` field what makes it hard,
 because a benchmark whose cases are hard for unstated reasons measures
-something nobody can act on.  The families follow the ones named in #251:
-high-gain recycles, phase-flipping flashes, sharp splits --- plus the linear
-overshoot map, which is here because its answer is known exactly and so it
-can distinguish "the solver was wrong" from "the case is hard".
+something nobody can act on.  The eleven cases cover the families #251 names
+--- high loop gain, sharp splits, multi-loop flowsheets, phase-regime
+switching, near-pinch columns --- plus a trace-magnitude tear, a signed tear,
+and two linear maps whose answers are known exactly and so can distinguish
+"the solver was wrong" from "the case is hard".
+
+Two of them are controls, meant to pass under every setting: an ordinary
+two-phase flash recycle, and a rigorous twelve-stage MESH column with 95% of
+its distillate returned.  A corpus where everything fails cannot tell a hard
+corpus from a broken solver.
+
+What it measured, and what that is for
+--------------------------------------
+**Every case is solved by at least one acceleration.**  Across eleven cases
+and three methods there is no flowsheet here that all three fail, which is
+the benchmark's main finding and a negative one.  It is the fact #251 turns
+on: a globally consistent MILP initial guess is aimed at failures that this
+corpus does not contain.  Extending the corpus until it does --- or failing
+to, deliberately and on the record --- is how that issue gets decided.
 """
 
 from __future__ import annotations
@@ -225,14 +240,20 @@ def _first_order_cstr(k: float, species: Sequence[str]):
     return CSTR(params, thermo=thermo, mode="isothermal")
 
 
-def _flash(species: Sequence[str]):
-    """An ideal-thermo flash over ``species``, from the shipped database."""
+def _ideal_thermo(species: Sequence[str]):
+    """Raoult K-values over ``species``, from the shipped database."""
     from difflow.database import get_species_data
     from difflow.thermo import IdealThermo
+
+    return IdealThermo({s: get_species_data(s) for s in species})
+
+
+def _flash(species: Sequence[str]):
+    """An ideal-thermo flash over ``species``, from the shipped database."""
     from difflow.units.flash import Flash, FlashParams
 
-    thermo = IdealThermo({s: get_species_data(s) for s in species})
-    return Flash(FlashParams(species_order=list(species)), thermo=thermo)
+    return Flash(FlashParams(species_order=list(species)),
+                 thermo=_ideal_thermo(species))
 
 
 def _passthrough(stream: Stream) -> Stream:
@@ -396,6 +417,186 @@ def _trace_check(fs: Flowsheet, streams: dict[str, Stream]) -> float:
             if jnp.isfinite(jnp.asarray(got)) else float("inf"))
 
 
+def _build_two_loop() -> Flowsheet:
+    """Two recycles around one mixer, nested: the inner split feeds the outer.
+
+    ``s_in`` returns 42.5% of the mixer outlet directly; ``s_out`` returns
+    90% of what is left, another 51.8%.  The combined gain is 0.943 and the
+    mixer carries about 17 times the feed.
+
+    The corpus was otherwise all single-tear.  Two tears is the case #251
+    calls "globally consistent around the loop" -- substitution has to
+    settle both at once, and the accelerated methods see one combined tear
+    vector rather than two loops.
+    """
+    def merge(feed: Stream, r_in: Stream, r_out: Stream) -> Stream:
+        f, a, b = get_flows(feed), get_flows(r_in), get_flows(r_out)
+        return make_stream({"A": f["A"] + a["A"] + b["A"]},
+                           feed["T"], feed["P"])
+
+    fs = Flowsheet(["A"], default_flow=0.01)
+    fs.add_feed("feed", make_stream({"A": 1.0}, 300.0, 101325.0))
+    fs.add_unit(Unit("mix", merge, ["feed", "r_in", "r_out"], ["mixed"]))
+    fs.add_unit(Unit("s_in", _splitter(0.425), ["mixed"], ["r_in_src", "mid"]))
+    fs.add_unit(Unit("s_out", _splitter(0.9), ["mid"], ["r_out_src", "product"]))
+    fs.add_recycle("r_in_src", "r_in")
+    fs.add_recycle("r_out_src", "r_out")
+    return fs
+
+
+def _build_sharp_split() -> Flowsheet:
+    """A 0.1% purge: 999 parts recycled for every one that leaves."""
+    def combine(feed: Stream, tear: Stream) -> Stream:
+        f, t = get_flows(feed), get_flows(tear)
+        return make_stream({k: f[k] + t[k] for k in f}, feed["T"], feed["P"])
+
+    fs = Flowsheet(["A"], default_flow=0.01)
+    fs.add_feed("feed", make_stream({"A": 1.0}, 300.0, 101325.0))
+    fs.add_unit(Unit("mix", combine, ["feed", "tear"], ["mixed"]))
+    fs.add_unit(Unit("split", _splitter(0.999), ["mixed"], ["rec_src", "purge"]))
+    fs.add_recycle("rec_src", "tear")
+    return fs
+
+
+#: Coupling matrix for :func:`_build_signed_tear`, spectral radius 0.75.
+#: Written out rather than reseeded so the case does not depend on NumPy's
+#: random stream staying put across versions.
+_SIGNED_M = (
+    (+0.060542, -0.063612, +0.308380, +0.050512, -0.257938, +0.174117),
+    (+0.627909, +0.456043, -0.338866, -0.609332, -0.300122, +0.019900),
+    (-1.119561, -0.105354, -0.599938, -0.352605, -0.262074, -0.152307),
+    (+0.198211, +0.501997, -0.061893, +0.657987, -0.320308, +0.169261),
+    (+0.435044, +0.045269, -0.358014, -0.443834, -0.220407, +0.106030),
+    (-0.486157, -0.100723, -0.076671, +0.260431, +0.103364, +0.171121),
+)
+
+#: ``(I - M)^-1 . 1``, the exact answer.  Three components are negative.
+_SIGNED_ANSWER = (1.151624, -0.437615, -1.230257, 3.785688, 0.365769, 1.933032)
+
+_SIGNED_SPECIES = tuple(f"S{i}" for i in range(6))
+
+
+def _build_signed_tear() -> Flowsheet:
+    """A tear that legitimately carries a signed quantity.
+
+    ``x <- f + M x`` with the spectral radius at 0.75, and three components
+    of the answer negative.  Not a contrivance: ``difflow_gas`` works in
+    signed flows throughout, because a pipe's direction is an unknown, and
+    its docs already say to solve with ``clip_negative_flows=False``.
+
+    The corpus needs it because it is the only case here that inverts the
+    usual ranking.  ``clip_negative_flows`` defaults to ``True`` and is
+    applied by the Wegstein and Anderson paths but **not** by the
+    unaccelerated one, so on this map the two accelerated methods have a
+    projection applied to their iterates that the plain one does not --
+    and they are the two that fail.
+    """
+    species = list(_SIGNED_SPECIES)
+    M = jnp.asarray(_SIGNED_M)
+
+    def loop(feed: Stream, tear: Stream) -> Stream:
+        x = jnp.array([tear[f"F_{s}"] for s in species])
+        f = jnp.array([feed[f"F_{s}"] for s in species])
+        y = f + M @ x
+        return make_stream({s: y[i] for i, s in enumerate(species)},
+                           feed["T"], feed["P"])
+
+    fs = Flowsheet(species, default_flow=0.01)
+    fs.add_feed("feed", make_stream({s: 1.0 for s in species}, 300.0, 101325.0))
+    fs.add_unit(Unit("loop", loop, ["feed", "tear"], ["loop_out"]))
+    fs.add_unit(Unit("out", _passthrough, ["loop_out"], ["product"]))
+    fs.add_recycle("loop_out", "tear")
+    return fs
+
+
+def _signed_check(fs: Flowsheet, streams: dict[str, Stream]) -> float:
+    """Against ``(I - M)^-1 f``, which is known in closed form.
+
+    The mole balance cannot audit a signed tear -- the map is not a
+    material balance and the "flows" are not moles.
+    """
+    if "product" not in streams:
+        return float("inf")
+    scale = max(abs(v) for v in _SIGNED_ANSWER)
+    worst = 0.0
+    for species, want in zip(_SIGNED_SPECIES, _SIGNED_ANSWER):
+        got = float(streams["product"][f"F_{species}"])
+        if not jnp.isfinite(jnp.asarray(got)):
+            return float("inf")
+        worst = max(worst, abs(got - want))
+    return worst / scale
+
+
+def _build_regime_switch() -> Flowsheet:
+    """The solution sits exactly on a switch between two linear regimes.
+
+    Below the threshold the loop is strongly expanding, above it strongly
+    contracting, and the two branches meet at the fixed point.  Plain
+    substitution can only chatter across the join.
+
+    This is the disjunction #251 proposes to hand to a MILP's binaries --
+    a unit picking a branch, with the answer on the boundary.  It is in the
+    corpus to find out whether difflow needs binaries to solve one.
+    """
+    threshold = 2.0
+
+    def loop(feed: Stream, tear: Stream) -> Stream:
+        x = tear["F_A"]
+        below = 4.0 * x - 6.0     # expanding;  g(2) = 2
+        above = 0.2 * x + 1.6     # contracting; g(2) = 2
+        return make_stream({"A": jnp.where(x < threshold, below, above)},
+                           feed["T"], feed["P"])
+
+    fs = Flowsheet(["A"], default_flow=0.01)
+    fs.add_feed("feed", make_stream({"A": 1.0}, 300.0, 101325.0))
+    fs.add_unit(Unit("loop", loop, ["feed", "tear"], ["loop_out"]))
+    fs.add_unit(Unit("out", _passthrough, ["loop_out"], ["product"]))
+    fs.add_recycle("loop_out", "tear")
+    return fs
+
+
+def _regime_check(fs: Flowsheet, streams: dict[str, Stream]) -> float:
+    """The switch point itself, ``x = 2``."""
+    if "product" not in streams:
+        return float("inf")
+    got = float(streams["product"]["F_A"])
+    return (abs(got - 2.0) / 2.0
+            if jnp.isfinite(jnp.asarray(got)) else float("inf"))
+
+
+def _build_column_recycle() -> Flowsheet:
+    """A rigorous MESH column with 95% of its distillate recycled.
+
+    #251 names near-pinch columns as a hard family, so the corpus should
+    contain one and say what happens.  A real
+    :class:`~difflow.units.distillation.DistillationColumn` -- twelve
+    stages, MESH after a CMO warm start -- inside a high-recycle loop.
+
+    The heaviest unit here by a wide margin, and it costs a JAX compile.
+    """
+    from difflow.units.distillation import (
+        DistillationColumn, DistillationColumnParams)
+
+    species = list(_PAIR)
+    params = DistillationColumnParams(species_order=species, n_stages=12,
+                                      feed_stage=6, P=101325.0, q=1.0)
+    column = DistillationColumn(params, _ideal_thermo(_PAIR))
+
+    def column_op(feed: Stream):
+        total = sum(get_flows(feed).values())
+        distillate, bottoms, _ = column(feed, R=1.5, D_spec=0.5 * total)
+        return distillate, bottoms
+
+    fs = Flowsheet(species, default_flow=0.01)
+    fs.add_feed("feed", make_stream({species[0]: 1.0, species[1]: 1.0},
+                                    360.0, 101325.0))
+    fs.add_unit(Unit("mix", _mixer, ["feed", "rec"], ["mixed"]))
+    fs.add_unit(Unit("col", column_op, ["mixed"], ["dist", "bot"]))
+    fs.add_unit(Unit("split", _splitter(0.95), ["dist"], ["rec_src", "product"]))
+    fs.add_recycle("rec_src", "rec")
+    return fs
+
+
 #: The corpus.  Ordered easiest-to-read, not easiest-to-solve.
 CORPUS: tuple[Case, ...] = (
     Case(
@@ -458,6 +659,69 @@ CORPUS: tuple[Case, ...] = (
         tags=("recycle", "trace", "high-gain", "analytic"),
         check=_trace_check,
         tol=1e-4,
+    ),
+    Case(
+        name="two_loop_recycle",
+        build=_build_two_loop,
+        difficulty=(
+            "Two recycles around one mixer, returning 0.425 and 0.518 of "
+            "its outlet for a combined loop gain of 0.943, so the solver "
+            "has to settle two tears at once rather than one. The only "
+            "multi-tear case in the corpus."),
+        tags=("recycle", "multi-loop", "high-gain"),
+    ),
+    Case(
+        name="sharp_split_purge",
+        build=_build_sharp_split,
+        difficulty=(
+            "A 0.1% purge: 999 parts recycled for every one leaving, so the "
+            "loop gain is 0.999 and the converged recycle is a thousand "
+            "times the feed. The sharp-split family, pushed a decade past "
+            "high_gain_recycle."),
+        tags=("recycle", "sharp-split", "high-gain"),
+    ),
+    Case(
+        name="signed_tear",
+        build=_build_signed_tear,
+        difficulty=(
+            "A tear carrying a signed quantity, as difflow_gas does: "
+            "x <- f + M x at spectral radius 0.75, with three of the six "
+            "components of the answer negative. The one case here that "
+            "inverts the ranking -- clip_negative_flows defaults to True "
+            "and is applied by Wegstein and Anderson but not by plain "
+            "substitution, and it is the two accelerated methods that "
+            "fail. Passing clip_negative_flows=False fixes Anderson."),
+        tags=("recycle", "signed", "clipping", "analytic"),
+        check=_signed_check,
+        # 1e-4, not the tighter 1e-6 the other analytic cases use: M is
+        # non-normal, so the error the tear tolerance leaves behind is
+        # amplified by ||(I - M)^-1|| rather than by 1/(1 - rho), and plain
+        # substitution lands at 1.2e-6.  Judging that "wrong" would be a
+        # verdict about the threshold rather than about the solver.
+        tol=1e-4,
+    ),
+    Case(
+        name="regime_switch",
+        build=_build_regime_switch,
+        difficulty=(
+            "Two linear branches meeting exactly at the fixed point, "
+            "expanding below the switch and contracting above it, so "
+            "substitution chatters across the join forever. This is the "
+            "disjunction #251 proposes handing to a MILP's binaries, and "
+            "it is here to find out whether difflow needs them."),
+        tags=("recycle", "phase-flip", "nonsmooth", "analytic"),
+        check=_regime_check,
+        tol=1e-6,
+    ),
+    Case(
+        name="column_recycle",
+        build=_build_column_recycle,
+        difficulty=(
+            "A rigorous twelve-stage MESH column with 95% of its "
+            "distillate recycled -- the near-pinch column family #251 "
+            "names. Not hard, as it turns out: every setting solves it. "
+            "The heaviest unit in the corpus by a wide margin."),
+        tags=("recycle", "column", "control"),
     ),
 )
 

--- a/src/difflow/convergence.py
+++ b/src/difflow/convergence.py
@@ -1,0 +1,850 @@
+"""How often does difflow's recycle solver actually converge?
+
+Nothing in the project answered that.  :mod:`difflow.benchmarks` compared SM
+against EO on *one* flowsheet the caller supplied, and the test suite asserts
+that the flowsheets it happens to contain converge --- which is a selection of
+flowsheets chosen, understandably, because they converge.  There was no corpus
+of deliberately hard ones and no pass-rate number, so "initialization strategy
+X helped" was not a claim anyone could check.
+
+This module is that corpus and that number.  It runs every case in
+:data:`CORPUS` across every acceleration and every initialization strategy,
+and reports how many solves *passed* --- where passing means the solver said
+it converged **and** the answer closes its material balance.  The two are not
+the same thing, and keeping them apart is most of the point: a tear iteration
+that stalls inside its tolerance, or one whose negative-flow clipping invents
+a fixed point that is not a solution, reports success either way.
+:attr:`Outcome.converged` is the solver's verdict and :attr:`Outcome.correct`
+is the audit of it.
+
+Why it exists now
+-----------------
+It is the measurement that #247 (tear initialization never fires) asked for
+and did not get: that fix changed every recycle's starting point, and whether
+it changed any *outcome* is an empirical question.  Run the benchmark with
+``initializations=("default", "unit")`` and the two columns are the before
+and after.
+
+It is also the gate on #251 (a piecewise-linear MILP initializer).  A MILP
+initial guess is a large piece of machinery to justify, and it can only be
+justified against a failure rate someone has measured.  If the cheap fixes
+already close the gap, the number says so and the MILP is not needed.
+
+Usage
+-----
+::
+
+    from difflow.convergence import run_benchmark
+
+    report = run_benchmark()
+    print(report.as_text())
+    print(report.pass_rate)
+
+Narrow it while iterating --- the full grid is a few hundred solves and each
+one pays JAX compilation::
+
+    report = run_benchmark(cases=["high_gain_recycle"],
+                           accelerations=("anderson",))
+
+The corpus
+----------
+Each :class:`Case` says in its own ``difficulty`` field what makes it hard,
+because a benchmark whose cases are hard for unstated reasons measures
+something nobody can act on.  The families follow the ones named in #251:
+high-gain recycles, phase-flipping flashes, sharp splits --- plus the linear
+overshoot map, which is here because its answer is known exactly and so it
+can distinguish "the solver was wrong" from "the case is hard".
+"""
+
+from __future__ import annotations
+
+import time
+import traceback
+import warnings
+from dataclasses import dataclass, field
+from typing import Callable, Iterable, Literal, Sequence
+
+import jax.numpy as jnp
+
+from difflow.flowsheet import ConvergenceWarning, Flowsheet, Unit
+from difflow.initialization import TearInitializationWarning
+from difflow.streams import Stream, get_flows, make_stream
+
+__all__ = [
+    "Case",
+    "Outcome",
+    "Report",
+    "CORPUS",
+    "ACCELERATIONS",
+    "INITIALIZATIONS",
+    "get_case",
+    "cases",
+    "run_case",
+    "run_benchmark",
+    "total_mole_balance",
+]
+
+
+#: The acceleration settings :meth:`Flowsheet.solve` offers.
+ACCELERATIONS: tuple[str, ...] = ("none", "wegstein", "anderson")
+
+#: The initialization strategies compared.  ``"default"`` is what every
+#: recycle in difflow got before #247 --- ``default_flow`` (0.01 mol/s) in
+#: every species.  ``"unit"`` is the propagation pass that #247 wired up.
+#: ``"feed"`` is the guess a user writes by hand when the default fails:
+#: the combined feed, handed to every tear.
+INITIALIZATIONS: tuple[str, ...] = ("default", "unit", "feed")
+
+
+# =============================================================================
+# Balance auditing
+# =============================================================================
+
+def _product_streams(fs: Flowsheet) -> list[str]:
+    """Streams that leave the flowsheet: produced, consumed by nothing.
+
+    A recycle source is produced and then consumed at the other end of the
+    tear, so it is not a product even though no ``inlet_names`` mentions it.
+    """
+    produced: set[str] = set()
+    consumed: set[str] = set()
+    for unit in fs.units:
+        produced.update(unit.outlet_names)
+        consumed.update(unit.inlet_names)
+    return sorted(produced - consumed - set(fs.recycles))
+
+
+def total_mole_balance(fs: Flowsheet, streams: dict[str, Stream]) -> float:
+    """Relative error in the overall mole balance, feeds against products.
+
+    The default audit.  It is valid for every case in :data:`CORPUS`: none
+    of them change the total mole count, either because nothing reacts or
+    because the reaction is ``A -> B``.  A case with a mole-changing
+    reaction must supply its own ``check``.
+
+    Args:
+        fs: The flowsheet that was solved.
+        streams: The streams :meth:`Flowsheet.solve` returned.
+
+    Returns:
+        ``|in - out| / max(in, 1)``.  Non-finite values (a diverged solve
+        that ran to ``inf``) come back as ``inf`` rather than raising, so a
+        failing case still reports a number.
+    """
+    total_in = sum(float(jnp.sum(jnp.asarray(list(get_flows(s).values()))))
+                   for s in fs.feeds.values())
+    total_out = 0.0
+    for name in _product_streams(fs):
+        if name not in streams:
+            continue
+        total_out += float(
+            jnp.sum(jnp.asarray(list(get_flows(streams[name]).values()))))
+    err = abs(total_in - total_out) / max(abs(total_in), 1.0)
+    return err if jnp.isfinite(jnp.asarray(err)) else float("inf")
+
+
+# =============================================================================
+# Cases
+# =============================================================================
+
+@dataclass(frozen=True)
+class Case:
+    """One deliberately hard flowsheet.
+
+    Attributes:
+        name: Identifier, unique within :data:`CORPUS`.
+        build: Returns a *fresh* :class:`~difflow.flowsheet.Flowsheet`.  It
+            must build a new one on every call: :meth:`Flowsheet.solve`
+            records state on the object, and a case reused across settings
+            would carry one run's verdict into the next.
+        difficulty: What makes this one hard, in a sentence.  Required ---
+            an unexplained hard case measures something nobody can act on.
+        tags: Free-form labels for filtering (``"recycle"``, ``"flash"``).
+        check: Audits a solution, returning a relative error.  Defaults to
+            :func:`total_mole_balance`.
+        tol: Balance error above which the answer is called wrong, however
+            confidently the solver reported convergence.
+    """
+
+    name: str
+    build: Callable[[], Flowsheet]
+    difficulty: str
+    tags: tuple[str, ...] = ()
+    check: Callable[[Flowsheet, dict[str, Stream]], float] = total_mole_balance
+    tol: float = 1e-4
+
+
+# -- shared pieces ------------------------------------------------------------
+
+def _mixer(s1: Stream, s2: Stream) -> Stream:
+    """Adiabatic-ish mixer: flows add, T is flow-averaged."""
+    f1, f2 = get_flows(s1), get_flows(s2)
+    n1 = sum(f1.values())
+    n2 = sum(f2.values())
+    total = n1 + n2
+    # jnp.where rather than a Python branch: total is traced under grad.
+    w = jnp.where(total > 0, n1 / jnp.where(total > 0, total, 1.0), 0.5)
+    return make_stream({k: f1[k] + f2[k] for k in f1},
+                       w * s1["T"] + (1 - w) * s2["T"], s1["P"])
+
+
+def _splitter(recycle_frac: float) -> Callable:
+    """Split into ``(recycle, product)``."""
+    def split(inlet: Stream):
+        flows = get_flows(inlet)
+        rec = make_stream({k: v * recycle_frac for k, v in flows.items()},
+                          inlet["T"], inlet["P"])
+        prod = make_stream({k: v * (1.0 - recycle_frac) for k, v in flows.items()},
+                           inlet["T"], inlet["P"])
+        return rec, prod
+    return split
+
+
+def _first_order_cstr(k: float, species: Sequence[str]):
+    """``A -> B``, ``r = k C_A``, isothermal."""
+    from difflow.database import get_species_data
+    from difflow.thermo import IdealThermo
+    from difflow.units.cstr import CSTR, CSTRParams
+
+    thermo = IdealThermo({
+        species[0]: get_species_data("n_hexane")._replace(name=species[0]),
+        species[1]: get_species_data("n_heptane")._replace(name=species[1]),
+    })
+
+    def rate_fn(C, T, params):
+        return jnp.array([params["k"] * C[species[0]]])
+
+    params = CSTRParams(
+        V=jnp.array(1.0),
+        rate_fn=rate_fn,
+        stoich=jnp.array([[-1.0], [+1.0]]),
+        rate_params={"k": jnp.array(k)},
+        species_order=list(species),
+        molar_density=55500.0,
+    )
+    return CSTR(params, thermo=thermo, mode="isothermal")
+
+
+def _flash(species: Sequence[str]):
+    """An ideal-thermo flash over ``species``, from the shipped database."""
+    from difflow.database import get_species_data
+    from difflow.thermo import IdealThermo
+    from difflow.units.flash import Flash, FlashParams
+
+    thermo = IdealThermo({s: get_species_data(s) for s in species})
+    return Flash(FlashParams(species_order=list(species)), thermo=thermo)
+
+
+def _passthrough(stream: Stream) -> Stream:
+    return make_stream(get_flows(stream), stream["T"], stream["P"])
+
+
+def _cooler(dT: float) -> Callable:
+    def cool(stream: Stream) -> Stream:
+        return make_stream(get_flows(stream), stream["T"] - dT, stream["P"])
+    return cool
+
+
+# -- the corpus ---------------------------------------------------------------
+
+_PAIR = ("n_hexane", "n_heptane")
+
+
+def _build_overshoot() -> Flowsheet:
+    """``g(x) = 6F - 2x``: one tear, eigenvalue -2, fixed point ``x = 2F``.
+
+    The fixed point is deliberately *not* the feed.  With ``3F - 2x`` it
+    would be ``x = F`` exactly, and the ``"feed"`` initialization would
+    start on the answer and score a win it had not earned.
+    """
+    class Overshoot:
+        def __call__(self, feed: Stream, tear: Stream) -> Stream:
+            return make_stream({"A": 6.0 * feed["F_A"] - 2.0 * tear["F_A"]},
+                               feed["T"], feed["P"])
+
+    fs = Flowsheet(["A"], default_flow=0.01)
+    fs.add_feed("feed", make_stream({"A": 1.0}, 300.0, 101325.0))
+    fs.add_unit(Unit("loop", Overshoot(), ["feed", "tear"], ["loop_out"]))
+    fs.add_unit(Unit("out", _passthrough, ["loop_out"], ["product"]))
+    fs.add_recycle("loop_out", "tear")
+    return fs
+
+
+def _overshoot_check(fs: Flowsheet, streams: dict[str, Stream]) -> float:
+    """The exact answer is known: ``x = 2F = 2``.
+
+    The mole balance cannot audit this one --- the map is not a material
+    balance --- so the case brings its own check, which is what
+    ``Case.check`` is for.
+    """
+    if "product" not in streams:
+        return float("inf")
+    got = float(streams["product"]["F_A"])
+    return (abs(got - 2.0) / 2.0
+            if jnp.isfinite(jnp.asarray(got)) else float("inf"))
+
+
+def _build_high_gain() -> Flowsheet:
+    """Mixer -> CSTR (2% conversion) -> 99% recycle split."""
+    species = ["A", "B"]
+    fs = Flowsheet(species, default_flow=0.01)
+    fs.add_feed("feed", make_stream({"A": 1.0, "B": 0.0}, 350.0, 101325.0))
+    fs.add_unit(Unit("mix", _mixer, ["feed", "rec"], ["mixed"]))
+    fs.add_unit(Unit("cstr", _first_order_cstr(0.02, species), ["mixed"], ["rout"]))
+    fs.add_unit(Unit("split", _splitter(0.99), ["rout"], ["rec_src", "product"]))
+    fs.add_recycle("rec_src", "rec")
+    return fs
+
+
+def _build_flash_recycle() -> Flowsheet:
+    """Flash below the bubble point, 99% of the liquid recycled.
+
+    Subcooled, so the flash passes essentially everything to the liquid and
+    the loop gain is the split fraction itself.  Deliberately the same gain
+    as ``high_gain_recycle``, through a real unit rather than an analytic
+    map: the two together separate "the solver cannot do 0.99" from
+    "the flash is what broke".
+    """
+    flash = _flash(_PAIR)
+    T, P = 340.0, 101325.0
+
+    fs = Flowsheet(list(_PAIR), default_flow=0.01)
+    fs.add_feed("feed", make_stream({_PAIR[0]: 1.0, _PAIR[1]: 1.0}, T, P))
+    fs.add_unit(Unit("mix", _mixer, ["feed", "rec"], ["mixed"]))
+    fs.add_unit(Unit("flash", lambda s: flash(s, T=T, P=P), ["mixed"],
+                     ["liq", "vap"]))
+    fs.add_unit(Unit("split", _splitter(0.99), ["liq"], ["rec_src", "bottoms"]))
+    fs.add_recycle("rec_src", "rec")
+    return fs
+
+
+def _build_phase_coupled_flash() -> Flowsheet:
+    """The flash picks the temperature that decides its own phase split.
+
+    The flash runs at its inlet temperature, and its inlet is the feed mixed
+    with cooled recycled liquid.  How much liquid comes back therefore sets
+    the mix temperature, which sets the phase split, which sets how much
+    liquid comes back.  Tuned to sit just inside the two-phase window, where
+    that loop has two regimes to choose between.
+
+    This is the case that catches Anderson.  At these settings Wegstein
+    converges in under 30 iterations to a recycle of about 18 mol/s;
+    Anderson stops near 0.4 and reports non-convergence, having gone
+    somewhere else rather than run out of road.
+    """
+    flash = _flash(_PAIR)
+    P = 101325.0
+
+    fs = Flowsheet(list(_PAIR), default_flow=0.01, default_T=300.0)
+    fs.add_feed("feed", make_stream({_PAIR[0]: 1.0, _PAIR[1]: 1.0}, 358.0, P))
+    fs.add_unit(Unit("mix", _mixer, ["feed", "rec"], ["mixed"]))
+    fs.add_unit(Unit("flash", lambda s: flash(s, T=s["T"], P=P), ["mixed"],
+                     ["liq", "vap"]))
+    fs.add_unit(Unit("cool", _cooler(5.0), ["liq"], ["cooled"]))
+    fs.add_unit(Unit("split", _splitter(0.9), ["cooled"], ["rec_src", "bottoms"]))
+    fs.add_recycle("rec_src", "rec")
+    return fs
+
+
+def _build_two_phase_flash() -> Flowsheet:
+    """The control: a flash recycle inside the two-phase window.
+
+    A benchmark made only of cases that fail cannot tell a hard corpus from
+    a broken solver.  This one is an ordinary flash recycle with a real
+    vapour purge, and every setting should pass it.
+    """
+    flash = _flash(_PAIR)
+    T, P = 360.0, 101325.0
+
+    fs = Flowsheet(list(_PAIR), default_flow=0.01)
+    fs.add_feed("feed", make_stream({_PAIR[0]: 1.0, _PAIR[1]: 1.0}, T, P))
+    fs.add_unit(Unit("mix", _mixer, ["feed", "rec"], ["mixed"]))
+    fs.add_unit(Unit("flash", lambda s: flash(s, T=T, P=P), ["mixed"],
+                     ["liq", "vap"]))
+    fs.add_unit(Unit("split", _splitter(0.9), ["liq"], ["rec_src", "bottoms"]))
+    fs.add_recycle("rec_src", "rec")
+    return fs
+
+
+def _build_trace_recycle() -> Flowsheet:
+    """Loop gain 0.97 on a tear whose true magnitude is about 1e-6.
+
+    ``default_flow`` is 0.01, so the default guess starts four orders of
+    magnitude above the answer.  Here to separate the two things a starting
+    point can be wrong about: its *magnitude* and its *direction*.
+    """
+    def loop(feed: Stream, tear: Stream) -> Stream:
+        f, t = get_flows(feed), get_flows(tear)
+        return make_stream({"A": f["A"] * 1e-6 + t["A"] * 0.97},
+                           feed["T"], feed["P"])
+
+    fs = Flowsheet(["A"], default_flow=0.01)
+    fs.add_feed("feed", make_stream({"A": 1.0}, 300.0, 101325.0))
+    fs.add_unit(Unit("loop", loop, ["feed", "tear"], ["loop_out"]))
+    fs.add_unit(Unit("out", _passthrough, ["loop_out"], ["product"]))
+    fs.add_recycle("loop_out", "tear")
+    return fs
+
+
+def _trace_check(fs: Flowsheet, streams: dict[str, Stream]) -> float:
+    """``x = 1e-6 F / (1 - 0.97)``, again exactly known."""
+    if "product" not in streams:
+        return float("inf")
+    got = float(streams["product"]["F_A"])
+    want = 1e-6 / (1.0 - 0.97)
+    return (abs(got - want) / want
+            if jnp.isfinite(jnp.asarray(got)) else float("inf"))
+
+
+#: The corpus.  Ordered easiest-to-read, not easiest-to-solve.
+CORPUS: tuple[Case, ...] = (
+    Case(
+        name="overshoot_loop",
+        build=_build_overshoot,
+        difficulty=(
+            "Linear tear map with eigenvalue -2: plain substitution triples "
+            "the error and flips its sign every step, so it diverges from "
+            "any start but the answer. Linear on purpose -- the fixed point "
+            "is exactly 2.0, so a wrong answer is unambiguous."),
+        tags=("recycle", "divergent", "analytic"),
+        check=_overshoot_check,
+        tol=1e-6,
+    ),
+    Case(
+        name="high_gain_recycle",
+        build=_build_high_gain,
+        difficulty=(
+            "CSTR at about 2% per-pass conversion with 99% of the effluent "
+            "recycled: loop gain just under one, so the error decays by "
+            "about 1% per substitution."),
+        tags=("recycle", "reactor", "high-gain"),
+    ),
+    Case(
+        name="flash_recycle",
+        build=_build_flash_recycle,
+        difficulty=(
+            "Flash held well below its bubble point (sum(z K) = 0.65 at "
+            "340 K), so nearly everything leaves as liquid and 99% of that "
+            "is recycled. The purge is the only thing bounding the loop."),
+        tags=("recycle", "flash", "high-gain"),
+    ),
+    Case(
+        name="phase_coupled_flash",
+        build=_build_phase_coupled_flash,
+        difficulty=(
+            "The flash runs at its own inlet temperature, which the cooled "
+            "recycle sets, so the loop chooses its phase regime as it goes. "
+            "Only Wegstein solves it: Anderson walks off somewhere else "
+            "entirely and plain substitution runs out of iterations. The "
+            "case that stops 'anderson' being a free win."),
+        tags=("recycle", "flash", "phase-flip"),
+    ),
+    Case(
+        name="two_phase_flash",
+        build=_build_two_phase_flash,
+        difficulty=(
+            "Not hard: an ordinary flash recycle inside the two-phase "
+            "window with a real vapour purge. The control -- if this one "
+            "fails, the solver is broken, not the case."),
+        tags=("recycle", "flash", "control"),
+    ),
+    Case(
+        name="trace_recycle",
+        build=_build_trace_recycle,
+        difficulty=(
+            "Loop gain 0.97 on a tear whose converged value is about 3e-5, "
+            "against a default guess of 0.01 -- the starting point is "
+            "wrong by three orders of magnitude in scale alone."),
+        tags=("recycle", "trace", "high-gain", "analytic"),
+        check=_trace_check,
+        tol=1e-4,
+    ),
+)
+
+
+def get_case(name: str) -> Case:
+    """Look a case up by name."""
+    for case in CORPUS:
+        if case.name == name:
+            return case
+    raise KeyError(
+        f"unknown case {name!r}; the corpus is "
+        f"{', '.join(c.name for c in CORPUS)}")
+
+
+def cases(names: Iterable[str] | None = None,
+          tags: Iterable[str] | None = None) -> list[Case]:
+    """Select cases by name or tag.
+
+    Args:
+        names: Case names to keep.  ``None`` keeps all.
+        tags: Keep only cases carrying at least one of these tags.
+
+    Returns:
+        The selected cases, in corpus order.
+    """
+    selected = list(CORPUS) if names is None else [get_case(n) for n in names]
+    if tags is not None:
+        wanted = set(tags)
+        selected = [c for c in selected if wanted & set(c.tags)]
+    return selected
+
+
+# =============================================================================
+# Running
+# =============================================================================
+
+def _feed_guess(fs: Flowsheet) -> dict[str, Stream]:
+    """The combined feed, offered to every tear.
+
+    The guess a user writes by hand when the default fails.  It is usually
+    too large by the recycle ratio, which is the point: it probes whether
+    being wrong in *scale* matters as much as being wrong in kind.
+    """
+    flows: dict[str, float] = {s: 0.0 for s in fs.species_order}
+    T = fs.default_T
+    P = fs.default_P
+    for stream in fs.feeds.values():
+        for species, value in get_flows(stream).items():
+            if species in flows:
+                flows[species] = flows[species] + value
+        T, P = stream["T"], stream["P"]
+    combined = make_stream(flows, T, P)
+    return {dest: combined for dest in fs.recycles.values()}
+
+
+def _solve_kwargs(fs: Flowsheet, initialization: str) -> dict:
+    """Translate an initialization strategy into ``solve`` arguments."""
+    if initialization == "default":
+        return {"use_initialization": False}
+    if initialization == "unit":
+        return {"use_initialization": True}
+    if initialization == "feed":
+        return {"use_initialization": False, "tear_initial": _feed_guess(fs)}
+    raise ValueError(
+        f"unknown initialization {initialization!r}; expected one of "
+        f"{', '.join(INITIALIZATIONS)}")
+
+
+@dataclass
+class Outcome:
+    """The result of one solve, at one setting.
+
+    Attributes:
+        case: Case name.
+        acceleration: The ``acceleration`` passed to :meth:`Flowsheet.solve`.
+        initialization: The strategy name from :data:`INITIALIZATIONS`.
+        converged: The solver's own verdict
+            (``Flowsheet.last_solve_converged``).  ``None`` if it raised.
+        correct: Whether the case's ``check`` came back within its ``tol``.
+            Kept apart from ``converged`` on purpose: a solve can report
+            success and land somewhere that does not close its balance, and
+            that is the failure mode worth knowing about.
+        balance_error: What the ``check`` returned.
+        iterations: Tear iterations used.
+        residual: Final tear residual.
+        method: What actually ran --- ``last_solve_method``, which is not
+            always the requested acceleration (a traced solve falls back).
+        wall_time: Seconds, including JAX compilation on first touch, so
+            useful for ranking rather than as an absolute cost.
+        error: ``"TypeName: message"`` if the solve raised, else ``None``.
+        traceback: Full traceback when it raised, for debugging a case.
+    """
+
+    case: str
+    acceleration: str
+    initialization: str
+    converged: bool | None = None
+    correct: bool = False
+    balance_error: float = float("inf")
+    iterations: int | None = None
+    residual: float | None = None
+    method: str | None = None
+    wall_time: float = 0.0
+    error: str | None = None
+    traceback: str | None = None
+
+    @property
+    def passed(self) -> bool:
+        """Converged *and* landed on an answer that audits."""
+        return bool(self.converged) and self.correct
+
+    @property
+    def verdict(self) -> str:
+        """One word for the report table."""
+        if self.error is not None:
+            return "raised"
+        if not self.converged:
+            return "no-conv"
+        return "pass" if self.correct else "WRONG"
+
+
+def run_case(case: Case, acceleration: str = "anderson",
+             initialization: str = "unit", tol: float = 1e-8,
+             max_iter: int = 100, **solve_kwargs) -> Outcome:
+    """Solve one case at one setting and audit the answer.
+
+    Neither a non-convergence warning nor an exception propagates: both are
+    outcomes to be counted, not errors to stop on.  A benchmark that dies on
+    its hardest case reports the pass rate of the cases before it.
+
+    Args:
+        case: The case to run.
+        acceleration: Passed to :meth:`Flowsheet.solve`.
+        initialization: One of :data:`INITIALIZATIONS`.
+        tol: Tear tolerance.
+        max_iter: Iteration cap.
+        **solve_kwargs: Anything else for :meth:`Flowsheet.solve`.
+
+    Returns:
+        An :class:`Outcome`.
+    """
+    fs = case.build()
+    kwargs = dict(_solve_kwargs(fs, initialization))
+    kwargs.update(solve_kwargs)
+    outcome = Outcome(case=case.name, acceleration=acceleration,
+                      initialization=initialization)
+
+    start = time.perf_counter()
+    try:
+        with warnings.catch_warnings():
+            # Non-convergence is counted, not announced: this reads
+            # last_solve_converged directly, so on_nonconvergence="ignore"
+            # is the verdict being taken rather than thrown away.
+            # TearInitializationWarning fires on nearly every case here by
+            # design -- the propagation pass cannot run a unit whose inlet
+            # is still unknown -- and 54 copies of it say nothing.
+            #
+            # Deliberately narrow: a blanket UserWarning filter would also
+            # swallow the modelling warnings (a defaulted CSTR density, a
+            # defaulted Cp) that mean a newly added case is wrong rather
+            # than hard.
+            warnings.simplefilter("ignore", ConvergenceWarning)
+            warnings.simplefilter("ignore", TearInitializationWarning)
+            streams = fs.solve(acceleration=acceleration, tol=tol,
+                               max_iter=max_iter,
+                               on_nonconvergence="ignore", **kwargs)
+    except Exception as exc:  # noqa: BLE001 - a raise is a result here
+        outcome.wall_time = time.perf_counter() - start
+        outcome.error = f"{type(exc).__name__}: {exc}"
+        outcome.traceback = traceback.format_exc()
+        return outcome
+
+    outcome.wall_time = time.perf_counter() - start
+    outcome.converged = fs.last_solve_converged
+    outcome.iterations = fs.last_solve_iterations
+    outcome.residual = fs.last_solve_residual
+    outcome.method = fs.last_solve_method
+
+    try:
+        outcome.balance_error = float(case.check(fs, streams))
+    except Exception as exc:  # noqa: BLE001 - an unauditable answer is wrong
+        outcome.balance_error = float("inf")
+        outcome.error = f"check raised: {type(exc).__name__}: {exc}"
+    outcome.correct = outcome.balance_error <= case.tol
+    return outcome
+
+
+@dataclass
+class Report:
+    """Every outcome of one benchmark run, and the rates over them.
+
+    Attributes:
+        outcomes: One per (case, acceleration, initialization).
+        tol: The tear tolerance every solve was asked for.
+        max_iter: The iteration cap every solve was given.
+    """
+
+    outcomes: list[Outcome] = field(default_factory=list)
+    tol: float = 1e-8
+    max_iter: int = 100
+
+    @property
+    def pass_rate(self) -> float:
+        """Fraction of solves that converged and audited."""
+        if not self.outcomes:
+            return float("nan")
+        return sum(o.passed for o in self.outcomes) / len(self.outcomes)
+
+    @property
+    def convergence_rate(self) -> float:
+        """Fraction the *solver* called converged, audit aside.
+
+        The gap between this and :attr:`pass_rate` is the answer to "how
+        often does a solve claim success and mean it?"
+        """
+        if not self.outcomes:
+            return float("nan")
+        return sum(bool(o.converged) for o in self.outcomes) / len(self.outcomes)
+
+    def by(self, field_name: Literal["case", "acceleration", "initialization"]
+           ) -> dict[str, tuple[int, int]]:
+        """Pass counts grouped by one field: ``{value: (passed, total)}``."""
+        groups: dict[str, tuple[int, int]] = {}
+        for outcome in self.outcomes:
+            key = getattr(outcome, field_name)
+            passed, total = groups.get(key, (0, 0))
+            groups[key] = (passed + outcome.passed, total + 1)
+        return groups
+
+    def mean_iterations(self, only_passed: bool = True) -> dict[str, float]:
+        """Mean tear iterations per acceleration.
+
+        Averaged over passing solves by default: a failed solve used
+        ``max_iter`` by definition, and mixing those in measures the cap
+        rather than the method.
+        """
+        sums: dict[str, list[int]] = {}
+        for outcome in self.outcomes:
+            if only_passed and not outcome.passed:
+                continue
+            if outcome.iterations is None:
+                continue
+            sums.setdefault(outcome.acceleration, []).append(outcome.iterations)
+        return {k: sum(v) / len(v) for k, v in sums.items() if v}
+
+    def failures(self) -> list[Outcome]:
+        """Every outcome that did not pass."""
+        return [o for o in self.outcomes if not o.passed]
+
+    def as_text(self, width: int = 78) -> str:
+        """The report as a table, for a terminal or a notebook."""
+        lines: list[str] = []
+        lines.append("difflow convergence benchmark")
+        lines.append("=" * width)
+        lines.append(
+            f"{len(self.outcomes)} solves  "
+            f"(tol={self.tol:.0e}, max_iter={self.max_iter})")
+        lines.append(
+            f"pass rate        {self.pass_rate:6.1%}   "
+            "(converged AND the answer audits)")
+        lines.append(
+            f"convergence rate {self.convergence_rate:6.1%}   "
+            "(the solver's own verdict)")
+        lines.append("")
+
+        lines.append("by acceleration")
+        lines.append("-" * width)
+        for key, (passed, total) in sorted(self.by("acceleration").items()):
+            lines.append(f"  {key:<12s} {passed:>3d}/{total:<3d}  {passed / total:6.1%}")
+        means = self.mean_iterations()
+        if means:
+            lines.append("  mean iterations over passing solves: " + ", ".join(
+                f"{k}={v:.1f}" for k, v in sorted(means.items())))
+        lines.append("")
+
+        lines.append("by initialization")
+        lines.append("-" * width)
+        for key, (passed, total) in sorted(self.by("initialization").items()):
+            lines.append(f"  {key:<12s} {passed:>3d}/{total:<3d}  {passed / total:6.1%}")
+        lines.append("")
+
+        lines.append("by case")
+        lines.append("-" * width)
+        for key, (passed, total) in self.by("case").items():
+            lines.append(f"  {key:<22s} {passed:>3d}/{total:<3d}  {passed / total:6.1%}")
+        lines.append("")
+
+        lines.append("detail")
+        lines.append("-" * width)
+        header = (f"  {'case':<22s} {'accel':<9s} {'init':<8s} "
+                  f"{'verdict':<8s} {'iters':>5s}  {'balance':>9s}")
+        lines.append(header)
+        for outcome in self.outcomes:
+            iters = "-" if outcome.iterations is None else str(outcome.iterations)
+            err = outcome.balance_error
+            bal = "-" if err != err else (  # NaN-safe
+                "inf" if err == float("inf") else f"{err:.2e}")
+            lines.append(
+                f"  {outcome.case:<22s} {outcome.acceleration:<9s} "
+                f"{outcome.initialization:<8s} {outcome.verdict:<8s} "
+                f"{iters:>5s}  {bal:>9s}")
+
+        raised = [o for o in self.outcomes if o.error]
+        if raised:
+            lines.append("")
+            lines.append("raised")
+            lines.append("-" * width)
+            for outcome in raised:
+                lines.append(
+                    f"  {outcome.case} / {outcome.acceleration} / "
+                    f"{outcome.initialization}: {outcome.error}")
+        return "\n".join(lines)
+
+    def to_csv(self, path: str) -> None:
+        """Write every outcome to CSV, one row per solve."""
+        import csv
+
+        fields = ["case", "acceleration", "initialization", "converged",
+                  "correct", "passed", "balance_error", "iterations",
+                  "residual", "method", "wall_time", "error"]
+        with open(path, "w", newline="") as handle:
+            writer = csv.DictWriter(handle, fieldnames=fields)
+            writer.writeheader()
+            for outcome in self.outcomes:
+                row = {f: getattr(outcome, f, None) for f in fields}
+                row["passed"] = outcome.passed
+                writer.writerow(row)
+
+    def __repr__(self) -> str:
+        return (f"Report({len(self.outcomes)} solves, "
+                f"pass_rate={self.pass_rate:.1%})")
+
+
+def run_benchmark(cases: Sequence[str] | Sequence[Case] | None = None,
+                  accelerations: Sequence[str] = ACCELERATIONS,
+                  initializations: Sequence[str] = INITIALIZATIONS,
+                  tol: float = 1e-8, max_iter: int = 100,
+                  progress: bool = False, **solve_kwargs) -> Report:
+    """Run the corpus across every setting and report the pass rate.
+
+    Args:
+        cases: Case names or :class:`Case` objects.  ``None`` runs
+            :data:`CORPUS`.
+        accelerations: Which ``acceleration`` settings to try.
+        initializations: Which strategies from :data:`INITIALIZATIONS`.
+        tol: Tear tolerance for every solve.
+        max_iter: Iteration cap for every solve.
+        progress: Print each outcome as it lands.  The full grid takes
+            minutes, most of it JAX compilation, and a silent run is hard
+            to tell from a hung one.
+        **solve_kwargs: Anything else for :meth:`Flowsheet.solve`.
+
+    Returns:
+        A :class:`Report`.
+
+    Example:
+        >>> report = run_benchmark(cases=["two_phase_flash"],  # doctest: +SKIP
+        ...                        accelerations=("anderson",),
+        ...                        initializations=("unit",))
+        >>> report.pass_rate                                  # doctest: +SKIP
+        1.0
+    """
+    if cases is None:
+        selected = list(CORPUS)
+    else:
+        selected = [c if isinstance(c, Case) else get_case(c) for c in cases]
+
+    report = Report(tol=tol, max_iter=max_iter)
+    for case in selected:
+        for acceleration in accelerations:
+            for initialization in initializations:
+                outcome = run_case(case, acceleration=acceleration,
+                                   initialization=initialization, tol=tol,
+                                   max_iter=max_iter, **solve_kwargs)
+                report.outcomes.append(outcome)
+                if progress:
+                    print(f"{outcome.case:<22s} {acceleration:<9s} "
+                          f"{initialization:<8s} {outcome.verdict}", flush=True)
+    return report
+
+
+def main() -> None:
+    """``python -m difflow.convergence``: run the corpus and print the report."""
+    report = run_benchmark(progress=True)
+    print()
+    print(report.as_text())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/difflow/gui/static/docs-index.json
+++ b/src/difflow/gui/static/docs-index.json
@@ -1,5 +1,5 @@
 {
- "n_sections": 868,
+ "n_sections": 873,
  "sections": [
   {
    "anchor": "convergence-and-initialization",
@@ -15,7 +15,7 @@
    "path": "Convergence and Initialization > Table of Contents",
    "source": "convergence.md",
    "targets": [],
-   "text": "- [When a solve does not converge](#when-a-solve-does-not-converge)\n- [Where the initial guess comes from](#where-the-initial-guess-comes-from)\n- [Unit-level `initialize()`](#unit-level-initialize)\n- [The three acceleration methods](#the-three-acceleration-methods)\n- [The traced fallback](#the-traced-fallback)\n- [The equation-oriented route](#the-equation-oriented-route)\n- [Diagnostics](#diagnostics)\n- [A worked diagnosis](#a-worked-diagnosis)\n- [Tear selection](#tear-selection)\n- [What the plugins add](#what-the-plugins-add)\n\n---"
+   "text": "- [When a solve does not converge](#when-a-solve-does-not-converge)\n- [Where the initial guess comes from](#where-the-initial-guess-comes-from)\n- [Unit-level `initialize()`](#unit-level-initialize)\n- [The three acceleration methods](#the-three-acceleration-methods)\n- [The traced fallback](#the-traced-fallback)\n- [The equation-oriented route](#the-equation-oriented-route)\n- [Diagnostics](#diagnostics)\n- [A worked diagnosis](#a-worked-diagnosis)\n- [Measured pass rates](#measured-pass-rates)\n- [Tear selection](#tear-selection)\n- [What the plugins add](#what-the-plugins-add)\n\n---"
   },
   {
    "anchor": "when-a-solve-does-not-converge",
@@ -144,6 +144,46 @@
    "source": "convergence.md",
    "targets": [],
    "text": "A one-unit loop whose tear map is $F \\mapsto F_{\\text{feed}} + k\\sqrt{F + 0.1}$,\ndeliberately given too few iterations:\n\n```python\nimport warnings\n\nimport jax\nimport jax.numpy as jnp\n\nfrom difflow import ConvergenceWarning\nfrom difflow.flowsheet import Flowsheet, Unit\nfrom difflow.streams import make_stream\n\njax.config.update(\"jax_enable_x64\", True)\n\n\nclass Loop:\n    def __init__(self, k):\n        self.k = k\n\n    def __call__(self, feed, tear):\n        return make_stream(\n            {\"A\": feed[\"F_A\"] + self.k * jnp.sqrt(tear[\"F_A\"] + 0.1)},\n            feed[\"T\"],\n            feed[\"P\"],\n        )\n\n\ndef build():\n    fs = Flowsheet(species_order=[\"A\"], default_flow=0.0)\n    fs.add_feed(\"feed\", make_stream({\"A\": 1.0}, 300.0, 1e5))\n    fs.add_unit(Unit(\"loop\", Loop(0.9), [\"feed\", \"tear\"], [\"loop_out\"]))\n    fs.add_recycle(\"loop_out\", \"tear\")\n    return fs\n\n\nfs = build()\nwith warnings.catch_warnings():\n    warnings.simplefilter(\"ignore\", ConvergenceWarning)\n    streams = fs.solve(max_iter=3)\n\nassert fs.last_solve_converged is False\nassert fs.last_solve_method == \"anderson\"\nassert fs.last_solve_residual > fs.last_solve_tol   # 1.9e-2 against 1e-8\n```\n\nThe residual is six orders above tolerance, so this is not a loop that needs a\nfew more iterations. A starting point taken from anywhere near the answer buys\nfour orders of magnitude at the *same* three iterations:\n\n```python\nimport warnings\n\nimport jax\nimport jax.numpy as jnp\n\nfrom difflow import ConvergenceWarning\nfrom difflow.flowsheet import Flowsheet, Unit\nfrom difflow.streams import make_stream\n\njax.config.update(\"jax_enable_x64\", True)\n\n\nclass Loop:\n    def __init__(self, k):\n        self.k = k\n\n    def __call__(self, feed, tear):\n        return make_stream(\n            {\"A\": feed[\"F_A\"] + self.k * jnp.sqrt(tear[\"F_A\"] + 0.1)},\n            feed[\"T\"],\n            feed[\"P\"],\n        )\n\n\nfs = Flowsheet(species_order=[\"A\"], default_flow=0.0)\nfs.add_feed(\"feed\", make_stream({\"A\": 1.0}, 300.0, 1e5))\nfs.add_unit(Unit(\"loop\", Loop(0.9), [\"feed\", \"tear\"], [\"loop_out\"]))\nfs.add_recycle(\"loop_out\", \"tear\")\n\nguess = {\"tear\": make_stream({\"A\": 2.4}, 300.0, 1e5)}\nwith warnings.catch_warnings():\n    warnings.simplefilter(\"ignore\", ConvergenceWarning)\n    fs.solve(tear_initial=guess, max_iter=3)\n\nassert fs.last_solve_residual < 1e-4     # 8.3e-6, from 1.9e-2\n```"
+  },
+  {
+   "anchor": "measured-pass-rates",
+   "heading": "Measured pass rates",
+   "path": "Convergence and Initialization > Measured pass rates",
+   "source": "convergence.md",
+   "targets": [],
+   "text": "How often any of this actually works is a measurement, and\n`difflow.convergence` is where it is made. It holds a corpus of deliberately\nhard flowsheets and runs each one across every acceleration and every\ninitialization strategy:\n\n```python\nfrom difflow.convergence import run_benchmark\n\nreport = run_benchmark()\nprint(report.as_text())\n```\n\nThe full grid is 54 solves and takes a few minutes, most of it JAX\ncompilation. Narrow it while iterating:\n\n```python\nreport = run_benchmark(cases=[\"high_gain_recycle\"], accelerations=(\"anderson\",))\n```"
+  },
+  {
+   "anchor": "passing-means-converged-and-right",
+   "heading": "Passing means converged *and* right",
+   "path": "Convergence and Initialization > Measured pass rates > Passing means converged *and* right",
+   "source": "convergence.md",
+   "targets": [],
+   "text": "A solve reports two separate things, and the benchmark keeps them apart:\n\n| | meaning |\n|---|---|\n| `Outcome.converged` | the solver's own verdict, `last_solve_converged` |\n| `Outcome.correct` | the answer closes its material balance, or matches a known one |\n| `Outcome.passed` | both |\n\nThey are not the same. `pass_rate` is 46.3% against a `convergence_rate` of\n51.9%: three of the 54 solves report success and land somewhere that does not\naudit. A benchmark that counted only the solver's flag would call those wins."
+  },
+  {
+   "anchor": "what-the-corpus-says-today",
+   "heading": "What the corpus says today",
+   "path": "Convergence and Initialization > Measured pass rates > What the corpus says today",
+   "source": "convergence.md",
+   "targets": [],
+   "text": "```\n54 solves  (tol=1e-08, max_iter=100)\npass rate         46.3%   (converged AND the answer audits)\nconvergence rate  51.9%   (the solver's own verdict)\n\nby acceleration                    by initialization\n  anderson      16/18   88.9%        default        8/18   44.4%\n  wegstein       6/18   33.3%        unit           8/18   44.4%\n  none           3/18   16.7%        feed           9/18   50.0%\n\nmean iterations over passing solves: anderson=4.9, wegstein=22.8, none=35.0\n```\n\nThree findings worth acting on:\n\n**Acceleration dominates; initialization barely registers.** Anderson passes\n88.9% where plain substitution passes 16.7%. Against that, the three starting\npoints are separated by a single solve. The obvious lever on a failing recycle\nis `acceleration`, not the guess.\n\n**The `initialize()` path (#247) changed no outcome.** `\"unit\"` \u2014 the\npropagation pass that #247 wired up \u2014 scores exactly what `\"default\"` scores,\nthe 0.01 mol/s stream it replaced: 8/18 either way. It reliably saves an\niteration or two (`flash_recycle` goes 3 \u2192 2 under Anderson) and it flips no\nverdict anywhere in the corpus. It made the first step better without making a\nfailing solve succeed. If a recycle is failing, a better guess of the same\nkind is not the fix.\n\n**Anderson is not free.** `phase_coupled_flash` is in the corpus because\nAnderson fails it where Wegstein converges in 28 iterations \u2014 and fails it by\nwalking somewhere else entirely, not by running out of iterations. On a loop\nthat changes phase regime as it iterates, try Wegstein before concluding the\nflowsheet is wrong."
+  },
+  {
+   "anchor": "the-trap-the-corpus-exposes",
+   "heading": "The trap the corpus exposes",
+   "path": "Convergence and Initialization > Measured pass rates > The trap the corpus exposes",
+   "source": "convergence.md",
+   "targets": [],
+   "text": "`tol` is an **absolute** residual on the tear, and on a high-gain loop that is\nmuch weaker than it looks. A step of $d$ on a loop of gain $g$ leaves an error\nof about $d/(1-g)$, so at $g = 0.97$ the residual understates the remaining\nerror by a factor of 33.\n\n`trace_recycle` is built on exactly that: gain 0.97 on a tear whose converged\nvalue is about $3 \\times 10^{-5}$. Wegstein stops with a residual inside\n`1e-8`, reports convergence, and is about 1% out. It is right on its own terms\n\u2014 the step really is that small \u2014 and wrong on yours.\n\nOn a loop where you know the gain is near one, tighten `tol` by roughly\n$1/(1-g)$, or audit the answer rather than the residual."
+  },
+  {
+   "anchor": "adding-a-case",
+   "heading": "Adding a case",
+   "path": "Convergence and Initialization > Measured pass rates > Adding a case",
+   "source": "convergence.md",
+   "targets": [],
+   "text": "A case is a name, a builder, and a sentence saying what makes it hard:\n\n```python\nfrom difflow.convergence import Case, run_case\n\ncase = Case(\n    name=\"my_hard_loop\",\n    build=build_my_flowsheet,          # must return a FRESH Flowsheet\n    difficulty=\"Why this one is hard, in a sentence.\",\n    tags=(\"recycle\", \"high-gain\"),\n)\nrun_case(case, acceleration=\"wegstein\")\n```\n\n`build` has to return a new flowsheet each call \u2014 `solve` records its verdict\non the object, so a shared one carries one run's result into the next. The\ndefault audit is the overall mole balance; a case whose reaction changes the\nmole count, or whose answer is known analytically, passes its own `check`.\n\nKeep at least one case in the corpus that is *meant* to pass. A benchmark\nwhere everything fails cannot distinguish a hard corpus from a broken solver;\n`two_phase_flash` is that control, and it passes 9/9.\n\n---"
   },
   {
    "anchor": "tear-selection",

--- a/src/difflow/gui/static/docs-index.json
+++ b/src/difflow/gui/static/docs-index.json
@@ -1,5 +1,5 @@
 {
- "n_sections": 873,
+ "n_sections": 874,
  "sections": [
   {
    "anchor": "convergence-and-initialization",
@@ -151,7 +151,7 @@
    "path": "Convergence and Initialization > Measured pass rates",
    "source": "convergence.md",
    "targets": [],
-   "text": "How often any of this actually works is a measurement, and\n`difflow.convergence` is where it is made. It holds a corpus of deliberately\nhard flowsheets and runs each one across every acceleration and every\ninitialization strategy:\n\n```python\nfrom difflow.convergence import run_benchmark\n\nreport = run_benchmark()\nprint(report.as_text())\n```\n\nThe full grid is 54 solves and takes a few minutes, most of it JAX\ncompilation. Narrow it while iterating:\n\n```python\nreport = run_benchmark(cases=[\"high_gain_recycle\"], accelerations=(\"anderson\",))\n```"
+   "text": "How often any of this actually works is a measurement, and\n`difflow.convergence` is where it is made. It holds a corpus of deliberately\nhard flowsheets and runs each one across every acceleration and every\ninitialization strategy:\n\n```python\nfrom difflow.convergence import run_benchmark\n\nreport = run_benchmark()\nprint(report.as_text())\n```\n\nThe full grid is 99 solves and takes several minutes, most of it JAX\ncompilation. Narrow it while iterating:\n\n```python\nreport = run_benchmark(cases=[\"high_gain_recycle\"], accelerations=(\"anderson\",))\n```"
   },
   {
    "anchor": "passing-means-converged-and-right",
@@ -159,7 +159,7 @@
    "path": "Convergence and Initialization > Measured pass rates > Passing means converged *and* right",
    "source": "convergence.md",
    "targets": [],
-   "text": "A solve reports two separate things, and the benchmark keeps them apart:\n\n| | meaning |\n|---|---|\n| `Outcome.converged` | the solver's own verdict, `last_solve_converged` |\n| `Outcome.correct` | the answer closes its material balance, or matches a known one |\n| `Outcome.passed` | both |\n\nThey are not the same. `pass_rate` is 46.3% against a `convergence_rate` of\n51.9%: three of the 54 solves report success and land somewhere that does not\naudit. A benchmark that counted only the solver's flag would call those wins."
+   "text": "A solve reports two separate things, and the benchmark keeps them apart:\n\n| | meaning |\n|---|---|\n| `Outcome.converged` | the solver's own verdict, `last_solve_converged` |\n| `Outcome.correct` | the answer closes its material balance, or matches a known one |\n| `Outcome.passed` | both |\n\nThey are not the same. `pass_rate` is 46.5% against a `convergence_rate` of\n49.5%: three of the 99 solves report success and land somewhere that does not\naudit. A benchmark that counted only the solver's flag would call those wins."
   },
   {
    "anchor": "what-the-corpus-says-today",
@@ -167,7 +167,15 @@
    "path": "Convergence and Initialization > Measured pass rates > What the corpus says today",
    "source": "convergence.md",
    "targets": [],
-   "text": "```\n54 solves  (tol=1e-08, max_iter=100)\npass rate         46.3%   (converged AND the answer audits)\nconvergence rate  51.9%   (the solver's own verdict)\n\nby acceleration                    by initialization\n  anderson      16/18   88.9%        default        8/18   44.4%\n  wegstein       6/18   33.3%        unit           8/18   44.4%\n  none           3/18   16.7%        feed           9/18   50.0%\n\nmean iterations over passing solves: anderson=4.9, wegstein=22.8, none=35.0\n```\n\nThree findings worth acting on:\n\n**Acceleration dominates; initialization barely registers.** Anderson passes\n88.9% where plain substitution passes 16.7%. Against that, the three starting\npoints are separated by a single solve. The obvious lever on a failing recycle\nis `acceleration`, not the guess.\n\n**The `initialize()` path (#247) changed no outcome.** `\"unit\"` \u2014 the\npropagation pass that #247 wired up \u2014 scores exactly what `\"default\"` scores,\nthe 0.01 mol/s stream it replaced: 8/18 either way. It reliably saves an\niteration or two (`flash_recycle` goes 3 \u2192 2 under Anderson) and it flips no\nverdict anywhere in the corpus. It made the first step better without making a\nfailing solve succeed. If a recycle is failing, a better guess of the same\nkind is not the fix.\n\n**Anderson is not free.** `phase_coupled_flash` is in the corpus because\nAnderson fails it where Wegstein converges in 28 iterations \u2014 and fails it by\nwalking somewhere else entirely, not by running out of iterations. On a loop\nthat changes phase regime as it iterates, try Wegstein before concluding the\nflowsheet is wrong."
+   "text": "```\n99 solves  (tol=1e-08, max_iter=100)\npass rate         46.5%   (converged AND the answer audits)\nconvergence rate  49.5%   (the solver's own verdict)\n\nby acceleration                    by initialization\n  anderson      28/33   84.8%        default       15/33   45.5%\n  wegstein       9/33   27.3%        unit          15/33   45.5%\n  none           9/33   27.3%        feed          16/33   48.5%\n\nmean iterations over passing solves: anderson=4.3, wegstein=18.9, none=41.0\n```\n\n**Every case in the corpus is solved by at least one acceleration.** Eleven\ncases across the hard families \u2014 high loop gain, sharp splits, multi-loop,\nphase-regime switching, near-pinch columns, trace-magnitude tears, signed\ntears \u2014 and none of them defeats all three methods. That is the most useful\nthing the benchmark says, and it is a negative result.\n\nFour findings worth acting on:\n\n**Acceleration dominates; initialization barely registers.** Anderson passes\n84.8% where plain substitution passes 27.3%. Against that, the three starting\npoints are separated by a single solve. The first thing to change on a failing\nrecycle is `acceleration`, not the guess.\n\n**The `initialize()` path (#247) changed no outcome.** `\"unit\"` \u2014 the\npropagation pass that #247 wired up \u2014 scores exactly what `\"default\"` scores,\nthe 0.01 mol/s stream it replaced: 15/33 either way, unchanged from when the\ncorpus was six cases. It reliably saves an iteration or two and it flips no\nverdict anywhere. It made the first step better without making a failing solve\nsucceed. If a recycle is failing, a better guess of the same kind is not the\nfix."
+  },
+  {
+   "anchor": "what-is-not-hard",
+   "heading": "What is *not* hard",
+   "path": "Convergence and Initialization > Measured pass rates > What is *not* hard",
+   "source": "convergence.md",
+   "targets": [],
+   "text": "Worth recording, because these are the families most often assumed difficult:\n\n- **A rigorous MESH column in a recycle.** `column_recycle` \u2014 twelve stages,\n  95% of the distillate returned \u2014 passes under every setting, at every reflux\n  ratio tried from just above minimum to well above it.\n- **Nonsmooth tear maps as such.** Both `regime_switch` and the kinked maps\n  tried while building the corpus fall to Anderson quickly.\n- **Tear dimension.** A tear with twelve components and a spectral radius of\n  0.985 converges under Anderson as readily as one with three, provided the\n  coupling is non-negative. Where high-dimensional cases did fail, the cause\n  was the negative-flow clipping above, not the dimension."
   },
   {
    "anchor": "the-trap-the-corpus-exposes",
@@ -175,7 +183,7 @@
    "path": "Convergence and Initialization > Measured pass rates > The trap the corpus exposes",
    "source": "convergence.md",
    "targets": [],
-   "text": "`tol` is an **absolute** residual on the tear, and on a high-gain loop that is\nmuch weaker than it looks. A step of $d$ on a loop of gain $g$ leaves an error\nof about $d/(1-g)$, so at $g = 0.97$ the residual understates the remaining\nerror by a factor of 33.\n\n`trace_recycle` is built on exactly that: gain 0.97 on a tear whose converged\nvalue is about $3 \\times 10^{-5}$. Wegstein stops with a residual inside\n`1e-8`, reports convergence, and is about 1% out. It is right on its own terms\n\u2014 the step really is that small \u2014 and wrong on yours.\n\nOn a loop where you know the gain is near one, tighten `tol` by roughly\n$1/(1-g)$, or audit the answer rather than the residual."
+   "text": "`tol` is an **absolute** residual on the tear, and on a high-gain loop that is\nmuch weaker than it looks. A step of $d$ on a loop of gain $g$ leaves an error\nof about $d/(1-g)$, so at $g = 0.97$ the residual understates the remaining\nerror by a factor of 33.\n\n`trace_recycle` is built on exactly that: gain 0.97 on a tear whose converged\nvalue is about $3 \\times 10^{-5}$. Wegstein stops with a residual inside\n`1e-8`, reports convergence, and is about 1% out. It is right on its own terms\n\u2014 the step really is that small \u2014 and wrong on yours.\n\nOn a loop where you know the gain is near one, tighten `tol` by roughly\n$1/(1-g)$, or audit the answer rather than the residual.\n\nFor a multicomponent tear the factor is $\\lVert (I-M)^{-1} \\rVert$ rather than\n$1/(1-\\rho)$, and for a non-normal $M$ those are not close: `signed_tear` has\n$\\rho = 0.75$, which suggests a factor of 4, and actually leaves a relative\nerror of $1.2 \\times 10^{-6}$ from a residual of $10^{-8}$ \u2014 a factor of about\n450."
   },
   {
    "anchor": "adding-a-case",
@@ -183,7 +191,7 @@
    "path": "Convergence and Initialization > Measured pass rates > Adding a case",
    "source": "convergence.md",
    "targets": [],
-   "text": "A case is a name, a builder, and a sentence saying what makes it hard:\n\n```python\nfrom difflow.convergence import Case, run_case\n\ncase = Case(\n    name=\"my_hard_loop\",\n    build=build_my_flowsheet,          # must return a FRESH Flowsheet\n    difficulty=\"Why this one is hard, in a sentence.\",\n    tags=(\"recycle\", \"high-gain\"),\n)\nrun_case(case, acceleration=\"wegstein\")\n```\n\n`build` has to return a new flowsheet each call \u2014 `solve` records its verdict\non the object, so a shared one carries one run's result into the next. The\ndefault audit is the overall mole balance; a case whose reaction changes the\nmole count, or whose answer is known analytically, passes its own `check`.\n\nKeep at least one case in the corpus that is *meant* to pass. A benchmark\nwhere everything fails cannot distinguish a hard corpus from a broken solver;\n`two_phase_flash` is that control, and it passes 9/9.\n\n---"
+   "text": "A case is a name, a builder, and a sentence saying what makes it hard:\n\n```python\nfrom difflow.convergence import Case, run_case\n\ncase = Case(\n    name=\"my_hard_loop\",\n    build=build_my_flowsheet,          # must return a FRESH Flowsheet\n    difficulty=\"Why this one is hard, in a sentence.\",\n    tags=(\"recycle\", \"high-gain\"),\n)\nrun_case(case, acceleration=\"wegstein\")\n```\n\n`build` has to return a new flowsheet each call \u2014 `solve` records its verdict\non the object, so a shared one carries one run's result into the next. The\ndefault audit is the overall mole balance; a case whose reaction changes the\nmole count, or whose answer is known analytically, passes its own `check`.\n\nKeep at least one case in the corpus that is *meant* to pass. A benchmark\nwhere everything fails cannot distinguish a hard corpus from a broken solver.\n`two_phase_flash` and `column_recycle` are the controls, and both pass 9/9.\n\nAnd check a new case is not *rigged* \u2014 that no initialization strategy starts\non the answer it is about to be scored against. `overshoot_loop` originally\nused $g(x) = 3F - 2x$, whose fixed point is $x = F$, exactly the `\"feed\"`\nguess; that strategy collected two passes on a case it had not solved.\n`TestNoCaseIsRigged` checks every case in the corpus against this.\n\n---"
   },
   {
    "anchor": "tear-selection",

--- a/tests/test_benchmarks_verdict.py
+++ b/tests/test_benchmarks_verdict.py
@@ -1,0 +1,92 @@
+"""``compare_solvers`` used to report the SM solve as always converged.
+
+The function predates #249, which gave ``Flowsheet`` its own verdict
+(``last_solve_converged``, ``last_solve_iterations``, ``last_solve_residual``).
+Before that there was nothing to read, so it hard-coded the dataclass default
+``sm_converged=True`` and reported ``sm_iterations=max_iter`` with a comment
+saying SM does not report iteration counts.
+
+Both are now wrong rather than merely approximate: a diverged SM solve looked
+like a converged one that happened to disagree with EO, which is exactly the
+comparison the function exists to make.
+"""
+
+import warnings
+
+import pytest
+
+from difflow.benchmarks import compare_solvers
+from difflow.flowsheet import ConvergenceWarning, Flowsheet, Unit
+from difflow.streams import get_flows, make_stream
+
+
+class Divergent:
+    """``g(x) = 6F - 2x``: eigenvalue -2, so substitution never settles."""
+
+    def __call__(self, feed, tear):
+        return make_stream({"A": 6.0 * feed["F_A"] - 2.0 * tear["F_A"]},
+                           feed["T"], feed["P"])
+
+
+class Contractive:
+    """``g(x) = 0.5 (F + x)``: converges from anywhere."""
+
+    def __call__(self, feed, tear):
+        return make_stream({"A": 0.5 * (feed["F_A"] + tear["F_A"])},
+                           feed["T"], feed["P"])
+
+
+def _loop(operation) -> Flowsheet:
+    fs = Flowsheet(["A"], default_flow=0.01)
+    fs.add_feed("feed", make_stream({"A": 1.0}, 300.0, 101325.0))
+    fs.add_unit(Unit("loop", operation, ["feed", "tear"], ["loop_out"]))
+    fs.add_unit(Unit(
+        "out", lambda s: make_stream(get_flows(s), s["T"], s["P"]),
+        ["loop_out"], ["product"]))
+    fs.add_recycle("loop_out", "tear")
+    return fs
+
+
+def _compare(fs, **kwargs):
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return compare_solvers(fs, **kwargs)
+
+
+class TestSMVerdictIsReported:
+
+    def test_a_diverged_sm_solve_is_not_reported_as_converged(self):
+        """The regression: this used to come back True regardless."""
+        result = _compare(_loop(Divergent()), max_iter=20,
+                          sm_acceleration="none")
+        assert result.sm_converged is False
+
+    def test_a_converged_sm_solve_is_reported_as_converged(self):
+        result = _compare(_loop(Contractive()), max_iter=200,
+                          sm_acceleration="none")
+        assert result.sm_converged is True
+
+    def test_sm_iterations_is_the_real_count_not_the_cap(self):
+        """It was hard-coded to max_iter, so it always equalled the cap."""
+        result = _compare(_loop(Contractive()), max_iter=200,
+                          sm_acceleration="none")
+        assert result.sm_iterations is not None
+        assert 0 < result.sm_iterations < 200
+
+    def test_the_residual_comes_back_too(self):
+        result = _compare(_loop(Contractive()), tol=1e-8, max_iter=200,
+                          sm_acceleration="none")
+        assert result.sm_residual is not None
+        assert result.sm_residual <= 1e-8
+
+    def test_a_diverged_solve_still_warns(self):
+        """#249 made a failed solve say so; comparing is no reason to mute it.
+
+        The verdict is returned *as well*, so a caller can test
+        ``sm_converged`` rather than catch the warning --- but the warning
+        is not the thing that got traded away for it.
+        """
+        with pytest.warns(ConvergenceWarning):
+            result = compare_solvers(_loop(Divergent()), max_iter=20,
+                                     sm_acceleration="none")
+        assert result.sm_converged is False

--- a/tests/test_convergence_benchmark.py
+++ b/tests/test_convergence_benchmark.py
@@ -407,6 +407,53 @@ class TestTheFindings:
         assert wegstein.passed
         assert not anderson.passed
 
+    def test_anderson_solves_a_disjunction_without_binaries(self):
+        """The negative result #251 most needs.
+
+        ``regime_switch`` is a unit picking between two linear branches with
+        the answer exactly on the boundary -- the disjunction that issue
+        proposes handing to a MILP's binaries. Anderson lands on it in two
+        iterations.
+        """
+        assert run_case(get_case("regime_switch"),
+                        acceleration="anderson").passed
+
+    def test_a_signed_tear_beats_both_accelerated_methods(self):
+        """The one case that inverts the corpus ranking.
+
+        ``clip_negative_flows`` defaults to True and is applied by the
+        Wegstein and Anderson paths but not by the unaccelerated one. On a
+        tear whose answer is genuinely negative, that projection is the
+        difference between solving it and not.
+        """
+        plain = run_case(get_case("signed_tear"), acceleration="none")
+        wegstein = run_case(get_case("signed_tear"), acceleration="wegstein")
+        anderson = run_case(get_case("signed_tear"), acceleration="anderson")
+        assert plain.passed, "plain substitution should solve this one"
+        assert not wegstein.passed
+        assert not anderson.passed
+
+    def test_turning_the_clip_off_rescues_the_signed_tear(self):
+        """Pins the remedy the case's `difficulty` claims."""
+        clipped = run_case(get_case("signed_tear"), acceleration="anderson")
+        unclipped = run_case(get_case("signed_tear"), acceleration="anderson",
+                             clip_negative_flows=False)
+        assert not clipped.passed
+        assert unclipped.passed
+        assert unclipped.iterations < 30
+
+    def test_a_rigorous_column_in_a_recycle_is_not_the_hard_part(self):
+        """#251 names near-pinch columns; every setting solves this one."""
+        for acceleration in ACCELERATIONS:
+            outcome = run_case(get_case("column_recycle"),
+                               acceleration=acceleration)
+            assert outcome.passed, outcome
+
+    def test_the_multi_loop_case_really_has_two_tears(self):
+        """Otherwise it is not testing what it says it tests."""
+        fs = get_case("two_loop_recycle").build()
+        assert len(fs.recycles) == 2
+
     @pytest.mark.slow
     def test_an_absolute_tear_tolerance_can_accept_a_wrong_answer(self):
         """The trap ``trace_recycle`` exists to expose.

--- a/tests/test_convergence_benchmark.py
+++ b/tests/test_convergence_benchmark.py
@@ -1,0 +1,463 @@
+"""Tests for :mod:`difflow.convergence`, the pass-rate benchmark.
+
+The benchmark's own correctness is what these pin, not the pass rate it
+reports: that number is a measurement and is meant to move.  What must not
+move is the machinery that produces it --- that a raised solve is counted
+rather than propagated, that "the solver said it converged" and "the answer
+audits" stay separate, and that no case is rigged so a strategy starts on
+the answer.
+
+The full grid is minutes of JAX compilation, so it is marked ``slow`` and
+everything else here runs against the two cheap analytic cases or against
+synthetic ones built in the test.
+"""
+
+import warnings
+
+import jax.numpy as jnp
+import pytest
+
+from difflow.convergence import (
+    ACCELERATIONS,
+    CORPUS,
+    INITIALIZATIONS,
+    Case,
+    Outcome,
+    Report,
+    _feed_guess,
+    _product_streams,
+    cases,
+    get_case,
+    run_benchmark,
+    run_case,
+    total_mole_balance,
+)
+from difflow.flowsheet import ConvergenceWarning, Flowsheet, Unit
+from difflow.streams import get_flows, make_stream
+
+
+# =============================================================================
+# The corpus itself
+# =============================================================================
+
+class TestCorpus:
+
+    def test_names_are_unique(self):
+        names = [c.name for c in CORPUS]
+        assert len(names) == len(set(names))
+
+    def test_every_case_says_why_it_is_hard(self):
+        """An unexplained hard case measures something nobody can act on."""
+        for case in CORPUS:
+            assert case.difficulty.strip(), f"{case.name} has no difficulty note"
+            assert len(case.difficulty) > 40, (
+                f"{case.name}: 'difficulty' should be a sentence, not a label")
+
+    def test_build_returns_a_fresh_flowsheet_each_time(self):
+        """Solve records its verdict on the object; a shared one leaks it."""
+        for case in CORPUS:
+            first, second = case.build(), case.build()
+            assert first is not second
+            assert first.last_solve_converged is None
+            assert second.last_solve_converged is None
+
+    def test_every_case_has_a_recycle(self):
+        """A flowsheet with no recycle does not exercise the tear solver."""
+        for case in CORPUS:
+            assert case.build().recycles, f"{case.name} has no recycle"
+
+    def test_get_case_rejects_an_unknown_name(self):
+        with pytest.raises(KeyError, match="unknown case"):
+            get_case("no_such_case")
+
+    def test_get_case_finds_every_corpus_member(self):
+        """The loop used to raise on the first non-match instead of the last."""
+        for case in CORPUS:
+            assert get_case(case.name) is case
+
+    def test_cases_filters_by_tag(self):
+        flash = cases(tags=["flash"])
+        assert flash
+        assert all("flash" in c.tags for c in flash)
+        assert len(flash) < len(CORPUS)
+
+    def test_the_corpus_has_a_control_that_is_meant_to_pass(self):
+        """All-failing corpora cannot tell a hard case from a broken solver."""
+        assert any("control" in c.tags for c in CORPUS)
+
+
+class TestNoCaseIsRigged:
+    """A strategy must not start on the answer it is being scored on.
+
+    ``overshoot_loop`` originally used ``g(x) = 3F - 2x``, whose fixed point
+    is ``x = F`` --- exactly the ``"feed"`` guess.  That strategy scored two
+    free passes on a case it had not solved.
+    """
+
+    @pytest.mark.parametrize("case", CORPUS, ids=lambda c: c.name)
+    def test_the_feed_guess_is_not_already_the_answer(self, case):
+        fs = case.build()
+        guess = _feed_guess(fs)
+        # No single acceleration converges every case -- that is the
+        # corpus's whole point -- so take the first that does.
+        for acceleration in ("anderson", "wegstein", "none"):
+            fs = case.build()
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                solved = fs.solve(acceleration=acceleration, tol=1e-10,
+                                  max_iter=500, on_nonconvergence="ignore")
+            if fs.last_solve_converged:
+                break
+        else:
+            pytest.fail(f"{case.name} converges under no acceleration, so "
+                        "its 'feed' guess cannot be checked against an answer")
+
+        for dest, start in guess.items():
+            source = next(s for s, d in fs.recycles.items() if d == dest)
+            answer = solved[source]
+            gap = max(
+                abs(float(start[f"F_{s}"]) - float(answer[f"F_{s}"]))
+                for s in fs.species_order)
+            scale = max(
+                max(abs(float(answer[f"F_{s}"])) for s in fs.species_order),
+                1e-12)
+            assert gap / scale > 1e-6, (
+                f"{case.name}: the 'feed' guess for {dest!r} is already the "
+                "converged answer, so that strategy is not being tested")
+
+
+# =============================================================================
+# Auditing
+# =============================================================================
+
+def _straight_through() -> Flowsheet:
+    """feed -> unit -> product, no recycle.  Balances exactly."""
+    fs = Flowsheet(["A"])
+    fs.add_feed("feed", make_stream({"A": 2.0}, 300.0, 101325.0))
+    fs.add_unit(Unit(
+        "u", lambda s: make_stream(get_flows(s), s["T"], s["P"]),
+        ["feed"], ["product"]))
+    return fs
+
+
+class TestBalanceAudit:
+
+    def test_a_recycle_source_is_not_a_product(self):
+        """It is consumed at the far end of the tear, so it does not leave."""
+        fs = get_case("high_gain_recycle").build()
+        products = _product_streams(fs)
+        assert "rec_src" not in products
+        assert "product" in products
+
+    def test_a_closed_balance_scores_zero(self):
+        fs = _straight_through()
+        streams = {"product": make_stream({"A": 2.0}, 300.0, 101325.0)}
+        assert total_mole_balance(fs, streams) == pytest.approx(0.0)
+
+    def test_a_broken_balance_is_caught(self):
+        fs = _straight_through()
+        streams = {"product": make_stream({"A": 1.0}, 300.0, 101325.0)}
+        assert total_mole_balance(fs, streams) == pytest.approx(0.5)
+
+    def test_a_diverged_answer_reports_inf_rather_than_raising(self):
+        """A failing case still has to report a number."""
+        fs = _straight_through()
+        streams = {"product": make_stream({"A": jnp.inf}, 300.0, 101325.0)}
+        assert total_mole_balance(fs, streams) == float("inf")
+
+    def test_a_missing_product_does_not_raise(self):
+        fs = _straight_through()
+        assert total_mole_balance(fs, {}) == pytest.approx(1.0)
+
+
+# =============================================================================
+# Outcomes: the solver's verdict against the audit
+# =============================================================================
+
+class TestOutcomeVerdict:
+    """The distinction the whole module exists to make."""
+
+    def test_converged_and_correct_passes(self):
+        o = Outcome("c", "anderson", "unit", converged=True, correct=True)
+        assert o.passed
+        assert o.verdict == "pass"
+
+    def test_converged_but_wrong_does_not_pass(self):
+        """The failure mode that a bare convergence flag cannot see."""
+        o = Outcome("c", "anderson", "unit", converged=True, correct=False)
+        assert not o.passed
+        assert o.verdict == "WRONG"
+
+    def test_correct_but_not_converged_does_not_pass(self):
+        o = Outcome("c", "none", "unit", converged=False, correct=True)
+        assert not o.passed
+        assert o.verdict == "no-conv"
+
+    def test_a_raise_is_its_own_verdict(self):
+        o = Outcome("c", "none", "unit", error="ValueError: boom")
+        assert not o.passed
+        assert o.verdict == "raised"
+
+
+# =============================================================================
+# Running
+# =============================================================================
+
+class TestRunCase:
+
+    def test_the_control_case_passes(self):
+        outcome = run_case(get_case("two_phase_flash"), acceleration="anderson")
+        assert outcome.passed, outcome
+        assert outcome.method == "anderson"
+        assert outcome.iterations is not None
+
+    def test_a_raising_case_is_counted_not_propagated(self):
+        """A benchmark that dies on its hardest case reports a short corpus."""
+        def build():
+            fs = Flowsheet(["A"])
+            fs.add_feed("feed", make_stream({"A": 1.0}, 300.0, 101325.0))
+
+            def explode(feed, tear):
+                raise RuntimeError("unit blew up")
+
+            fs.add_unit(Unit("boom", explode, ["feed", "tear"], ["out"]))
+            fs.add_recycle("out", "tear")
+            return fs
+
+        case = Case(name="explodes", build=build,
+                    difficulty="A unit that raises, to check the harness "
+                               "records a raise rather than propagating it.")
+        outcome = run_case(case)
+        assert outcome.error is not None
+        assert "unit blew up" in outcome.error
+        assert outcome.traceback is not None
+        assert not outcome.passed
+        assert outcome.verdict == "raised"
+
+    def test_a_check_that_raises_makes_the_answer_wrong(self):
+        def bad_check(fs, streams):
+            raise ValueError("cannot audit")
+
+        case = Case(name="unauditable", build=get_case("two_phase_flash").build,
+                    difficulty="A check that raises, to confirm an "
+                               "unauditable answer counts as wrong.",
+                    check=bad_check)
+        outcome = run_case(case)
+        assert not outcome.correct
+        assert outcome.balance_error == float("inf")
+        assert "check raised" in outcome.error
+
+    def test_non_convergence_does_not_warn_through(self):
+        """Counting non-convergence is the job; announcing each one is not."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", ConvergenceWarning)
+            run_case(get_case("overshoot_loop"), acceleration="none")
+
+    def test_an_unknown_initialization_is_rejected(self):
+        with pytest.raises(ValueError, match="unknown initialization"):
+            run_case(get_case("two_phase_flash"), initialization="telepathy")
+
+    @pytest.mark.parametrize("initialization", INITIALIZATIONS)
+    def test_every_initialization_strategy_runs(self, initialization):
+        outcome = run_case(get_case("two_phase_flash"),
+                           initialization=initialization)
+        assert outcome.passed, outcome
+
+
+class TestFeedGuess:
+
+    def test_it_sums_the_feeds_and_reaches_every_tear(self):
+        fs = get_case("high_gain_recycle").build()
+        guess = _feed_guess(fs)
+        assert set(guess) == set(fs.recycles.values())
+        assert float(guess["rec"]["F_A"]) == pytest.approx(1.0)
+
+    def test_it_covers_every_species_in_order(self):
+        """A guess missing a species fails as a KeyError frames away."""
+        fs = get_case("high_gain_recycle").build()
+        for stream in _feed_guess(fs).values():
+            for species in fs.species_order:
+                assert f"F_{species}" in stream
+
+
+# =============================================================================
+# Reporting
+# =============================================================================
+
+def _report(*verdicts) -> Report:
+    """A report from (acceleration, converged, correct) triples."""
+    report = Report()
+    for i, (accel, converged, correct) in enumerate(verdicts):
+        report.outcomes.append(Outcome(
+            case=f"case{i}", acceleration=accel, initialization="unit",
+            converged=converged, correct=correct, iterations=10,
+            balance_error=0.0 if correct else 1.0))
+    return report
+
+
+class TestReport:
+
+    def test_pass_rate_counts_only_audited_answers(self):
+        report = _report(("anderson", True, True), ("anderson", True, False))
+        assert report.pass_rate == pytest.approx(0.5)
+
+    def test_convergence_rate_is_the_solvers_own_verdict(self):
+        """The gap between the two rates is the point of keeping both."""
+        report = _report(("anderson", True, True), ("anderson", True, False))
+        assert report.convergence_rate == pytest.approx(1.0)
+        assert report.convergence_rate > report.pass_rate
+
+    def test_empty_report_does_not_divide_by_zero(self):
+        empty = Report()
+        assert empty.pass_rate != empty.pass_rate  # NaN
+        assert empty.convergence_rate != empty.convergence_rate
+
+    def test_by_groups_pass_counts(self):
+        report = _report(("anderson", True, True), ("none", False, False),
+                         ("none", True, True))
+        assert report.by("acceleration") == {"anderson": (1, 1), "none": (1, 2)}
+
+    def test_mean_iterations_ignores_failures_by_default(self):
+        """A failed solve used max_iter by definition; it measures the cap."""
+        report = Report()
+        report.outcomes.append(Outcome("a", "none", "unit", converged=True,
+                                       correct=True, iterations=5))
+        report.outcomes.append(Outcome("b", "none", "unit", converged=False,
+                                       correct=False, iterations=100))
+        assert report.mean_iterations() == {"none": 5.0}
+        assert report.mean_iterations(only_passed=False) == {"none": 52.5}
+
+    def test_failures_lists_everything_that_did_not_pass(self):
+        report = _report(("anderson", True, True), ("none", True, False))
+        assert [o.acceleration for o in report.failures()] == ["none"]
+
+    def test_as_text_reports_both_rates_and_every_solve(self):
+        report = _report(("anderson", True, True), ("none", True, False))
+        text = report.as_text()
+        assert "pass rate" in text
+        assert "convergence rate" in text
+        assert "WRONG" in text
+        for outcome in report.outcomes:
+            assert outcome.case in text
+
+    def test_as_text_survives_an_infinite_balance_error(self):
+        report = Report()
+        report.outcomes.append(Outcome("diverged", "none", "unit",
+                                       converged=False, correct=False,
+                                       balance_error=float("inf")))
+        assert "inf" in report.as_text()
+
+    def test_to_csv_writes_one_row_per_solve(self, tmp_path):
+        report = _report(("anderson", True, True), ("none", True, False))
+        path = tmp_path / "bench.csv"
+        report.to_csv(str(path))
+        rows = path.read_text().strip().splitlines()
+        assert len(rows) == 3  # header + 2
+        assert "passed" in rows[0]
+
+
+class TestRunBenchmark:
+
+    def test_it_covers_the_whole_grid(self):
+        report = run_benchmark(cases=["two_phase_flash"],
+                               accelerations=("anderson", "wegstein"),
+                               initializations=("unit", "default"))
+        assert len(report.outcomes) == 4
+        assert {o.acceleration for o in report.outcomes} == {"anderson", "wegstein"}
+        assert {o.initialization for o in report.outcomes} == {"unit", "default"}
+
+    def test_it_accepts_case_objects_as_well_as_names(self):
+        report = run_benchmark(cases=[get_case("two_phase_flash")],
+                               accelerations=("anderson",),
+                               initializations=("unit",))
+        assert len(report.outcomes) == 1
+
+    def test_the_report_carries_the_settings_it_ran_under(self):
+        report = run_benchmark(cases=["two_phase_flash"],
+                               accelerations=("anderson",),
+                               initializations=("unit",),
+                               tol=1e-6, max_iter=42)
+        assert report.tol == 1e-6
+        assert report.max_iter == 42
+
+
+# =============================================================================
+# The measurements the corpus was built to make
+# =============================================================================
+
+class TestTheFindings:
+    """These pin *why* each hard case is in the corpus.
+
+    They assert the qualitative finding, not the exact iteration count: the
+    point of a benchmark is that its numbers move.
+    """
+
+    def test_anderson_rescues_a_divergent_map_that_substitution_cannot(self):
+        divergent = run_case(get_case("overshoot_loop"), acceleration="none")
+        accelerated = run_case(get_case("overshoot_loop"), acceleration="anderson")
+        assert not divergent.passed
+        assert accelerated.passed
+
+    def test_anderson_is_not_a_free_win(self):
+        """phase_coupled_flash is in the corpus precisely because it isn't."""
+        anderson = run_case(get_case("phase_coupled_flash"),
+                            acceleration="anderson", initialization="unit")
+        wegstein = run_case(get_case("phase_coupled_flash"),
+                            acceleration="wegstein", initialization="unit")
+        assert wegstein.passed
+        assert not anderson.passed
+
+    @pytest.mark.slow
+    def test_an_absolute_tear_tolerance_can_accept_a_wrong_answer(self):
+        """The trap ``trace_recycle`` exists to expose.
+
+        ``tol`` is an absolute residual on the tear.  On a loop of gain
+        ``g``, a step of ``d`` means a remaining error of ``d / (1 - g)``,
+        so at ``g = 0.97`` the residual understates the error by about 33x.
+        With a tear whose converged value is ~3e-5, Wegstein stops on a
+        residual inside 1e-8 while still about 1% out --- reporting
+        convergence and meaning it, on the solver's own terms.
+        """
+        outcome = run_case(get_case("trace_recycle"), acceleration="wegstein",
+                           initialization="unit")
+        assert outcome.converged is True, "the solver should claim success"
+        assert not outcome.correct, "and the audit should disagree"
+        assert outcome.verdict == "WRONG"
+
+
+@pytest.fixture(scope="module")
+def full_grid() -> Report:
+    """The whole corpus, once.
+
+    Several minutes of JAX compilation, so it is shared rather than rebuilt
+    per test.  Safe to share: a :class:`Report` is read-only once returned,
+    and each solve inside it built its own flowsheet.
+    """
+    return run_benchmark()
+
+
+@pytest.mark.slow
+class TestFullGrid:
+
+    def test_it_covers_every_combination(self, full_grid):
+        assert len(full_grid.outcomes) == (
+            len(CORPUS) * len(ACCELERATIONS) * len(INITIALIZATIONS))
+
+    def test_the_corpus_measures_something(self, full_grid):
+        """All-pass or all-fail would mean the corpus is mistuned."""
+        assert 0.0 < full_grid.pass_rate < 1.0
+
+    def test_no_case_raises_at_any_setting(self, full_grid):
+        """A raise is a harness-visible outcome, but not one we expect here."""
+        raised = [o for o in full_grid.outcomes if o.error]
+        assert not raised, [o.error for o in raised]
+
+    def test_every_case_passes_somewhere(self, full_grid):
+        """A case no setting solves cannot discriminate between settings."""
+        for case, (passed, _) in full_grid.by("case").items():
+            assert passed > 0, f"{case} fails under every setting"
+
+    def test_the_report_renders(self, full_grid):
+        text = full_grid.as_text()
+        for case in CORPUS:
+            assert case.name in text


### PR DESCRIPTION
Adds `difflow.convergence`: eleven deliberately hard flowsheets, run across every acceleration and every initialization strategy, reporting how often the recycle solver actually works.

Refs #251. Deliberately **not** `Closes #251` — the keyword would close it as *completed*, and the recommendation is to close it as *not planned*. The evidence is below; the decision is yours.

## Why

Nobody knew difflow's failure rate. `benchmarks.py::compare_solvers` compared SM against EO on one caller-supplied flowsheet, and the test suite asserts that the flowsheets it happens to contain converge — a selection chosen, reasonably, because they converge. With no corpus of hard ones and no pass-rate number, "initialization strategy X helped" was not a checkable claim.

#251 makes that measurement the gate on everything it proposes, and #247 ("fix and measure") asked for it and did not get it.

## What passing means

A solve reports two separate things and the benchmark keeps them apart:

| | meaning |
|---|---|
| `Outcome.converged` | the solver's verdict, `last_solve_converged` |
| `Outcome.correct` | the answer closes its material balance, or matches a known one |
| `Outcome.passed` | both |

Three of the 99 solves report success and land somewhere that does not audit. A benchmark reading only the flag would score those as wins.

## Results

```
99 solves  (tol=1e-08, max_iter=100)
pass rate         46.5%   (converged AND the answer audits)
convergence rate  49.5%   (the solver's own verdict)

by acceleration                    by initialization
  anderson      28/33   84.8%        default       15/33   45.5%
  wegstein       9/33   27.3%        unit          15/33   45.5%
  none           9/33   27.3%        feed          16/33   48.5%

mean iterations over passing solves: anderson=4.3, wegstein=18.9, none=41.0
```

## The evidence on #251

**Every case is solved by at least one acceleration.** Eleven cases across every family the issue names — high loop gain, sharp splits, multi-loop, phase-regime switching, near-pinch columns, trace-magnitude tears, signed tears — and none defeats all three methods.

**The disjunction case does not need binaries.** `regime_switch` is a unit choosing between two linear branches with the answer exactly on the boundary — the disjunction #251 proposes handing to a MILP's binaries. Substitution chatters across the join, Wegstein stalls at residual 16, Anderson lands on it in two iterations.

**Initialization is worth one solve out of 99; acceleration is worth nineteen.** `"unit"` — the propagation pass #247 wired up — scores exactly what the 0.01 mol/s default it replaced scores, 15/33 either way. It saves an iteration or two and flips no verdict. That held unchanged when the corpus went from six cases to eleven.

**Measured as not hard**, and recorded so it need not be rediscovered: a rigorous MESH column in a recycle (every setting, every reflux ratio from just above minimum upward), nonsmooth tear maps as such, and tear dimension (twelve components at ρ = 0.985 converges as readily as three).

Taken together: the failures difflow has are loop-gain failures Anderson already handles. A globally consistent MILP guess is aimed at a failure mode this corpus does not contain.

## Findings worth having regardless of #251

**`clip_negative_flows` is applied asymmetrically.** It defaults to `True` and is applied by the Wegstein and Anderson paths but **not** by the unaccelerated one (`flowsheet.py:553-562`). On a tear whose answer is genuinely negative, that projection is the difference between solving it and not: `signed_tear` is the one case where plain substitution beats both accelerated methods, and `clip_negative_flows=False` takes Anderson from 100 iterations without convergence to 13. `difflow_gas` already makes this point for signed flows; the asymmetry between the accelerated paths and `none` is not documented anywhere.

**`tol` is an absolute tear residual**, so on a loop of gain `g` it understates the remaining error by `1/(1-g)` — and by `‖(I−M)⁻¹‖` for a multicomponent tear, which for a non-normal coupling is far larger. `signed_tear` has ρ = 0.75, suggesting a factor of 4; the measured amplification is about 450. `trace_recycle` pins the scalar version: Wegstein stops inside `1e-8` and is 1% out, reporting convergence and meaning it.

## Also fixed

`compare_solvers` predates #249 and so had nothing to read: it hard-coded `sm_converged=True` and reported `sm_iterations` as the iteration cap, making a diverged SM solve look like a converged one that happened to disagree with EO. It now reads `last_solve_converged`/`iterations`/`residual`, and leaves the non-convergence warning to fire rather than trading it for the returned verdict.

## Design notes for review

- `Case.build` must return a **fresh** flowsheet — `solve` records its verdict on the object, so a shared one carries one run's result into the next.
- **No case may be rigged.** `overshoot_loop` originally used `g(x) = 3F − 2x`, whose fixed point is `x = F`, exactly the `"feed"` guess — that strategy collected two passes on a case it had not solved. Fixed, and `TestNoCaseIsRigged` now checks all eleven.
- **Two controls that are meant to pass** (`two_phase_flash`, `column_recycle`, both 9/9). A corpus where everything fails cannot distinguish a hard corpus from a broken solver.
- A raise is an outcome, not an error: `run_case` records it and carries on.

One earlier conclusion was wrong and is worth flagging: a first pass looked like a dimensional failure (Anderson stalling for n ≥ 5). It was entirely the negative-flow clipping — with a physically non-negative coupling, twelve components converge as readily as three. It only surfaced by testing the clip on and off separately, and the wrong version would have read as a compelling argument *for* the MILP.

## Testing

68 tests, all passing, including the full-grid suite under the `slow` marker. `make convergence` or `python -m difflow.convergence` runs the benchmark (several minutes, mostly JAX compilation).

Docs: `docs/convergence.md` → "Measured pass rates", with a "What is *not* hard" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGs6MSgpqbM2vNy8hY2f52

---
_Generated by [Claude Code](https://claude.ai/code/session_01XGs6MSgpqbM2vNy8hY2f52)_